### PR TITLE
Github actions käyttöön

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,248 @@
+name: Backend CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+    tags-ignore:
+      - "*"
+  pull_request:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Dependency check
+        continue-on-error: true
+        run: ./gradlew dependencyCheckAnalyze
+      - name: Upload dependency check report
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report.csv
+          path: ./build/reports/dependency-check-report.csv
+      - name: Build and test
+        run: ./gradlew build
+      - name: Store reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports
+          path: |
+            **/build/test-results/integrationTest/
+
+  build-image:
+    runs-on: ubuntu-latest
+    needs: test-and-build
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
+    outputs:
+      image-tag: ${{ steps.image-tag.outputs.image-tag }}
+    environment: shared
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Set image tag
+        id: image-tag
+        run: echo "image-tag=$(date +"%Y%m%d%H%M%S")" >> "$GITHUB_OUTPUT"
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/GithubActionsRole
+          aws-region: eu-west-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Build image and push to ecr
+        env:
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+        run: |
+          ./gradlew jib -Pprod -Djib.to.image=$ECR_REPOSITORY:${{ steps.image-tag.outputs.image-tag }}
+
+  backend-deploy-dev:
+    runs-on: ubuntu-latest
+    needs: build-image
+    if: github.ref == 'refs/heads/main'
+    environment: development
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/GithubActionsRole
+          aws-region: eu-west-1
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition --task-definition elsa-dev-backend --query taskDefinition | jq -r 'del(
+          .taskDefinitionArn,
+          .requiresAttributes,
+          .compatibilities,
+          .revision,
+          .status,
+          .registeredAt,
+          .registeredBy
+          )' > task-definition.json
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: elsa-dev-backend-container
+          image: ${{ secrets.ECR_REPOSITORY }}:${{ needs.build-image.outputs.image-tag }}
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: elsa-dev-backend-service
+          cluster: elsa-dev-cluster
+          wait-for-service-stability: true
+
+  backend-deploy-maintenance-page-staging:
+    runs-on: ubuntu-latest
+    needs: build-image
+    if: startsWith(github.ref, 'refs/heads/release/')
+    environment: staging
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/GithubActionsRole
+          aws-region: eu-west-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Deploy static site to S3 bucket
+        run: aws s3 sync src/main/resources/templates/huoltokatko.html s3://testi.elsapalvelu.fi/index.html
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
+
+  backend-deploy-staging:
+    runs-on: ubuntu-latest
+    needs: build-image
+    if: startsWith(github.ref, 'refs/heads/release/')
+    environment: staging
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/GithubActionsRole
+          aws-region: eu-west-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition --task-definition elsa-staging-backend --query taskDefinition | jq -r 'del(
+          .taskDefinitionArn,
+          .requiresAttributes,
+          .compatibilities,
+          .revision,
+          .status,
+          .registeredAt,
+          .registeredBy
+          )' > task-definition.json
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: elsa-staging-backend-container
+          image: ${{ secrets.ECR_REPOSITORY }}:${{ needs.build-image.outputs.image-tag }}
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: elsa-staging-backend
+          cluster: elsa-staging-cluster
+          wait-for-service-stability: true
+
+  backend-deploy-maintenance-page-prod:
+    runs-on: ubuntu-latest
+    needs: build-image
+    if: startsWith(github.ref, 'refs/heads/release/')
+    environment: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/GithubActionsRole
+          aws-region: eu-west-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Deploy static site to S3 bucket
+        run: aws s3 sync src/main/resources/templates/huoltokatko.html s3://elsapalvelu.fi/index.html
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
+
+  backend-deploy-prod:
+    runs-on: ubuntu-latest
+    needs: build-image
+    if: startsWith(github.ref, 'refs/heads/release/')
+    environment: production
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/GithubActionsRole
+          aws-region: eu-west-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition --task-definition elsa-prod-backend --query taskDefinition | jq -r 'del(
+          .taskDefinitionArn,
+          .requiresAttributes,
+          .compatibilities,
+          .revision,
+          .status,
+          .registeredAt,
+          .registeredBy
+          )' > task-definition.json
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: elsa-prod-backend-container
+          image: ${{ secrets.ECR_REPOSITORY }}:${{ needs.build-image.outputs.image-tag }}
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: elsa-prod-backend
+          cluster: elsa-prod-cluster
+          wait-for-service-stability: true


### PR DESCRIPTION
Github Actions hyötyjä:
- Ei rajoituksia montako samanaikaista runneria
- Ajot näkee suoraan githubista
- Ympäristökohtaisia asetuksia ja muuttujia voidaan hallitan githubista

Muita parannuksia:
- Github OIDC käyttöön jolloin ei tarvita erillisiä AWS käyttäjiä CI:lle vaan githubia varten tehdään aina väliaikainen pääsy
- Ei ajeta testejä useaan kertaan
- jib tekee docker imagen suoraan ecr:ään

Huomioita:
- Toistaiseksi jätetty azure devops konfiguraatio myös paikalleen, voidaan ottaa pois jossain kohti jos actions toimii vakaasti
- Releasen yhteydessä täytyy seurata meneekö deploy läpi
- Cache luodaan vain main branchista, muissa read only tilassa. Seurattava käytetäänkö cachea oikein.

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
