### PR TITLE
YEK-1597: Uusi YEK oikeus ei saa vaihtaa erikoistumisen aktiivista opinto-oikeutta

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
@@ -373,9 +373,9 @@ class OpintotietodataPersistenceServiceImpl(
             user.authorities.add(Authority(name = ERIKOISTUVA_LAAKARI))
             user.activeAuthority = Authority(name = ERIKOISTUVA_LAAKARI)
             userRepository.save(user)
+            erikoistuvaLaakari.aktiivinenOpintooikeus = opintooikeus.id
         }
         erikoistuvaLaakari.opintooikeudet.add(opintooikeus)
-        erikoistuvaLaakari.aktiivinenOpintooikeus = opintooikeus.id
         erikoistuvaLaakariRepository.save(erikoistuvaLaakari)
     }
 


### PR DESCRIPTION

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
