### PR TITLE
UOELSA-1065: Korjaa opintosuoritusten päivittäminen

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintosuorituksetPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintosuorituksetPersistenceServiceImpl.kt
@@ -116,11 +116,12 @@ class OpintosuorituksetPersistenceServiceImpl(
             updated = true
         }
 
-        opintosuoritusDTO.vanhenemispaiva.takeIf { opintosuoritus.vanhenemispaiva != it }
-            ?.let {
-                opintosuoritus.vanhenemispaiva = it
-                updated = true
-            }
+        // Päivitetään vanhenemispäivä vaikka se olisi null opintotietojärjestelmästä saadussa datassa,
+        // koska vanhenemispäivä saatetaan haluta poistaa joiltakin suorituksilta.
+        if (opintosuoritusDTO.vanhenemispaiva != opintosuoritus.vanhenemispaiva) {
+            opintosuoritus.vanhenemispaiva = opintosuoritusDTO.vanhenemispaiva
+            updated = true
+        }
 
         if (updated) {
             opintosuoritus.muokkausaika = Instant.now()
@@ -168,8 +169,10 @@ class OpintosuorituksetPersistenceServiceImpl(
             updated = true
         }
 
-        osakokonaisuusDTO.vanhenemispaiva.takeIf { osakokonaisuus.vanhenemispaiva != it }?.let {
-            osakokonaisuus.vanhenemispaiva = it
+        // Päivitetään vanhenemispäivä vaikka se olisi null opintotietojärjestelmästä saadussa datassa,
+        // koska vanhenemispäivä saatetaan haluta poistaa joiltakin osakokonaisuuksilta.
+        if (osakokonaisuusDTO.vanhenemispaiva != osakokonaisuus.vanhenemispaiva) {
+            osakokonaisuus.vanhenemispaiva = osakokonaisuusDTO.vanhenemispaiva
             updated = true
         }
 

--- a/src/main/resources/config/liquibase/changelog/20220408121744_modify_entity_OpintosuoritusOsakokonaisuus.xml
+++ b/src/main/resources/config/liquibase/changelog/20220408121744_modify_entity_OpintosuoritusOsakokonaisuus.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+    <changeSet id="20220408121744" author="jhipster">
+        <dropColumn tableName="opintosuoritus_osakokonaisuus" columnName="nimi_en"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -191,5 +191,6 @@
     <include file="config/liquibase/changelog/20220324154832_added_entity_OpintosuoritusKurssikoodi.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20220324164511_added_entity_Opintosuoritus.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20220324164811_added_entity_OpintosuoritusOsakokonaisuus.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20220408121744_modify_entity_OpintosuoritusOsakokonaisuus.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>
 <!-- @formatter:on -->


### PR DESCRIPTION
- Päivitä vanhenemispäivämäärä vaikka se olisi lähdedatassa null
- Poista tarpeeton sarake opintosuoritus_osakokonaisuus taulusta

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
