### PR TITLE
UOELSA-1161: Poista päivämäärätarkistus kouluttajavaltuutusta haettaessa

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/KouluttajavaltuutusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/KouluttajavaltuutusRepository.kt
@@ -31,4 +31,9 @@ interface KouluttajavaltuutusRepository : JpaRepository<Kouluttajavaltuutus, Lon
         valtuutettuId: String,
         pvm: LocalDate
     ): Optional<Kouluttajavaltuutus>
+
+    fun findByValtuuttajaOpintooikeusIdAndValtuutettuUserId(
+        valtuuttajaOpintooikeusId: Long,
+        valtuutettuId: String
+    ): Optional<Kouluttajavaltuutus>
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KouluttajavaltuutusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KouluttajavaltuutusServiceImpl.kt
@@ -36,11 +36,9 @@ class KouluttajavaltuutusServiceImpl(
         val opintooikeus = erikoistuvaLaakari?.getOpintooikeusKaytossa()
 
         if (kouluttajavaltuutus.id == null) {
-            kouluttajavaltuutusRepository.findByValtuuttajaOpintooikeusIdAndValtuutettuUserIdAndPaattymispaivaAfter(
+            kouluttajavaltuutusRepository.findByValtuuttajaOpintooikeusIdAndValtuutettuUserId(
                 opintooikeus?.id!!,
-                kayttajaRepository.findById(kouluttajavaltuutusDTO.valtuutettu?.id!!)
-                    .get().user?.id!!,
-                LocalDate.now().minusDays(1)
+                kayttajaRepository.findById(kouluttajavaltuutusDTO.valtuutettu?.id!!).get().user?.id!!
             ).ifPresentOrElse({
                 kouluttajavaltuutus = it
                 kouluttajavaltuutus.paattymispaiva = kouluttajavaltuutusDTO.paattymispaiva


### PR DESCRIPTION
- Mikäli olemassaolevista kouluttajavaltuutuksista haetaan vain voimassaolevat ei uutta valtuutusta pysty lisäämään samalle kouluttajalle unique constaintin takia

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
