### PR TITLE
YEK-1566: Päivitä käytössä oleva opinto-oikeus roolin vaihdossa

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/ErikoistuvaLaakari.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/ErikoistuvaLaakari.kt
@@ -48,7 +48,10 @@ data class ErikoistuvaLaakari(
     var laillistamispaivanLiitetiedostonTyyppi: String? = null,
 
     @Column(name = "laakarikoulutussuoritettusuomitaibelgia")
-    var laakarikoulutusSuoritettuSuomiTaiBelgia: Boolean? = false
+    var laakarikoulutusSuoritettuSuomiTaiBelgia: Boolean? = false,
+
+    @Column(name = "aktiivinen_opintooikeus")
+    var aktiivinenOpintooikeus: Long? = null
 
 ) : Serializable {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/OpintooikeusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/OpintooikeusRepository.kt
@@ -18,6 +18,8 @@ interface OpintooikeusRepository : JpaRepository<Opintooikeus, Long>,
 
     fun findOneByErikoistuvaLaakariKayttajaUserIdAndKaytossaTrue(userId: String): Opintooikeus?
 
+    fun findOneByErikoisalaIdAndErikoistuvaLaakariKayttajaUserId(id: Long, userId: String): Opintooikeus?
+
     fun findOneByErikoistuvaLaakariKayttajaUserIdAndKaytossaTrueAndErikoisalaId(userId: String, erikoisalaId: Long): Opintooikeus?
 
     fun findOneByErikoistuvaLaakariIdAndYliopistoOpintooikeusId(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/ErikoistuvaLaakariService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/ErikoistuvaLaakariService.kt
@@ -56,4 +56,6 @@ interface ErikoistuvaLaakariService {
         userId: String,
         laakarikoulutusSuoritettuSuomiTaiBelgia: Boolean?
     )
+
+    fun updateAktiivinenOpintooikeus(userId: String, opintooikeusId: Long)
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/OpintooikeusService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/OpintooikeusService.kt
@@ -12,6 +12,8 @@ interface OpintooikeusService {
 
     fun findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(userId: String): Long
 
+    fun findOneByErikoisalaIdAndErikoistuvaLaakariKayttajaUserId(erikoisalaId: Long, userId: String): Long
+
     fun findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(userId: String, erikoisalaId: Long): Long
 
     fun findOneByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(userId: String, erikoisalaId: Long): OpintooikeusDTO
@@ -23,6 +25,8 @@ interface OpintooikeusService {
     fun checkOpintooikeusKaytossaValid(user: User)
 
     fun setOpintooikeusKaytossa(userId: String, opintooikeusId: Long)
+
+    fun setAktiivinenOpintooikeusKaytossa(userId: String)
 
     fun updateMuokkausoikeudet(userId: String, muokkausoikeudet: Boolean)
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ErikoistuvaLaakariServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ErikoistuvaLaakariServiceImpl.kt
@@ -111,6 +111,7 @@ class ErikoistuvaLaakariServiceImpl(
         opintooikeus = opintooikeusRepository.save(opintooikeus)
 
         erikoistuvaLaakari.opintooikeudet.add(opintooikeus)
+        erikoistuvaLaakari.aktiivinenOpintooikeus = opintooikeus.id
         erikoistuvaLaakari = erikoistuvaLaakariRepository.save(erikoistuvaLaakari)
 
         val token = verificationTokenService.save(user.id!!)
@@ -278,6 +279,12 @@ class ErikoistuvaLaakariServiceImpl(
                 it.laakarikoulutusSuoritettuSuomiTaiBelgia = laakarikoulutusSuoritettuSuomiTaiBelgia
                 erikoistuvaLaakariRepository.save(it)
             }
+        }
+    }
+
+    override fun updateAktiivinenOpintooikeus(userId: String, opintooikeusId: Long) {
+        erikoistuvaLaakariRepository.findOneByKayttajaUserId(userId)?.let {
+            it.aktiivinenOpintooikeus = opintooikeusId
         }
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
@@ -173,6 +173,7 @@ class OpintotietodataPersistenceServiceImpl(
         opintooikeus = opintooikeusRepository.save(opintooikeus)
 
         erikoistuvaLaakari.opintooikeudet.add(opintooikeus)
+        erikoistuvaLaakari.aktiivinenOpintooikeus = opintooikeus.id
         erikoistuvaLaakariRepository.save(erikoistuvaLaakari)
     }
 
@@ -349,6 +350,7 @@ class OpintotietodataPersistenceServiceImpl(
         opintooikeus = opintooikeusRepository.save(opintooikeus)
 
         erikoistuvaLaakari.opintooikeudet.add(opintooikeus)
+        erikoistuvaLaakari.aktiivinenOpintooikeus = opintooikeus.id
         erikoistuvaLaakariRepository.save(erikoistuvaLaakari)
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KayttajaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KayttajaResource.kt
@@ -1,14 +1,9 @@
 package fi.elsapalvelu.elsa.web.rest
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED
-import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
-import fi.elsapalvelu.elsa.security.KOULUTTAJA
-import fi.elsapalvelu.elsa.security.VASTUUHENKILO
-import fi.elsapalvelu.elsa.service.ErikoisalaService
-import fi.elsapalvelu.elsa.service.KayttajaService
-import fi.elsapalvelu.elsa.service.UserService
-import fi.elsapalvelu.elsa.service.YliopistoService
+import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
+import fi.elsapalvelu.elsa.security.*
+import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.*
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import org.springframework.http.ResponseEntity
@@ -28,6 +23,7 @@ class KayttajaResource(
     private val kayttajaService: KayttajaService,
     private val yliopistoService: YliopistoService,
     private val erikoisalaService: ErikoisalaService,
+    private val opintooikeusService: OpintooikeusService,
     private val objectMapper: ObjectMapper
 ) {
 
@@ -149,6 +145,15 @@ class KayttajaResource(
         }
 
         userService.updateRooli(rooli, userId)
+
+        if (rooli == YEK_KOULUTETTAVA) {
+            opintooikeusService.findOneByErikoisalaIdAndErikoistuvaLaakariKayttajaUserId(YEK_ERIKOISALA_ID, userId).let {
+                opintooikeusService.setOpintooikeusKaytossa(userId, it)
+            }
+        } else if (rooli == ERIKOISTUVA_LAAKARI) {
+            opintooikeusService.setAktiivinenOpintooikeusKaytossa(userId)
+        }
+
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/resources/config/liquibase/changelog/20240422151300_modify_entity_ErikoistuvaLaakari.xml
+++ b/src/main/resources/config/liquibase/changelog/20240422151300_modify_entity_ErikoistuvaLaakari.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+    <changeSet id="20240320151400" author="jhipster">
+        <addColumn tableName="erikoistuva_laakari">
+            <column name="aktiivinen_opintooikeus" type="bigint"/>
+        </addColumn>
+        <update tableName="erikoistuva_laakari">
+            <column name="aktiivinen_opintooikeus"
+                    valueComputed="(select id from opintooikeus where erikoistuva_laakari_id = erikoistuva_laakari.id and kaytossa = true)"/>
+            <where>id = erikoistuva_laakari.id</where>
+        </update>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -268,6 +268,7 @@
     <include file="config/liquibase/changelog/20240229130000_modify_entity_PoissaolonSyy.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20240319000000_modify_entity_Erikoisala.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20240320151400_modify_entity_ErikoistuvaLaakari.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20240422151300_modify_entity_ErikoistuvaLaakari.xml" relativeToChangelogFile="false"/>
 
 </databaseChangeLog>
 <!-- @formatter:on -->


### PR DESCRIPTION
- Erikoistujalla voi olla vain yksi opinto-oikeus käytössä kerrallaan
- Erikoistujan ja YEK-roolin vaihdossa katoaa tieto mikä opinto-oikeus oli käytössä ennen vaihtoa, joten lisätään sille oma kenttä 

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
