### PR TITLE
ELSA-486: Pakota käyttäjän poisto ennen toisen käyttäjän päivitystä

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KayttajienYhdistaminenServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KayttajienYhdistaminenServiceImpl.kt
@@ -12,6 +12,7 @@ import fi.elsapalvelu.elsa.service.KayttajienYhdistaminenService
 import fi.elsapalvelu.elsa.service.dto.kayttajahallinta.KayttajienYhdistaminenDTO
 import fi.elsapalvelu.elsa.service.dto.kayttajahallinta.KayttajienYhdistaminenResult
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
+import jakarta.persistence.EntityManager
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,7 +31,8 @@ class KayttajienYhdistaminenServiceImpl(
     private val koejaksonKehittamistoimenpiteetRepository: KoejaksonKehittamistoimenpiteetRepository,
     private val koejaksonKoulutussopimusRepository: KoejaksonKoulutussopimusRepository,
     private val suoritusarviointiRepository: SuoritusarviointiRepository,
-    private val seurantajaksoRepository: SeurantajaksoRepository
+    private val seurantajaksoRepository: SeurantajaksoRepository,
+    private val entityManager: EntityManager
 ) : KayttajienYhdistaminenService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -380,6 +382,8 @@ class KayttajienYhdistaminenServiceImpl(
         try {
             kayttajaRepository.delete(toinenKayttaja)
             toinenKayttaja.user?.let { userRepository.delete(it) }
+            entityManager.flush()
+
             log.info(
                 "poistaToinenKayttaja poistettu käyttäjä id:llä {}",
                 toinenKayttaja.id


### PR DESCRIPTION
JPA ei aja SQL komentoja heti, vaan vasta transaktion lopussa. Komennot ajetaan seuraavassa järjestyksessä:
1. Inserts, in the order they were performed
2. Updates
3. Deletion of collection elements
4. Insertion of collection elements
5. Deletes, in the order they were performed 

Toisen käyttäjän sähköposti yritetään päivittää ennen kuin toinen käyttäjä poistetaan. Pakotetaan SQL ajo käyttäjän poiston yhteydessä, jotta toisen käyttäjän päivityksen yhteydessä ei tule konflikteja.

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
