### PR TITLE
UOELSA-1175: Aseta opiskelijatunnus ei pakolliseksi

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/KoejaksonAloituskeskusteluDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/KoejaksonAloituskeskusteluDTO.kt
@@ -15,7 +15,6 @@ data class KoejaksonAloituskeskusteluDTO(
     @get: NotNull
     var erikoistuvanErikoisala: String? = null,
 
-    @get: NotNull
     var erikoistuvanOpiskelijatunnus: String? = null,
 
     @get: NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/KoejaksonKehittamistoimenpiteetDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/KoejaksonKehittamistoimenpiteetDTO.kt
@@ -16,7 +16,6 @@ data class KoejaksonKehittamistoimenpiteetDTO(
     @get: NotNull
     var erikoistuvanErikoisala: String? = null,
 
-    @get: NotNull
     var erikoistuvanOpiskelijatunnus: String? = null,
 
     @get: NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/KoejaksonLoppukeskusteluDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/KoejaksonLoppukeskusteluDTO.kt
@@ -16,7 +16,6 @@ data class KoejaksonLoppukeskusteluDTO(
     @get: NotNull
     var erikoistuvanErikoisala: String? = null,
 
-    @get: NotNull
     var erikoistuvanOpiskelijatunnus: String? = null,
 
     @get: NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/KoejaksonValiarviointiDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/KoejaksonValiarviointiDTO.kt
@@ -16,7 +16,6 @@ data class KoejaksonValiarviointiDTO(
     @get: NotNull
     var erikoistuvanErikoisala: String? = null,
 
-    @get: NotNull
     var erikoistuvanOpiskelijatunnus: String? = null,
 
     @get: NotNull


### PR DESCRIPTION
- Aseta opiskelijatunnus ei pakolliseksi AloituskeskusteluDTO:ssa, ValiarviointiDTO:ssa, KehittamistoimenpiteetDTO:ssa ja LoppukeskusteluDTO:ssa, koska kyseistä tietoa ei käytetä tallennuksen yhteydessä vaan opiskelijatunnus haetaan opintooikeus-taulusta.

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
