### PR TITLE
UOELSA-1144: Tarkista opinto-oikeuden voimassaolo kirjautumisen yhteydessä

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
@@ -3,7 +3,10 @@ package fi.elsapalvelu.elsa.config
 import fi.elsapalvelu.elsa.domain.Authority
 import fi.elsapalvelu.elsa.domain.User
 import fi.elsapalvelu.elsa.domain.enumeration.KayttajatilinTila
-import fi.elsapalvelu.elsa.repository.*
+import fi.elsapalvelu.elsa.repository.KayttajaRepository
+import fi.elsapalvelu.elsa.repository.KouluttajavaltuutusRepository
+import fi.elsapalvelu.elsa.repository.OpintooikeusRepository
+import fi.elsapalvelu.elsa.repository.UserRepository
 import fi.elsapalvelu.elsa.security.*
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
@@ -284,7 +287,7 @@ class SecurityConfiguration(
             )
         }
 
-        var existingUser = userService.findExistingUser(cipher, originalKey, hetu, eppn )
+        var existingUser = userService.findExistingUser(cipher, originalKey, hetu, eppn)
 
         if (hetu != null) {
             if (existingUser == null) {
@@ -311,6 +314,7 @@ class SecurityConfiguration(
             } else if (hasErikoistuvaLaakariRole(existingUser)) {
                 fetchAndUpdateOpintotietodataIfChanged(existingUser.id!!, hetu, firstName, lastName)
                 fetchAndHandleOpintosuorituksetNonBlocking(existingUser.id!!, hetu)
+                opintooikeusService.checkOpintooikeusKaytossaValid(existingUser)
             }
         }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/ErikoistuvaLaakariRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/ErikoistuvaLaakariRepository.kt
@@ -1,21 +1,20 @@
 package fi.elsapalvelu.elsa.repository
 
 import fi.elsapalvelu.elsa.domain.ErikoistuvaLaakari
+import fi.elsapalvelu.elsa.domain.enumeration.OpintooikeudenTila
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
 interface ErikoistuvaLaakariRepository : JpaRepository<ErikoistuvaLaakari, Long>,
     JpaSpecificationExecutor<ErikoistuvaLaakari> {
 
     fun findOneByKayttajaUserId(userId: String): ErikoistuvaLaakari?
-
-    @Query("select distinct e from ErikoistuvaLaakari e join fetch e.opintooikeudet where e.id = :id")
-    fun findByIdWithOpintooikeudet(id: Long): ErikoistuvaLaakari?
 
     fun findOneByKayttajaId(kayttajaId: Long): ErikoistuvaLaakari?
 
@@ -37,4 +36,17 @@ interface ErikoistuvaLaakariRepository : JpaRepository<ErikoistuvaLaakari, Long>
         """
     )
     fun findAllByYliopistoId(pageable: Pageable, yliopistoId: Long): Page<ErikoistuvaLaakari>
+
+    @Query(
+        """
+        select distinct e from ErikoistuvaLaakari e join fetch e.opintooikeudet o where e.kayttaja.user.id = :userId
+        and :betweenDate between o.opintooikeudenMyontamispaiva and o.opintooikeudenPaattymispaiva
+        and o.tila in :validStates and o.erikoisala.liittynytElsaan = true
+        """
+    )
+    fun findOneByKayttajaUserIdWithValidOpintooikeudet(
+        userId: String,
+        betweenDate: LocalDate,
+        validStates: List<OpintooikeudenTila>
+    ): ErikoistuvaLaakari?
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/OpintooikeusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/OpintooikeusRepository.kt
@@ -1,6 +1,7 @@
 package fi.elsapalvelu.elsa.repository
 
 import fi.elsapalvelu.elsa.domain.Opintooikeus
+import fi.elsapalvelu.elsa.domain.enumeration.OpintooikeudenTila
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
@@ -31,12 +32,14 @@ interface OpintooikeusRepository : JpaRepository<Opintooikeus, Long>, JpaSpecifi
         join o.erikoistuvaLaakari e
         join e.kayttaja k
         join k.user u
-        where :paiva between o.opintooikeudenMyontamispaiva and o.opintooikeudenPaattymispaiva and u.id = :userId
+        where :betweenDate between o.opintooikeudenMyontamispaiva and o.opintooikeudenPaattymispaiva
+        and o.tila in :validStates and o.erikoisala.liittynytElsaan = true and u.id = :userId
         """
     )
-    fun findByErikoistuvaLaakariKayttajaUserIdAndBetweenDate(
+    fun findAllValidByErikoistuvaLaakariKayttajaUserId(
         userId: String,
-        paiva: LocalDate
+        betweenDate: LocalDate,
+        validStates: List<OpintooikeudenTila>
     ): List<Opintooikeus>
 
     @Query(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/ErikoistuvaLaakariService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/ErikoistuvaLaakariService.kt
@@ -32,6 +32,8 @@ interface ErikoistuvaLaakariService {
 
     fun findOneByKayttajaUserId(userId: String): ErikoistuvaLaakariDTO?
 
+    fun findOneByKayttajaUserIdWithValidOpintooikeudet(userId: String): ErikoistuvaLaakariDTO?
+
     fun findOneByKayttajaId(kayttajaId: Long): ErikoistuvaLaakariDTO?
 
     fun findAllForVastuuhenkilo(kayttajaId: Long): List<ErikoistuvaLaakariDTO>

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/OpintooikeusService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/OpintooikeusService.kt
@@ -12,5 +12,7 @@ interface OpintooikeusService {
 
     fun onOikeus(user: User): Boolean
 
+    fun checkOpintooikeusKaytossaValid(user: User)
+
     fun setOpintooikeusKaytossa(userId: String, opintooikeusId: Long)
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/constants/Constants.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/constants/Constants.kt
@@ -4,6 +4,7 @@ const val HYVAKSILUETTAVAT_DAYS: Double = 30.0
 const val KAYTTAJA_NOT_FOUND_ERROR = "Käyttäjää ei löydy"
 const val ERIKOISTUVA_LAAKARI_NOT_FOUND_ERROR = "Erikoistuvaa lääkäriä ei löydy"
 const val VASTUUHENKILO_NOT_FOUND_ERROR = "Vastuuhenkilöä ei löydy"
+const val OPINTOOIKEUS_NOT_FOUND_ERROR = "Opinto-oikeutta ei löydy"
 const val JSON_FETCHING_ERROR = "Datan hakeminen epäonnistui"
 const val JSON_DATA_PROSESSING_ERROR = "Datan prosessointio epäonnistui"
 const val JSON_MAPPING_ERROR = "Data mäppäys epäonnistui"

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ErikoistuvaLaakariServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ErikoistuvaLaakariServiceImpl.kt
@@ -20,6 +20,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.time.LocalDate
 import java.util.*
 import javax.persistence.EntityNotFoundException
 
@@ -125,7 +126,11 @@ class ErikoistuvaLaakariServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun findAll(userId:String, criteria: KayttajahallintaCriteria, pageable: Pageable): Page<KayttajahallintaKayttajaListItemDTO> {
+    override fun findAll(
+        userId: String,
+        criteria: KayttajahallintaCriteria,
+        pageable: Pageable
+    ): Page<KayttajahallintaKayttajaListItemDTO> {
         val kayttaja =
             kayttajaRepository.findOneByUserId(userId).orElseThrow { EntityNotFoundException(KAYTTAJA_NOT_FOUND_ERROR) }
         return erikoistuvaLaakariQueryService.findErikoistuvatByCriteria(
@@ -168,6 +173,20 @@ class ErikoistuvaLaakariServiceImpl(
         userId: String
     ): ErikoistuvaLaakariDTO? {
         erikoistuvaLaakariRepository.findOneByKayttajaUserId(userId)?.let {
+            return erikoistuvaLaakariMapper.toDto(it)
+        }
+
+        return null
+    }
+
+    override fun findOneByKayttajaUserIdWithValidOpintooikeudet(
+        userId: String
+    ): ErikoistuvaLaakariDTO? {
+        erikoistuvaLaakariRepository.findOneByKayttajaUserIdWithValidOpintooikeudet(
+            userId,
+            LocalDate.now(),
+            OpintooikeusServiceImpl.allowedOpintooikeusTilat()
+        )?.let {
             return erikoistuvaLaakariMapper.toDto(it)
         }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintooikeusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintooikeusServiceImpl.kt
@@ -7,6 +7,7 @@ import fi.elsapalvelu.elsa.repository.OpintooikeusRepository
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
 import fi.elsapalvelu.elsa.service.OpintooikeusService
+import fi.elsapalvelu.elsa.service.constants.OPINTOOIKEUS_NOT_FOUND_ERROR
 import fi.elsapalvelu.elsa.service.dto.OpintooikeusDTO
 import fi.elsapalvelu.elsa.service.mapper.OpintooikeusMapper
 import org.springframework.security.core.context.SecurityContextHolder
@@ -17,9 +18,6 @@ import java.time.Clock
 import java.time.LocalDate
 import javax.persistence.EntityNotFoundException
 
-
-private const val ENTITY_NOT_FOUND_ERROR_MSG = "Opinto-oikeutta ei löydy"
-
 @Service
 @Transactional
 class OpintooikeusServiceImpl(
@@ -29,10 +27,9 @@ class OpintooikeusServiceImpl(
     private val clock: Clock
 ) : OpintooikeusService {
     override fun findAllValidByErikoistuvaLaakariKayttajaUserId(userId: String): List<OpintooikeusDTO> {
-        return opintooikeusRepository.findByErikoistuvaLaakariKayttajaUserIdAndBetweenDate(
-            userId,
-            LocalDate.now(clock)
-        ).filter { allowedOpintooikeusTilat().contains(it.tila) }.map(opintooikeusMapper::toDto)
+        return opintooikeusRepository.findAllValidByErikoistuvaLaakariKayttajaUserId(
+            userId, LocalDate.now(clock), allowedOpintooikeusTilat()
+        ).map(opintooikeusMapper::toDto)
     }
 
     override fun findOneByKaytossaAndErikoistuvaLaakariKayttajaUserId(userId: String): OpintooikeusDTO {
@@ -41,53 +38,51 @@ class OpintooikeusServiceImpl(
                 opintooikeusRepository.findById(it).get()
             )
         }
-        opintooikeusRepository.findOneByErikoistuvaLaakariKayttajaUserIdAndKaytossaTrue(userId)
-            ?.let {
-                return opintooikeusMapper.toDto(it)
-            }
+        opintooikeusRepository.findOneByErikoistuvaLaakariKayttajaUserIdAndKaytossaTrue(userId)?.let {
+            return opintooikeusMapper.toDto(it)
+        }
 
-        throw EntityNotFoundException(ENTITY_NOT_FOUND_ERROR_MSG)
+        throw EntityNotFoundException(OPINTOOIKEUS_NOT_FOUND_ERROR)
     }
 
     override fun findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(userId: String): Long {
         getImpersonatedOpintooikeusId()?.let { return it }
-        opintooikeusRepository.findOneByErikoistuvaLaakariKayttajaUserIdAndKaytossaTrue(userId)
-            ?.let {
-                return it.id!!
-            }
-
-        throw EntityNotFoundException(ENTITY_NOT_FOUND_ERROR_MSG)
-    }
-
-    private fun getImpersonatedOpintooikeusId(): Long? {
-        val authentication = SecurityContextHolder.getContext().authentication
-        val principal: Saml2AuthenticatedPrincipal =
-            authentication.principal as Saml2AuthenticatedPrincipal
-        val authorities = authentication.authorities.map { it.authority }
-        if (authorities.contains(ERIKOISTUVA_LAAKARI_IMPERSONATED) ||
-            authorities.contains(ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA)
-        ) {
-            return principal.getFirstAttribute("opintooikeusId") as Long
+        opintooikeusRepository.findOneByErikoistuvaLaakariKayttajaUserIdAndKaytossaTrue(userId)?.let {
+            return it.id!!
         }
-        return null
+
+        throw EntityNotFoundException(OPINTOOIKEUS_NOT_FOUND_ERROR)
     }
 
     override fun onOikeus(user: User): Boolean {
-        opintooikeusRepository.findByErikoistuvaLaakariKayttajaUserIdAndBetweenDate(
-            user.id!!,
-            LocalDate.now(clock)
-        ).forEach {
-            if (allowedOpintooikeusTilat().contains(it.tila) && it.erikoisala?.liittynytElsaan == true) return true
+        if (opintooikeusRepository.findAllValidByErikoistuvaLaakariKayttajaUserId(
+                user.id!!, LocalDate.now(clock), allowedOpintooikeusTilat()
+            ).any()
+        ) {
+            return true
         }
+
         return false
+    }
+
+    override fun checkOpintooikeusKaytossaValid(user: User) {
+        val opintooikeusKaytossa =
+            opintooikeusRepository.findOneByErikoistuvaLaakariKayttajaUserIdAndKaytossaTrue(user.id!!)
+                ?: throw EntityNotFoundException(OPINTOOIKEUS_NOT_FOUND_ERROR)
+        if (opintooikeusKaytossa.opintooikeudenPaattymispaiva!! < LocalDate.now()) {
+            opintooikeusRepository.findAllValidByErikoistuvaLaakariKayttajaUserId(
+                user.id!!, LocalDate.now(clock), allowedOpintooikeusTilat()
+            ).elementAtOrNull(0)?.let {
+                opintooikeusKaytossa.kaytossa = false
+                it.kaytossa = true
+            }
+        }
     }
 
     override fun setOpintooikeusKaytossa(userId: String, opintooikeusId: Long) {
         erikoistuvaLaakariRepository.findOneByKayttajaUserId(userId)?.let { erikoistuva ->
             opintooikeusRepository.findOneByIdAndErikoistuvaLaakariIdAndBetweenDate(
-                opintooikeusId,
-                erikoistuva.id!!,
-                LocalDate.now(clock)
+                opintooikeusId, erikoistuva.id!!, LocalDate.now(clock)
             )?.let { preferredOpintooikeus ->
                 erikoistuva.opintooikeudet.forEach { opintooikeus ->
                     opintooikeus.kaytossa = false
@@ -95,6 +90,19 @@ class OpintooikeusServiceImpl(
                 preferredOpintooikeus.kaytossa = true
             }
         }
+    }
+
+    private fun getImpersonatedOpintooikeusId(): Long? {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val principal: Saml2AuthenticatedPrincipal = authentication.principal as Saml2AuthenticatedPrincipal
+        val authorities = authentication.authorities.map { it.authority }
+        if (authorities.contains(ERIKOISTUVA_LAAKARI_IMPERSONATED) || authorities.contains(
+                ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
+            )
+        ) {
+            return principal.getFirstAttribute("opintooikeusId") as Long
+        }
+        return null
     }
 
     companion object {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKaytonAloitusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKaytonAloitusResource.kt
@@ -38,9 +38,9 @@ class ErikoistuvaLaakariKaytonAloitusResource(
             userService.updateEmail(it, user.id!!)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
 
-        val opintooikeudetVoimassa = opintooikeusService.findAllValidByErikoistuvaLaakariKayttajaUserId(user.id!!)
+        val validOpintooikeudet = opintooikeusService.findAllValidByErikoistuvaLaakariKayttajaUserId(user.id!!)
         val opintooikeusId = kaytonAloitusDTO.opintooikeusId
-        val shouldSelectOpintooikeusKaytossa = opintooikeudetVoimassa.count() > 1
+        val shouldSelectOpintooikeusKaytossa = validOpintooikeudet.count() > 1
 
         if ((opintooikeusId == null && shouldSelectOpintooikeusKaytossa) ||
             (opintooikeusId != null && !shouldSelectOpintooikeusKaytossa)
@@ -49,7 +49,7 @@ class ErikoistuvaLaakariKaytonAloitusResource(
         }
 
         opintooikeusId?.let { id ->
-            if (opintooikeudetVoimassa.find { it.id == id } == null) {
+            if (validOpintooikeudet.find { it.id == id } == null) {
                 throw ResponseStatusException(HttpStatus.BAD_REQUEST)
             }
             opintooikeusService.setOpintooikeusKaytossa(user.id!!, id)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariMuutToiminnotResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariMuutToiminnotResource.kt
@@ -41,7 +41,7 @@ class ErikoistuvaLaakariMuutToiminnotResource(
         principal: Principal?
     ): ResponseEntity<ErikoistuvaLaakariDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        erikoistuvaLaakariService.findOneByKayttajaUserId(user.id!!)?.let {
+        erikoistuvaLaakariService.findOneByKayttajaUserIdWithValidOpintooikeudet(user.id!!)?.let {
             if (user.authorities?.contains(ERIKOISTUVA_LAAKARI_IMPERSONATED) == true ||
                 user.authorities?.contains(ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA) == true
             ) {

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/ErikoisalaHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/ErikoisalaHelper.kt
@@ -23,7 +23,8 @@ class ErikoisalaHelper {
             return Erikoisala(
                 nimi = nimi,
                 tyyppi = DEFAULT_TYYPPI,
-                virtaPatevyyskoodi = virtaPatevyyskoodi
+                virtaPatevyyskoodi = virtaPatevyyskoodi,
+                liittynytElsaan = true
             )
         }
 
@@ -35,7 +36,8 @@ class ErikoisalaHelper {
             return Erikoisala(
                 nimi = nimi,
                 tyyppi = UPDATED_TYYPPI,
-                virtaPatevyyskoodi = virtaPatevyyskoodi
+                virtaPatevyyskoodi = virtaPatevyyskoodi,
+                liittynytElsaan = true
             )
         }
     }


### PR DESCRIPTION
- Siirrä opinto-oikeuksien filtteröinti JPA-queryyn ja hae vain voimassaolevat ja kirjautumisen sallivan tilan omaavat opinto-oikeudet
- Mikäli käyttäjän valitsema opinto-oikeus ei ole enää voimassa myöhemmällä kirjautumiskerralla, aseta aktiiviseksi opinto-oikeudeksi ensimmäinen voimassaoleva, jonka tila sallii kirjautumisen

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
