### PR TITLE
UOELSA-1187: Muokkaa erikoisalanimet

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20220923114933_modify_erikoisala_nimet.xml
+++ b/src/main/resources/config/liquibase/changelog/20220923114933_modify_erikoisala_nimet.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+    <changeSet id="20220923114933" author="jhipster">
+        <update tableName="erikoisala">
+            <column name="nimi" value="Suu- ja leukakirurgia (Hammaslääketiede)"/>
+            <where>nimi='Suu- ja leukakirurgia' and tyyppi='HAMMASLAAKETIEDE'</where>
+        </update>
+        <update tableName="erikoisala">
+            <column name="nimi" value="Terveydenhuolto (Hammaslääketiede)"/>
+            <where>nimi='Terveydenhuolto' and tyyppi='HAMMASLAAKETIEDE'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -235,5 +235,6 @@
     <include file="config/liquibase/changelog/20220908152328_modify_entity_TerveyskeskuskoulutusjaksonHyvaksynta.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20220912142112_modify_entity_Valmistumispyynto.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20220915162419_modify_entity_Tyoskentelyjakso.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20220923114933_modify_erikoisala_nimet.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>
 <!-- @formatter:on -->


### PR DESCRIPTION
- Muokkaa nimeä niille hammaslääketieteen erikoisaloille, jotka ovat samannimisiä kuin lääketieteellä

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
