### PR TITLE
UOELSA-765: Korjaa käyttäjän IP-osoitteen lokitus  handleAccessDenied…

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/errors/ExceptionTranslator.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/errors/ExceptionTranslator.kt
@@ -131,7 +131,7 @@ class ExceptionTranslator(
                 "user: ${request.let { it?.userPrincipal?.name }}, " +
                 "method: ${request.let { (it?.nativeRequest as HttpServletRequest).method }}, " +
                 "path: ${request.let { (it?.nativeRequest as HttpServletRequest).requestURI }}, " +
-                "ip: ${request.let { (it?.nativeRequest as HttpServletRequest) }.remoteAddr}"
+                "ip: ${request.let { (it?.nativeRequest as HttpServletRequest) }.getHeader("X-Forwarded-For")}"
         )
         return super.handleAccessDenied(e, request)
     }


### PR DESCRIPTION
…issa

- Tähän asti IP-osoite on haettu requestin remoteAddr propertystä mikä on lokittanut load balancerin internal IP:n. Haettaan IP-osoite sen sijaan X-Forwarded-For headerista.