### PR TITLE
YEK-1599: Ei luoda ylimääräistä EL roolia

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
@@ -116,19 +116,15 @@ class OpintotietodataPersistenceServiceImpl(
             }
         }
 
-        val user = erikoistuvaLaakari!!.kayttaja?.user!!
-        if (!user.authorities.contains(Authority(name = ERIKOISTUVA_LAAKARI))) {
-            user.authorities.add(Authority(name = ERIKOISTUVA_LAAKARI))
-            userRepository.save(user)
+        erikoistuvaLaakari?.let {
+            updateNimiIfChanged(it, etunimi, sukunimi)
+
+            checkOpintooikeudetAmount(
+                filterOpintooikeudetByVoimassaDate(opintotietodataOpintooikeudet),
+                it
+            )
+            updateOpintooikeudet(userId, opintotietodataOpintooikeudet, it)
         }
-
-        updateNimiIfChanged(erikoistuvaLaakari, etunimi, sukunimi)
-
-        checkOpintooikeudetAmount(
-            filterOpintooikeudetByVoimassaDate(opintotietodataOpintooikeudet),
-            erikoistuvaLaakari
-        )
-        updateOpintooikeudet(userId, opintotietodataOpintooikeudet, erikoistuvaLaakari)
     }
 
     override fun createOrUpdateOpintotieto(userId: String, opintotietodataDTO: OpintotietodataDTO) {


### PR DESCRIPTION
Jos käyttäjälle löytyy pelkkä YEK opinto-oikeus, muodostetaan sille ensimmäisellä kerralla rooli oikein. Seuraavalla kirjautumisella hänelle muodostuu kuitenkin lisäksi EL rooli. Jos käyttäjä yrittää vaihtaa roolia EL:ksi, heitetään hänet ulos järjestelmästä eikä hän pääse takaisin sisälle. Poistetaan ylimääräinen roolin muodostus.

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
