### PR TITLE
UOELSA-496: Asiakirjan liittäminen työskentelyjaksoon

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/Asiakirja.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/Asiakirja.kt
@@ -35,7 +35,7 @@ data class Asiakirja(
 
     @NotNull
     @Column(name = "lisattypvm", nullable = false)
-    var lisattypvm : LocalDateTime? = null,
+    var lisattypvm: LocalDateTime? = null,
 
     @NotNull
     @Column(name = "data", nullable = false)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/AsiakirjaService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/AsiakirjaService.kt
@@ -8,12 +8,16 @@ interface AsiakirjaService {
 
     fun create(asiakirjat: List<AsiakirjaDTO>, userId: String, tyoskentelyJaksoId: Long? = null): List<AsiakirjaDTO>?
 
-    fun findAllByErikoistuvaLaakari(userId: String): MutableList<AsiakirjaListProjection>
+    fun findAllByErikoistuvaLaakariUserId(userId: String): MutableList<AsiakirjaListProjection>
 
-    fun findAllByErikoistuvaLaakariAndTyoskentelyjakso(userId: String, tyoskentelyJaksoId: Long?): MutableList<AsiakirjaListProjection>
+    fun findAllByErikoistuvaLaakariIdAndTyoskentelyjaksoId(userId: String, tyoskentelyJaksoId: Long?): MutableList<AsiakirjaListProjection>
 
     fun findOne(id: Long, userId: String): AsiakirjaItemProjection?
 
     fun delete(id: Long, userId: String)
+
+    fun delete(ids: List<Long> , userId: String)
+
+    fun removeTyoskentelyjaksoReference(userId: String, tyoskentelyJaksoId: Long?)
 
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/TyoskentelyjaksoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/TyoskentelyjaksoDTO.kt
@@ -1,6 +1,7 @@
 package fi.elsapalvelu.elsa.service.dto
 
 import fi.elsapalvelu.elsa.domain.enumeration.KaytannonKoulutusTyyppi
+import fi.elsapalvelu.elsa.service.projection.AsiakirjaListProjection
 import java.io.Serializable
 import java.time.LocalDate
 import javax.validation.constraints.Max
@@ -37,7 +38,11 @@ data class TyoskentelyjaksoDTO(
 
     var suoritusarvioinnit: Boolean? = null,
 
-    var liitettyKoejaksoon: Boolean? = null
+    var liitettyKoejaksoon: Boolean? = null,
+
+    var asiakirjat: MutableList<AsiakirjaListProjection>? = null,
+
+    var kaikkiAsiakirjaNimet: MutableSet<String>? = null
 
 ) : Serializable {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/TyoskentelyjaksoFormDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/TyoskentelyjaksoFormDTO.kt
@@ -6,6 +6,8 @@ class TyoskentelyjaksoFormDTO(
 
     var kunnat: MutableSet<KuntaDTO> = mutableSetOf(),
 
-    var erikoisalat: MutableSet<ErikoisalaDTO> = mutableSetOf()
+    var erikoisalat: MutableSet<ErikoisalaDTO> = mutableSetOf(),
+
+    var kaikkiAsiakirjaNimet: MutableSet<String> = mutableSetOf()
 
 ) : Serializable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/validation/FileValidator.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/validation/FileValidator.kt
@@ -1,0 +1,7 @@
+package fi.elsapalvelu.elsa.validation
+
+import org.springframework.web.multipart.MultipartFile
+
+interface FileValidator {
+    fun validate(files: List<MultipartFile>, userId: String)
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/validation/impl/FileValidatorImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/validation/impl/FileValidatorImpl.kt
@@ -1,0 +1,44 @@
+package fi.elsapalvelu.elsa.validation.impl
+
+import fi.elsapalvelu.elsa.service.AsiakirjaService
+import fi.elsapalvelu.elsa.validation.FileValidator
+import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+
+private const val MAXIMUM_FILE_NAME_LENGTH = 255
+
+@Service
+class FileValidatorImpl(
+    private val asiakirjaService: AsiakirjaService
+    ) : FileValidator {
+
+    private val allowedContentTypes = listOf("application/pdf", "image/jpg", "image/jpeg", "image/png")
+
+    override fun validate(files: List<MultipartFile>, userId: String) {
+        val existingFileNames = asiakirjaService.findAllByErikoistuvaLaakariUserId(userId).map { it.nimi }
+        if (files.any { it.originalFilename?.toString() in existingFileNames }) {
+            throw BadRequestAlertException(
+                "Samanniminen tiedosto on jo olemassa",
+                "asiakirja",
+                "idexists"
+            )
+        }
+
+        if (files.any { it.contentType?.toString() !in allowedContentTypes }) {
+            throw BadRequestAlertException(
+                "Sallitut tiedostomuodot: .pdf, .png, .jpeg ja .jpg",
+                "asiakirja",
+                "dataillegal"
+            )
+        }
+
+        if (files.any { it.name.length > MAXIMUM_FILE_NAME_LENGTH }) {
+            throw BadRequestAlertException(
+                "Tiedostonimen maksimipituus: 255 merkkiä",
+                "asiakirja",
+                "dataillegal"
+            )
+        }
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
@@ -1,7 +1,9 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.*
+import fi.elsapalvelu.elsa.validation.FileValidator
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import io.github.jhipster.web.util.HeaderUtil
 import org.slf4j.LoggerFactory
@@ -9,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
 import java.net.URI
 import java.security.Principal
@@ -26,7 +29,10 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
     private val kuntaService: KuntaService,
     private val erikoisalaService: ErikoisalaService,
     private val poissaolonSyyService: PoissaolonSyyService,
-    private val keskeytysaikaService: KeskeytysaikaService
+    private val keskeytysaikaService: KeskeytysaikaService,
+    private val asiakirjaService: AsiakirjaService,
+    private val objectMapper: ObjectMapper,
+    private val fileValidator: FileValidator
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -36,68 +42,83 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
 
     @PostMapping("/tyoskentelyjaksot")
     fun createTyoskentelyjakso(
-        @Valid @RequestBody tyoskentelyjaksoDTO: TyoskentelyjaksoDTO,
+        @Valid @RequestParam tyoskentelyjaksoJson: String,
+        @Valid @RequestParam files: List<MultipartFile>?,
         principal: Principal?
     ): ResponseEntity<TyoskentelyjaksoDTO> {
-        log.debug("REST request to create Tyoskentelyjakso : $tyoskentelyjaksoDTO")
+        val user = userService.getAuthenticatedUser(principal)
+        tyoskentelyjaksoJson?.let {
+            objectMapper.readValue(it, TyoskentelyjaksoDTO::class.java)
+        }?.apply {
+            log.debug("REST request to create Tyoskentelyjakso : $this")
 
-        if (tyoskentelyjaksoDTO.id != null) {
-            throw BadRequestAlertException(
-                "Uusi tyoskentelyjakso ei saa sisältää ID:tä.",
-                ENTITY_NAME,
-                "idexists"
-            )
-        }
-        val tyoskentelypaikka = tyoskentelyjaksoDTO.tyoskentelypaikka
-        if (tyoskentelypaikka == null || tyoskentelypaikka.id != null) {
-            throw BadRequestAlertException(
-                "Uusi tyoskentelypaikka ei saa sisältää ID:tä.",
-                "tyoskentelypaikka",
-                "idexists"
-            )
-        }
-        if (tyoskentelyjaksoDTO.paattymispaiva != null
-        ) {
-            val daysBetween = ChronoUnit.DAYS.between(
-                tyoskentelyjaksoDTO.alkamispaiva,
-                tyoskentelyjaksoDTO.paattymispaiva
-            ) + 1
-            val minDays = ceil(
-                (
-                    30 * (
-                        100 / tyoskentelyjaksoDTO.osaaikaprosentti!!
-                            .coerceIn(50, 100)
-                        )
-                    ).toDouble()
-            ).toInt()
-            if (tyoskentelyjaksoDTO.paattymispaiva!!.isBefore(tyoskentelyjaksoDTO.alkamispaiva!!)) {
+            if (id != null) {
                 throw BadRequestAlertException(
-                    "Työskentelyjakson päättymispäivä ei saa olla ennen alkamisaikaa",
-                    "tyoskentelypaikka",
-                    "dataillegal"
-                )
-            } else if (daysBetween < minDays) {
-                throw BadRequestAlertException(
-                    "Työskentelyjakson minimikesto on 30 täyttä työpäivää",
-                    "tyoskentelypaikka",
-                    "dataillegal"
+                    "Uusi tyoskentelyjakso ei saa sisältää ID:tä.",
+                    ENTITY_NAME,
+                    "idexists"
                 )
             }
-        }
-
-        val user = userService.getAuthenticatedUser(principal)
-
-        tyoskentelyjaksoService.save(tyoskentelyjaksoDTO, user.id!!)?.let {
-            return ResponseEntity.created(URI("/api/tyoskentelyjaksot/${it.id}"))
-                .headers(
-                    HeaderUtil.createEntityCreationAlert(
-                        applicationName,
-                        true,
-                        ENTITY_NAME,
-                        it.id.toString()
-                    )
+            val tyoskentelypaikka = tyoskentelypaikka
+            if (tyoskentelypaikka == null || tyoskentelypaikka.id != null) {
+                throw BadRequestAlertException(
+                    "Uusi tyoskentelypaikka ei saa sisältää ID:tä.",
+                    "tyoskentelypaikka",
+                    "idexists"
                 )
-                .body(it)
+            }
+            if (paattymispaiva != null
+            ) {
+                val daysBetween = ChronoUnit.DAYS.between(
+                    alkamispaiva,
+                    paattymispaiva
+                ) + 1
+                val minDays = ceil(
+                    (
+                        30 * (
+                            100 / osaaikaprosentti!!
+                                .coerceIn(50, 100)
+                            )
+                        ).toDouble()
+                ).toInt()
+                if (paattymispaiva!!.isBefore(alkamispaiva!!)) {
+                    throw BadRequestAlertException(
+                        "Työskentelyjakson päättymispäivä ei saa olla ennen alkamisaikaa",
+                        "tyoskentelypaikka",
+                        "dataillegal"
+                    )
+                } else if (daysBetween < minDays) {
+                    throw BadRequestAlertException(
+                        "Työskentelyjakson minimikesto on 30 täyttä työpäivää",
+                        "tyoskentelypaikka",
+                        "dataillegal"
+                    )
+                }
+            }
+        }?.let {
+            tyoskentelyjaksoService.save(it, user.id!!)?.let { result ->
+                files?.also { files ->
+                    fileValidator.validate(files, user.id!!)
+                }?.map { file ->
+                    AsiakirjaDTO(
+                        nimi = file.originalFilename,
+                        tyyppi = file.contentType,
+                        data = file.bytes,
+                        tyoskentelyjaksoId = result.id
+                    )
+                }?.let { asiakirjat -> asiakirjaService.create(asiakirjat, user.id!!) }
+                return ResponseEntity.created(URI("/api/tyoskentelyjaksot/${result.id}"))
+                    .headers(
+                        HeaderUtil.createEntityCreationAlert(
+                            applicationName,
+                            true,
+                            ENTITY_NAME,
+                            result.id.toString()
+                        )
+                    )
+                    .body(result)
+            }
+
         } ?: throw BadRequestAlertException(
             "Työskentelyjakson lisääminen epäonnistui.",
             ENTITY_NAME,
@@ -107,28 +128,50 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
 
     @PutMapping("/tyoskentelyjaksot")
     fun updateTyoskentelyjakso(
-        @Valid @RequestBody tyoskentelyjaksoDTO: TyoskentelyjaksoDTO,
+        @Valid @RequestParam tyoskentelyjaksoJson: String,
+        @Valid @RequestParam files: List<MultipartFile>?,
+        @RequestParam deletedAsiakirjaIdsJson: String?,
         principal: Principal?
     ): ResponseEntity<TyoskentelyjaksoDTO> {
-        log.debug("REST request to update Tyoskentelyjakso : $tyoskentelyjaksoDTO")
-
-        if (tyoskentelyjaksoDTO.id == null) {
-            throw BadRequestAlertException("Työskentelyjakson ID puuttuu.", ENTITY_NAME, "idnull")
-        }
-
         val user = userService.getAuthenticatedUser(principal)
+        tyoskentelyjaksoJson?.let {
+            objectMapper.readValue(it, TyoskentelyjaksoDTO::class.java)
+        }?.apply {
+            log.debug("REST request to update Tyoskentelyjakso : $this")
+            if (id == null) {
+                throw BadRequestAlertException("Työskentelyjakson ID puuttuu.", ENTITY_NAME, "idnull")
+            }
 
-        tyoskentelyjaksoService.save(tyoskentelyjaksoDTO, user.id!!)?.let {
-            return ResponseEntity.ok()
-                .headers(
-                    HeaderUtil.createEntityUpdateAlert(
-                        applicationName,
-                        true,
-                        ENTITY_NAME,
-                        tyoskentelyjaksoDTO.id.toString()
-                    )
+            files?.also { files ->
+                fileValidator.validate(files, user.id!!)
+            }?.map {
+                AsiakirjaDTO(
+                    nimi = it.originalFilename,
+                    tyyppi = it.contentType,
+                    data = it.bytes,
+                    tyoskentelyjaksoId = id
                 )
-                .body(it)
+            }?.let { asiakirjat -> asiakirjaService.create(asiakirjat, user.id!!) }
+
+            deletedAsiakirjaIdsJson?.let {
+                objectMapper.readValue(it, mutableListOf<Long>()::class.java)
+            }?.let {
+                it.forEach { id -> asiakirjaService.delete(id, user.id!!) }
+            }
+
+        }?.let {
+            tyoskentelyjaksoService.save(it, user.id!!)?.let { result ->
+                return ResponseEntity.ok()
+                    .headers(
+                        HeaderUtil.createEntityUpdateAlert(
+                            applicationName,
+                            true,
+                            ENTITY_NAME,
+                            result.id.toString()
+                        )
+                    )
+                    .body(result)
+            }
         } ?: throw BadRequestAlertException(
             "Työskentelyjakson päivittäminen epäonnistui.",
             ENTITY_NAME,
@@ -174,6 +217,10 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
 
         val user = userService.getAuthenticatedUser(principal)
         tyoskentelyjaksoService.findOne(id, user.id!!)?.let {
+            it.asiakirjat = asiakirjaService.findAllByErikoistuvaLaakariIdAndTyoskentelyjaksoId(user.id!!, id)
+            it.kaikkiAsiakirjaNimet =
+                asiakirjaService.findAllByErikoistuvaLaakariUserId(user.id!!).map { asiakirja -> asiakirja.nimi }
+                    .toMutableSet()
             return ResponseEntity.ok(it)
         } ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
     }
@@ -186,6 +233,8 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
         log.debug("REST request to delete Tyoskentelyjakso : $id")
 
         val user = userService.getAuthenticatedUser(principal)
+
+        asiakirjaService.removeTyoskentelyjaksoReference(user.id!!, id)
         tyoskentelyjaksoService.delete(id, user.id!!)
         return ResponseEntity.noContent()
             .headers(
@@ -204,11 +253,15 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
     ): ResponseEntity<TyoskentelyjaksoFormDTO> {
         log.debug("REST request to get TyoskentelyjaksoForm")
 
+        val user = userService.getAuthenticatedUser(principal)
         val form = TyoskentelyjaksoFormDTO()
 
         form.kunnat = kuntaService.findAll().toMutableSet()
 
         form.erikoisalat = erikoisalaService.findAll().toMutableSet()
+
+        form.kaikkiAsiakirjaNimet =
+            asiakirjaService.findAllByErikoistuvaLaakariUserId(user.id!!).map { it.nimi }.toMutableSet()
 
         return ResponseEntity.ok(form)
     }

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResourceIT.kt
@@ -3,40 +3,34 @@ package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 import fi.elsapalvelu.elsa.ElsaBackendApp
 import fi.elsapalvelu.elsa.config.TestSecurityConfiguration
 import fi.elsapalvelu.elsa.domain.Asiakirja
-import fi.elsapalvelu.elsa.domain.ErikoistuvaLaakari
 import fi.elsapalvelu.elsa.repository.AsiakirjaRepository
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI
-import fi.elsapalvelu.elsa.service.mapper.AsiakirjaMapper
-import fi.elsapalvelu.elsa.web.rest.convertObjectToJsonBytes
-import fi.elsapalvelu.elsa.web.rest.findAll
-import fi.elsapalvelu.elsa.web.rest.helpers.ErikoistuvaLaakariHelper
+import fi.elsapalvelu.elsa.web.rest.helpers.AsiakirjaHelper
+import fi.elsapalvelu.elsa.web.rest.helpers.KayttajaHelper
 import junit.framework.TestCase.assertNotNull
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.MockitoAnnotations
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.security.core.authority.SimpleGrantedAuthority
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User
-import org.springframework.security.test.context.TestSecurityContextHolder
-import org.springframework.test.web.servlet.MockMvc
-import org.springframework.transaction.annotation.Transactional
-import javax.persistence.EntityManager
-import org.assertj.core.api.Assertions.assertThat
-import org.hamcrest.Matchers
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+import org.springframework.security.test.context.TestSecurityContextHolder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
-import java.io.BufferedReader
+import org.springframework.transaction.annotation.Transactional
 import java.io.File
-import java.nio.file.Files
-
 import java.time.LocalDate
 import java.time.LocalDateTime
+import javax.persistence.EntityManager
 
 @AutoConfigureMockMvc
 @SpringBootTest(classes = [ElsaBackendApp::class, TestSecurityConfiguration::class])
@@ -44,9 +38,6 @@ class ErikoistuvaLaakariAsiakirjaResourceIT {
 
     @Autowired
     private lateinit var asiakirjaRepository: AsiakirjaRepository
-
-    @Autowired
-    private lateinit var asiakirjaMapper: AsiakirjaMapper
 
     @Autowired
     private lateinit var em: EntityManager
@@ -87,9 +78,9 @@ class ErikoistuvaLaakariAsiakirjaResourceIT {
         assertThat(asiakirjaList).hasSize(databaseSizeBeforeCreate + 1)
 
         val testAsiakirja = asiakirjaList[asiakirjaList.size - 1]
-        assertThat(testAsiakirja.nimi).isEqualTo(ASIAKIRJA_PDF_NIMI)
-        assertThat(testAsiakirja.tyyppi).isEqualTo(ASIAKIRJA_PDF_TYYPPI)
-        assertThat(testAsiakirja.data).isEqualTo(ASIAKIRJA_PDF_DATA)
+        assertThat(testAsiakirja.nimi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_NIMI)
+        assertThat(testAsiakirja.tyyppi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_TYYPPI)
+        assertThat(testAsiakirja.data).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_DATA)
         assertThat(testAsiakirja.lisattypvm?.toLocalDate()).isEqualTo(LocalDate.now())
     }
 
@@ -111,15 +102,15 @@ class ErikoistuvaLaakariAsiakirjaResourceIT {
         assertThat(asiakirjaList).hasSize(databaseSizeBeforeCreate + 2)
 
         val testAsiakirja = asiakirjaList[asiakirjaList.size - 2]
-        assertThat(testAsiakirja.nimi).isEqualTo(ASIAKIRJA_PDF_NIMI)
-        assertThat(testAsiakirja.tyyppi).isEqualTo(ASIAKIRJA_PDF_TYYPPI)
-        assertThat(testAsiakirja.data).isEqualTo(ASIAKIRJA_PDF_DATA)
+        assertThat(testAsiakirja.nimi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_NIMI)
+        assertThat(testAsiakirja.tyyppi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_TYYPPI)
+        assertThat(testAsiakirja.data).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_DATA)
         assertThat(testAsiakirja.lisattypvm?.toLocalDate()).isEqualTo(LocalDate.now())
 
         val testAsiakirja2 = asiakirjaList[asiakirjaList.size - 1]
-        assertThat(testAsiakirja2.nimi).isEqualTo(ASIAKIRJA_PNG_NIMI)
-        assertThat(testAsiakirja2.tyyppi).isEqualTo(ASIAKIRJA_PNG_TYYPPI)
-        assertThat(testAsiakirja2.data).isEqualTo(ASIAKIRJA_PNG_DATA)
+        assertThat(testAsiakirja2.nimi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PNG_NIMI)
+        assertThat(testAsiakirja2.tyyppi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PNG_TYYPPI)
+        assertThat(testAsiakirja2.data).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PNG_DATA)
         assertThat(testAsiakirja2.lisattypvm?.toLocalDate()).isEqualTo(LocalDate.now())
     }
 
@@ -207,11 +198,11 @@ class ErikoistuvaLaakariAsiakirjaResourceIT {
         asiakirjaRepository.saveAndFlush(asiakirja)
         em.detach(asiakirja)
 
-        val asiakirja2 = createEntity(em, DEFAULT_ID)
-        asiakirja2.nimi = ASIAKIRJA_PNG_NIMI
-        asiakirja2.tyyppi = ASIAKIRJA_PNG_TYYPPI
+        val asiakirja2 = AsiakirjaHelper.createEntity(em, KayttajaHelper.DEFAULT_ID)
+        asiakirja2.nimi = AsiakirjaHelper.ASIAKIRJA_PNG_NIMI
+        asiakirja2.tyyppi = AsiakirjaHelper.ASIAKIRJA_PNG_TYYPPI
         asiakirja2.lisattypvm = LocalDateTime.now().minusDays(1)
-        asiakirja2.data = ASIAKIRJA_PNG_DATA
+        asiakirja2.data = AsiakirjaHelper.ASIAKIRJA_PNG_DATA
 
         asiakirjaRepository.saveAndFlush(asiakirja2)
         em.detach(asiakirja2)
@@ -221,12 +212,12 @@ class ErikoistuvaLaakariAsiakirjaResourceIT {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("$").value(Matchers.hasSize<Any>(2)))
             .andExpect(jsonPath("$[0].id").exists())
-            .andExpect(jsonPath("$[0].nimi").value(ASIAKIRJA_PDF_NIMI))
+            .andExpect(jsonPath("$[0].nimi").value(AsiakirjaHelper.ASIAKIRJA_PDF_NIMI))
             .andExpect(jsonPath("$[0].lisattypvm").value(Matchers.containsString(LocalDate.now().toString())))
             .andExpect(jsonPath("$[0].tyyppi").doesNotExist())
             .andExpect(jsonPath("$[0].data").doesNotExist())
             .andExpect(jsonPath("$[1].id").exists())
-            .andExpect(jsonPath("$[1].nimi").value(ASIAKIRJA_PNG_NIMI))
+            .andExpect(jsonPath("$[1].nimi").value(AsiakirjaHelper.ASIAKIRJA_PNG_NIMI))
             .andExpect(
                 jsonPath("$[1].lisattypvm").value(
                     Matchers.containsString(
@@ -251,7 +242,7 @@ class ErikoistuvaLaakariAsiakirjaResourceIT {
         restAsiakirjaMockMvc.perform(get("/api/erikoistuva-laakari/asiakirjat/{id}", id))
             .andExpect(status().isOk)
             .andExpect(content().contentType("application/pdf;charset=UTF-8"))
-            .andExpect(content().bytes(ASIAKIRJA_PDF_DATA))
+            .andExpect(content().bytes(AsiakirjaHelper.ASIAKIRJA_PDF_DATA))
     }
 
     @Test
@@ -292,77 +283,41 @@ class ErikoistuvaLaakariAsiakirjaResourceIT {
         assertThat(asiakirjaList).hasSize(databaseSizeBeforeDelete)
     }
 
-    fun initTest(userId: String? = DEFAULT_ID) {
+    fun initTest(userId: String? = KayttajaHelper.DEFAULT_ID) {
         val userDetails = mapOf<String, Any>(
-            "uid" to DEFAULT_ID,
-            "sub" to DEFAULT_LOGIN,
-            "email" to DEFAULT_EMAIL
+            "uid" to KayttajaHelper.DEFAULT_ID,
+            "sub" to KayttajaHelper.DEFAULT_LOGIN,
+            "email" to KayttajaHelper.DEFAULT_EMAIL
         )
         val authorities = listOf(SimpleGrantedAuthority(ERIKOISTUVA_LAAKARI))
         val user = DefaultOAuth2User(authorities, userDetails, "sub")
         val authentication = OAuth2AuthenticationToken(user, authorities, "oidc")
         TestSecurityContextHolder.getContext().authentication = authentication
 
-        asiakirja = createEntity(em, userId)
+        asiakirja = AsiakirjaHelper.createEntity(em, userId)
     }
 
     fun initMockFiles() {
         tempFile1 = File.createTempFile("file", "pdf")
-        tempFile1.writeBytes(ASIAKIRJA_PDF_DATA)
+        tempFile1.writeBytes(AsiakirjaHelper.ASIAKIRJA_PDF_DATA)
         tempFile1.deleteOnExit()
 
         tempFile2 = File.createTempFile("file", "png")
-        tempFile2.writeBytes(ASIAKIRJA_PNG_DATA)
+        tempFile2.writeBytes(AsiakirjaHelper.ASIAKIRJA_PNG_DATA)
         tempFile2.deleteOnExit()
 
         mockMultipartFile1 = MockMultipartFile(
             "files",
-            ASIAKIRJA_PDF_NIMI,
-            ASIAKIRJA_PDF_TYYPPI,
+            AsiakirjaHelper.ASIAKIRJA_PDF_NIMI,
+            AsiakirjaHelper.ASIAKIRJA_PDF_TYYPPI,
             tempFile1.readBytes()
         )
 
         mockMultipartFile2 = MockMultipartFile(
             "files",
-            ASIAKIRJA_PNG_NIMI,
-            ASIAKIRJA_PNG_TYYPPI,
+            AsiakirjaHelper.ASIAKIRJA_PNG_NIMI,
+            AsiakirjaHelper.ASIAKIRJA_PNG_TYYPPI,
             tempFile2.readBytes()
         )
-    }
-
-    companion object {
-
-        private const val DEFAULT_ID = "c47f46ad-21c4-47e8-9c7c-ba44f60c8bae"
-        private const val DEFAULT_LOGIN = "johndoe"
-        private const val DEFAULT_EMAIL = "john.doe@example.com"
-
-        private const val ASIAKIRJA_PDF_NIMI: String = "Asiakirja.pdf"
-        private const val ASIAKIRJA_PNG_NIMI: String = "Asiakirja.png"
-        private const val ASIAKIRJA_PDF_TYYPPI: String = "application/pdf"
-        private const val ASIAKIRJA_PNG_TYYPPI: String = "image/png"
-        private val ASIAKIRJA_PDF_DATA = byteArrayOf(0x2E, 0x38)
-        private val ASIAKIRJA_PNG_DATA = byteArrayOf(0x2E, 0x14)
-
-        @JvmStatic
-        fun createEntity(em: EntityManager, userId: String? = null): Asiakirja {
-            val asiakirja = Asiakirja(
-                nimi = ASIAKIRJA_PDF_NIMI,
-                tyyppi = ASIAKIRJA_PDF_TYYPPI,
-                lisattypvm = LocalDateTime.now(),
-                data = ASIAKIRJA_PDF_DATA
-            )
-
-            val erikoistuvaLaakari: ErikoistuvaLaakari
-            if (em.findAll(ErikoistuvaLaakari::class).isEmpty()) {
-                erikoistuvaLaakari = ErikoistuvaLaakariHelper.createEntity(em, userId)
-                em.persist(erikoistuvaLaakari)
-                em.flush()
-            } else {
-                erikoistuvaLaakari = em.findAll(ErikoistuvaLaakari::class).get(0)
-            }
-            asiakirja.erikoistuvaLaakari = erikoistuvaLaakari
-
-            return asiakirja
-        }
     }
 }

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/AsiakirjaHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/AsiakirjaHelper.kt
@@ -1,0 +1,50 @@
+package fi.elsapalvelu.elsa.web.rest.helpers
+
+import fi.elsapalvelu.elsa.domain.Asiakirja
+import fi.elsapalvelu.elsa.domain.ErikoistuvaLaakari
+import fi.elsapalvelu.elsa.domain.Tyoskentelyjakso
+import fi.elsapalvelu.elsa.web.rest.findAll
+import java.time.LocalDateTime
+import javax.persistence.EntityManager
+
+class AsiakirjaHelper {
+
+    companion object {
+
+        const val ASIAKIRJA_PDF_NIMI: String = "Asiakirja.pdf"
+        const val ASIAKIRJA_PNG_NIMI: String = "Asiakirja.png"
+        const val ASIAKIRJA_PDF_TYYPPI: String = "application/pdf"
+        const val ASIAKIRJA_PNG_TYYPPI: String = "image/png"
+        val ASIAKIRJA_PDF_DATA = byteArrayOf(0x2E, 0x38)
+        val ASIAKIRJA_PNG_DATA = byteArrayOf(0x2E, 0x14)
+
+        @JvmStatic
+        fun createEntity(
+            em: EntityManager,
+            userId: String? = null,
+            tyoskentelyjakso: Tyoskentelyjakso? = null
+        ): Asiakirja {
+            val asiakirja = Asiakirja(
+                nimi = ASIAKIRJA_PDF_NIMI,
+                tyyppi = ASIAKIRJA_PDF_TYYPPI,
+                lisattypvm = LocalDateTime.now(),
+                data = ASIAKIRJA_PDF_DATA,
+                tyoskentelyjakso = tyoskentelyjakso
+            )
+
+            val erikoistuvaLaakari: ErikoistuvaLaakari
+            if (em.findAll(ErikoistuvaLaakari::class).isEmpty()) {
+                erikoistuvaLaakari = ErikoistuvaLaakariHelper.createEntity(em, userId)
+                em.persist(erikoistuvaLaakari)
+                em.flush()
+            } else {
+                erikoistuvaLaakari = em.findAll(ErikoistuvaLaakari::class).get(0)
+            }
+            asiakirja.erikoistuvaLaakari = erikoistuvaLaakari
+
+            return asiakirja
+        }
+
+    }
+
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/KayttajaHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/KayttajaHelper.kt
@@ -9,6 +9,10 @@ class KayttajaHelper {
 
     companion object {
 
+        const val DEFAULT_ID = "c47f46ad-21c4-47e8-9c7c-ba44f60c8bae"
+        const val DEFAULT_LOGIN = "johndoe"
+        const val DEFAULT_EMAIL = "john.doe@example.com"
+
         private const val DEFAULT_NIMI = "AAAAAAAAAA"
         private const val UPDATED_NIMI = "BBBBBBBBBB"
 


### PR DESCRIPTION
- Receive tyoskentelyjakso data (create and update) as json string within multipart/form-data because of the file attachments included
- Use AsiakirjaService to save new files and delete the deleted ones. Do not use bidirectional relation between asiakirja and tyoskentelyjakso because asiakirjat data is fetched using projection (to avoid loading file data unnecessarily).
- If tyoskentelyjakso is deleted, do not delete assosiated asiakirjat but just remove the reference