### PR TITLE
UOELSA-513: Convert data in Asiakirja entity as Blob

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/Asiakirja.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/Asiakirja.kt
@@ -3,13 +3,15 @@ package fi.elsapalvelu.elsa.domain
 import com.sun.istack.NotNull
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
+import org.hibernate.annotations.Type
 import java.io.Serializable
+import java.sql.Blob
 import java.time.LocalDateTime
 import javax.persistence.*
 
 @Entity
 @Table(name = "asiakirja")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.NONE)
 data class Asiakirja(
 
     @Id
@@ -38,8 +40,9 @@ data class Asiakirja(
     var lisattypvm: LocalDateTime? = null,
 
     @NotNull
+    @Lob
     @Column(name = "data", nullable = false)
-    var data: ByteArray? = null
+    var data: Blob? = null
 
 ) : Serializable {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/AsiakirjaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/AsiakirjaDTO.kt
@@ -21,8 +21,9 @@ data class AsiakirjaDTO (
     @get: NotNull
     var lisattypvm: LocalDateTime? = null,
 
-    @get: NotNull
-    var inputStream: InputStream? = null
+    var fileInputStream: InputStream? = null,
+
+    var fileSize: Long? = null
 
 ): Serializable {
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/AsiakirjaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/AsiakirjaServiceImpl.kt
@@ -7,7 +7,7 @@ import fi.elsapalvelu.elsa.service.dto.AsiakirjaDTO
 import fi.elsapalvelu.elsa.service.mapper.AsiakirjaMapper
 import fi.elsapalvelu.elsa.service.projection.AsiakirjaItemProjection
 import fi.elsapalvelu.elsa.service.projection.AsiakirjaListProjection
-import org.apache.commons.io.IOUtils
+import org.hibernate.engine.jdbc.BlobProxy
 import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -34,13 +34,14 @@ class AsiakirjaServiceImpl(
                 it.erikoistuvaLaakariId = kirjautunutErikoistuvaLaakari.id
                 it.lisattypvm = LocalDateTime.now()
             }
+
             var asiakirjaEntities = asiakirjat.map {
                 asiakirjaMapper.toEntity(it).apply {
-                    data = IOUtils.toByteArray(it.inputStream)
+                    data = BlobProxy.generateProxy(it.fileInputStream, it.fileSize!!)
                 }
             }
-
             asiakirjaEntities = asiakirjaRepository.saveAll(asiakirjaEntities)
+
             return asiakirjaEntities.map { asiakirjaMapper.toDto(it) }
         }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResource.kt
@@ -42,9 +42,11 @@ class ErikoistuvaLaakariAsiakirjaResource(
                 AsiakirjaDTO(
                     nimi = it.originalFilename,
                     tyyppi = it.contentType,
-                    inputStream = it.inputStream
+                    fileInputStream = it.inputStream,
+                    fileSize = it.size
                 )
             }
+
         val result = asiakirjaService.create(asiakirjat, user.id!!)
         return ResponseEntity.created(URI("/api/asiakirjat"))
             .headers(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
@@ -103,7 +103,8 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
                     AsiakirjaDTO(
                         nimi = file.originalFilename,
                         tyyppi = file.contentType,
-                        inputStream = file.inputStream,
+                        fileInputStream = file.inputStream,
+                        fileSize = file.size,
                         tyoskentelyjaksoId = result.id
                     )
                 }?.let { asiakirjat -> asiakirjaService.create(asiakirjat, user.id!!) }
@@ -148,7 +149,8 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
                 AsiakirjaDTO(
                     nimi = it.originalFilename,
                     tyyppi = it.contentType,
-                    inputStream = it.inputStream,
+                    fileInputStream = it.inputStream,
+                    fileSize = it.size,
                     tyoskentelyjaksoId = id
                 )
             }?.let { asiakirjat -> asiakirjaService.create(asiakirjat, user.id!!) }

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResourceIT.kt
@@ -10,6 +10,8 @@ import fi.elsapalvelu.elsa.web.rest.helpers.KayttajaHelper
 import junit.framework.TestCase.assertNotNull
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers
+import org.hibernate.engine.jdbc.BinaryStream
+import org.hibernate.engine.jdbc.BlobProxy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.MockitoAnnotations
@@ -80,7 +82,7 @@ class ErikoistuvaLaakariAsiakirjaResourceIT {
         val testAsiakirja = asiakirjaList[asiakirjaList.size - 1]
         assertThat(testAsiakirja.nimi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_NIMI)
         assertThat(testAsiakirja.tyyppi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_TYYPPI)
-        assertThat(testAsiakirja.data).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_DATA)
+        assertThat(testAsiakirja.data?.binaryStream?.readBytes()).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_DATA)
         assertThat(testAsiakirja.lisattypvm?.toLocalDate()).isEqualTo(LocalDate.now())
     }
 
@@ -104,13 +106,13 @@ class ErikoistuvaLaakariAsiakirjaResourceIT {
         val testAsiakirja = asiakirjaList[asiakirjaList.size - 2]
         assertThat(testAsiakirja.nimi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_NIMI)
         assertThat(testAsiakirja.tyyppi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_TYYPPI)
-        assertThat(testAsiakirja.data).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_DATA)
+        assertThat(testAsiakirja.data?.binaryStream?.readBytes()).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_DATA)
         assertThat(testAsiakirja.lisattypvm?.toLocalDate()).isEqualTo(LocalDate.now())
 
         val testAsiakirja2 = asiakirjaList[asiakirjaList.size - 1]
         assertThat(testAsiakirja2.nimi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PNG_NIMI)
         assertThat(testAsiakirja2.tyyppi).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PNG_TYYPPI)
-        assertThat(testAsiakirja2.data).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PNG_DATA)
+        assertThat(testAsiakirja2.data?.binaryStream?.readBytes()).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PNG_DATA)
         assertThat(testAsiakirja2.lisattypvm?.toLocalDate()).isEqualTo(LocalDate.now())
     }
 
@@ -202,7 +204,7 @@ class ErikoistuvaLaakariAsiakirjaResourceIT {
         asiakirja2.nimi = AsiakirjaHelper.ASIAKIRJA_PNG_NIMI
         asiakirja2.tyyppi = AsiakirjaHelper.ASIAKIRJA_PNG_TYYPPI
         asiakirja2.lisattypvm = LocalDateTime.now().minusDays(1)
-        asiakirja2.data = AsiakirjaHelper.ASIAKIRJA_PNG_DATA
+        asiakirja2.data = BlobProxy.generateProxy(AsiakirjaHelper.ASIAKIRJA_PDF_DATA)
 
         asiakirjaRepository.saveAndFlush(asiakirja2)
         em.detach(asiakirja2)

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/AsiakirjaHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/AsiakirjaHelper.kt
@@ -4,6 +4,7 @@ import fi.elsapalvelu.elsa.domain.Asiakirja
 import fi.elsapalvelu.elsa.domain.ErikoistuvaLaakari
 import fi.elsapalvelu.elsa.domain.Tyoskentelyjakso
 import fi.elsapalvelu.elsa.web.rest.findAll
+import org.hibernate.engine.jdbc.BlobProxy
 import java.time.LocalDateTime
 import javax.persistence.EntityManager
 
@@ -28,7 +29,7 @@ class AsiakirjaHelper {
                 nimi = ASIAKIRJA_PDF_NIMI,
                 tyyppi = ASIAKIRJA_PDF_TYYPPI,
                 lisattypvm = LocalDateTime.now(),
-                data = ASIAKIRJA_PDF_DATA,
+                data = BlobProxy.generateProxy(ASIAKIRJA_PDF_DATA),
                 tyoskentelyjakso = tyoskentelyjakso
             )
 

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -45,7 +45,7 @@ spring:
       hibernate.cache.use_second_level_cache: false
       hibernate.cache.use_query_cache: false
       hibernate.generate_statistics: false
-      hibernate.hbm2ddl.auto: validate
+      hibernate.hbm2ddl.auto: update
       hibernate.jdbc.time_zone: UTC
   liquibase:
     contexts: test


### PR DESCRIPTION
- Create BlobProxy object with file input stream and size to prevent storing any file content bytes in heap memory