### PR TITLE
ELSA-255: Korjaus työskentelyjaksojen hyväksiluettujen päivien laskuun

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/TyoskentelyjaksoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/TyoskentelyjaksoServiceImpl.kt
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import jakarta.validation.ValidationException
+import java.time.LocalDate
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.round
@@ -417,15 +418,18 @@ class TyoskentelyjaksoServiceImpl(
                     tyoskentelyjaksot
                 )
         }
+        val now = LocalDate.now()
         tyoskentelyjaksot.map { it.keskeytykset }.flatten()
             .sortedBy { it.alkamispaiva }.forEach {
                 val tyoskentelyjaksoFactor =
                     it.tyoskentelyjakso?.osaaikaprosentti!!.toDouble() / 100.0
+                val endDate = it.tyoskentelyjakso?.paattymispaiva ?: now
                 val amountOfReducedDays =
                     tyoskentelyjaksonPituusCounterService.calculateAmountOfReducedDaysAndUpdateHyvaksiluettavatCounter(
                         it,
                         tyoskentelyjaksoFactor,
-                        hyvaksiluettavatCounter
+                        hyvaksiluettavatCounter,
+                        if (endDate.isAfter(now)) now else endDate
                     )
                 result.putIfAbsent(it.tyoskentelyjakso!!.id!!, 0.0)
                 result[it.tyoskentelyjakso!!.id!!] =

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/TyoskentelyjaksonPituusCounterServiceTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/TyoskentelyjaksonPituusCounterServiceTest.kt
@@ -543,8 +543,8 @@ class TyoskentelyjaksonPituusCounterServiceTest {
 
         val keskeytysaikaMock4 = KeskeytysaikaMockHelper.createKeskeytysaikaMock(
             null,
-            LocalDate.ofEpochDay(900L),
-            LocalDate.ofEpochDay(910L),
+            LocalDate.ofEpochDay(660L),
+            LocalDate.ofEpochDay(670L),
             100,
             PoissaolonSyyTyyppi.VAHENNETAAN_YLIMENEVA_AIKA_PER_VUOSI
         )


### PR DESCRIPTION
Työskentelyjaksojen hyväksiluettujen päivien logiikka hajoaa, jos työskentelyjaksolla ei ole päättymispäivämäärää ja keskeytys sijoittuu seuraavalle vuodelle

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
