### PR TITLE
UOELSA-513: Convert data in Asiakirja entity as Blob

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/AsiakirjaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/AsiakirjaServiceImpl.kt
@@ -40,6 +40,7 @@ class AsiakirjaServiceImpl(
                     data = BlobProxy.generateProxy(it.fileInputStream, it.fileSize!!)
                 }
             }
+
             asiakirjaEntities = asiakirjaRepository.saveAll(asiakirjaEntities)
 
             return asiakirjaEntities.map { asiakirjaMapper.toDto(it) }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -90,6 +90,7 @@ spring:
       hibernate.order_updates: true
       hibernate.query.fail_on_pagination_over_collection_fetch: true
       hibernate.query.in_clause_parameter_padding: true
+      hibernate.jdbc.use_streams_for_binary: true
     hibernate:
       ddl-auto: none
       naming:


### PR DESCRIPTION
- Create BlobProxy object with file input stream and size to prevent storing any file content bytes in heap memory