### PR TITLE
UOELSA-636: Muunna kouluttajat arrayksi ennen muokkausta ja tallennusta

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonKoulutussopimusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonKoulutussopimusServiceImpl.kt
@@ -81,7 +81,7 @@ class KoejaksonKoulutussopimusServiceImpl(
             koulutussopimus = handleErikoistuva(koulutussopimus, updatedKoulutussopimus)
         }
 
-        koulutussopimus.kouluttajat?.forEach {
+        koulutussopimus.kouluttajat?.toTypedArray()?.forEach {
             if (it.kouluttaja?.user?.id == userId) {
                 koulutussopimus = handleKouluttaja(koulutussopimus, it, updatedKoulutussopimus)
             }


### PR DESCRIPTION
- Muutoin toisen kouluttajan allekirjoituksen yhteydessä virhe java.util.ConcurrentModificationException