### PR TITLE
UOELSA-911: Korjaa kantamigraatio

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/ArvioitavanKokonaisuudenKategoria.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/ArvioitavanKokonaisuudenKategoria.kt
@@ -21,7 +21,6 @@ data class ArvioitavanKokonaisuudenKategoria(
     @Column(name = "nimi", nullable = false)
     var nimi: String? = null,
 
-    @get: NotNull
     @Column(name = "jarjestysnumero", nullable = false)
     var jarjestysnumero: Int? = null,
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/ArvioitavanKokonaisuudenKategoriaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/ArvioitavanKokonaisuudenKategoriaDTO.kt
@@ -11,7 +11,6 @@ data class ArvioitavanKokonaisuudenKategoriaDTO(
     @get: NotNull
     var nimi: String? = null,
 
-    @get: NotNull
     var jarjestysnumero: Int? = null,
 
     @get: NotNull

--- a/src/main/resources/config/liquibase/changelog/20220113123834_add_erikoisala_data_syopataudit.xml
+++ b/src/main/resources/config/liquibase/changelog/20220113123834_add_erikoisala_data_syopataudit.xml
@@ -6,6 +6,7 @@
 
     <changeSet id="20220113123834" author="jhipster" context="!test">
 
+        <!-- Järjestysnumeroa ei kaikissa erikoisalojen toimittamissa datoissa, joten poistetaan not null constraint -->
         <dropNotNullConstraint tableName="arvioitavan_kokonaisuuden_kategoria" columnName="jarjestysnumero"/>
 
         <loadData
@@ -30,12 +31,48 @@
             <column name="kategoria_id" type="numeric"/>
         </loadData>
 
+        <!-- Poista constraintit, jotka edelleen vanhoilla nimillä -->
+        <dropAllForeignKeyConstraints baseTableName="arvioitava_kokonaisuus"/>
+
+        <!-- Poista foreign keyt datan poistamisen ajaksi -->
+        <dropForeignKeyConstraint baseTableName="suoritusarviointi"
+                                  constraintName="fk_suoritusarviointi_arvioitava_kokonaisuus_id"/>
+
+        <!-- Poista foreign key arvioitavan kokonaisuuden primary keyn uudelleennimeämisen ajaksi -->
+        <dropForeignKeyConstraint baseTableName="rel_koulutusjakso__osaamistavoitteet"
+                                  constraintName="fk_rel_koulutusjakso__osaamistavoitteet__osaamistavoitteet_id"/>
+
+        <dropPrimaryKey tableName="arvioitava_kokonaisuus"/>
+        <addPrimaryKey tableName="arvioitava_kokonaisuus" columnNames="id"/>
+
+        <!-- Lisää foreign key takaisin -->
+        <addForeignKeyConstraint baseTableName="rel_koulutusjakso__osaamistavoitteet"
+                                 baseColumnNames="osaamistavoitteet_id"
+                                 constraintName="fk_rel_koulutusjakso__osaamistavoitteet__osaamistavoitteet_id"
+                                 referencedTableName="arvioitava_kokonaisuus"
+                                 referencedColumnNames="id"/>
+
+        <dropPrimaryKey tableName="arvioitavan_kokonaisuuden_kategoria"/>
+        <addPrimaryKey tableName="arvioitavan_kokonaisuuden_kategoria" columnNames="id"/>
+
         <!-- Korjaa työterveyden arvioitavat kokonaisuudet -->
-        <delete tableName="arvioitava_kokonaisuus">
-            <where>id in
-                (3100, 3101, 3102, 3103, 3104, 3105)
-            </where>
+        <delete tableName="arvioitavan_kokonaisuuden_kategoria">
+            <where>id between 3100 and 3104</where>
         </delete>
+
+        <delete tableName="arvioitava_kokonaisuus">
+            <where>id between 3100 and 3105</where>
+        </delete>
+
+        <loadData
+            file="config/liquibase/data/erikoisala/tyoterveyshuolto/arvioitavan_kokonaisuuden_kategoria.csv"
+            separator=";"
+            tableName="arvioitavan_kokonaisuuden_kategoria">
+            <column name="id" type="numeric"/>
+            <column name="nimi" type="string"/>
+            <column name="jarjestysnumero" type="numeric"/>
+            <column name="voimassaolo_alkaa" type="date"/>
+        </loadData>
 
         <loadData
             file="config/liquibase/data/erikoisala/tyoterveyshuolto/arvioitava_kokonaisuus.csv"
@@ -48,6 +85,22 @@
             <column name="erikoisala_id" type="numeric"/>
             <column name="kategoria_id" type="numeric"/>
         </loadData>
+
+        <!-- Lisää foreign key takaisin -->
+        <addForeignKeyConstraint baseTableName="suoritusarviointi" baseColumnNames="arvioitava_kokonaisuus_id"
+                                 constraintName="fk_suoritusarviointi_arvioitava_kokonaisuus_id"
+                                 referencedTableName="arvioitava_kokonaisuus"
+                                 referencedColumnNames="id"/>
+
+        <!-- Lisää foreign keyt oikeilla nimillä -->
+        <addForeignKeyConstraint baseTableName="arvioitava_kokonaisuus" baseColumnNames="erikoisala_id"
+                                 constraintName="fk_arvioitava_kokonaisuus__erikoisala_id"
+                                 referencedTableName="erikoisala"
+                                 referencedColumnNames="id"/>
+        <addForeignKeyConstraint baseTableName="arvioitava_kokonaisuus" baseColumnNames="kategoria_id"
+                                 constraintName="fk_arvioitava_kokonaisuus__kategoria_id"
+                                 referencedTableName="arvioitavan_kokonaisuuden_kategoria"
+                                 referencedColumnNames="id"/>
 
     </changeSet>
 

--- a/src/main/resources/config/liquibase/changelog/20220114084411_delete_old_testdata.xml
+++ b/src/main/resources/config/liquibase/changelog/20220114084411_delete_old_testdata.xml
@@ -5,6 +5,16 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
 
     <changeSet id="20220114084411" author="jhipster" context="!test">
+        <update tableName="suoritusarviointi">
+            <column name="arvioitava_kokonaisuus_id" value="3100"/>
+            <where>arvioitava_kokonaisuus_id between 1 and 32</where>
+        </update>
+
+        <update tableName="suoritemerkinta">
+            <column name="suorite_id" value="3106"/>
+            <where>suorite_id between 1 and 24</where>
+        </update>
+
         <delete tableName="arvioitava_kokonaisuus">
             <where>id between 1 and 32</where>
         </delete>


### PR DESCRIPTION
- Poista foreign key virheellisen datan poiston ajaksi
- Uudelleennimeä arvioitavan kokonaisuuden ja arvioitavan kokonaisuuden kategorian constraintit
- Poista NotNull attribuutit arvioitavan kokonaisuuden kategorian jarjestysnumerolta

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
