### PR TITLE
UOELSA-546: Korjaa audit-taulujen not null constraintit

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20211209114123_modify_audit_constraints_KoejaksonKoulutussopimus.xml
+++ b/src/main/resources/config/liquibase/changelog/20211209114123_modify_audit_constraints_KoejaksonKoulutussopimus.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+    <changeSet id="20211209114123" author="jhipster">
+        <dropNotNullConstraint tableName="koejakson_koulutussopimus_audit" columnName="koejakson_alkamispaiva"/>
+        <dropNotNullConstraint tableName="koejakson_koulutussopimus_audit" columnName="erikoistuvan_puhelinnumero"/>
+        <dropNotNullConstraint tableName="koejakson_koulutussopimus_audit" columnName="erikoistuvan_sahkoposti"/>
+        <dropNotNullConstraint tableName="koejakson_koulutussopimus_audit" columnName="vastuuhenkilo_id"/>
+        <dropNotNullConstraint tableName="koejakson_koulutussopimus_audit" columnName="vastuuhenkilon_nimi"/>
+        <dropNotNullConstraint tableName="koejakson_koulutussopimus_audit" columnName="vastuuhenkilon_nimi"/>
+
+        <dropNotNullConstraint tableName="koulutussopimuksen_kouluttaja_audit" columnName="kouluttaja_id"/>
+        <dropNotNullConstraint tableName="koulutussopimuksen_kouluttaja_audit" columnName="nimi"/>
+
+        <dropNotNullConstraint tableName="koulutussopimuksen_koulutuspaikka_audit" columnName="nimi"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20211209114446_modify_audit_constraints_KoejaksonAloituskeskustelu.xml
+++ b/src/main/resources/config/liquibase/changelog/20211209114446_modify_audit_constraints_KoejaksonAloituskeskustelu.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+    <changeSet id="20211209114446" author="jhipster">
+        <dropNotNullConstraint tableName="koejakson_aloituskeskustelu_audit" columnName="erikoistuvan_sahkoposti"/>
+        <dropNotNullConstraint tableName="koejakson_aloituskeskustelu_audit" columnName="koejakson_suorituspaikka"/>
+        <dropNotNullConstraint tableName="koejakson_aloituskeskustelu_audit" columnName="koejakson_alkamispaiva"/>
+        <dropNotNullConstraint tableName="koejakson_aloituskeskustelu_audit" columnName="koejakson_paattymispaiva"/>
+        <dropNotNullConstraint tableName="koejakson_aloituskeskustelu_audit" columnName="suoritettu_kokoaikatyossa"/>
+        <dropNotNullConstraint tableName="koejakson_aloituskeskustelu_audit" columnName="tyotunnit_viikossa"/>
+        <dropNotNullConstraint tableName="koejakson_aloituskeskustelu_audit" columnName="lahikouluttaja_id"/>
+        <dropNotNullConstraint tableName="koejakson_aloituskeskustelu_audit" columnName="lahikouluttajan_nimi"/>
+        <dropNotNullConstraint tableName="koejakson_aloituskeskustelu_audit" columnName="lahiesimies_id"/>
+        <dropNotNullConstraint tableName="koejakson_aloituskeskustelu_audit" columnName="lahiesimiehen_nimi"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -136,5 +136,7 @@
     <include file="config/liquibase/changelog/20211119173244_modify_entity_constraints_Suoritusarviointi.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20211129175050_modify_entity_constraints_Suoritemerkinta.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20211209110134_modify_entity_constraints_KoejaksonKoulutussopimus.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20211209114123_modify_audit_constraints_KoejaksonKoulutussopimus.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20211209114446_modify_audit_constraints_KoejaksonAloituskeskustelu.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>
 <!-- @formatter:on -->


### PR DESCRIPTION
- Poista not null constraintit koulutussopimuksen ja aloituskeskustelun audit-tauluista niiden kenttien osalta, jotka pitää pystyä tallentamaan tyhjänä (= tallenna keskeneräisenä)

## Muistilista

- [ ] Testit
- [ ] Auditointitaulut
