### PR TITLE
ELSA-807: Bugikorjauksia

### DIFF
--- a/src/main/graphql/fi.elsapalvelu.elsa/schema.graphqls
+++ b/src/main/graphql/fi.elsapalvelu.elsa/schema.graphqls
@@ -376,7 +376,7 @@ type RequirementCollection {
 }
 
 type StudyRight {
-  id: ID!
+  id: ID
   acceptedSelectionPath: SelectionPath
   requestedSelectionPath: SelectionPath!
   decreeOnUniversityDegreesUrn: String

--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
@@ -402,7 +402,7 @@ class SecurityConfiguration(
         }
 
         if (existingUser == null) {
-            log.error(
+            log.warn(
                 "Kirjautuminen epäonnistui käyttäjälle $firstName $lastName (eppn $eppn). " +
                     "Käyttäjällä ei ole käyttöoikeutta."
             )

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintosuorituksetPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintosuorituksetPersistenceServiceImpl.kt
@@ -224,7 +224,7 @@ class OpintosuorituksetPersistenceServiceImpl(
 
     private fun checkKurssikoodiExistsOrLogError(opintosuoritusDTO: OpintosuoritusDTO, userId: String): String? =
         opintosuoritusDTO.kurssikoodi ?: run {
-            log.error(
+            log.warn(
                 "${javaClass.name}: user id: $userId. Kurssikoodia ei ole asetettu" +
                     " opintosuoritukselle $opintosuoritusDTO"
             )
@@ -236,7 +236,7 @@ class OpintosuorituksetPersistenceServiceImpl(
         userId: String
     ): String? =
         osakokonaisuusDTO.kurssikoodi ?: run {
-            log.error(
+            log.warn(
                 "${javaClass.name}: user id: $userId. Kurssikoodia ei ole asetettu" +
                     " opintosuorituksen osakokonaisuudelle $osakokonaisuusDTO"
             )
@@ -248,7 +248,7 @@ class OpintosuorituksetPersistenceServiceImpl(
         opintosuoritusDTO: OpintosuoritusDTO,
         userId: String
     ): String? = opintosuoritusDTO.nimi_fi ?: run {
-        log.error(
+        log.warn(
             "${javaClass.name}: user id: $userId. Nimeä (fi) ei ole asetettu" +
                 " opintosuoritukselle $opintosuoritusDTO"
         )
@@ -259,7 +259,7 @@ class OpintosuorituksetPersistenceServiceImpl(
         opintosuoritusDTO: OpintosuoritusDTO,
         userId: String
     ): LocalDate? = opintosuoritusDTO.suorituspaiva ?: run {
-        log.error(
+        log.warn(
             "${javaClass.name}: user id: $userId. Kelvollista suorituspäivämäärää ei ole asetettu" +
                 " opintosuoritukselle $opintosuoritusDTO"
         )
@@ -272,7 +272,7 @@ class OpintosuorituksetPersistenceServiceImpl(
         osakokonaisuusDTO: OpintosuoritusOsakokonaisuusDTO,
         userId: String,
     ): String? = osakokonaisuusDTO.nimi_fi ?: run {
-        log.error(
+        log.warn(
             "${javaClass.name}: user id: $userId. Nimeä (fi) ei ole asetettu opintosuorituksen" +
                 " osakokonaisuudelle $osakokonaisuusDTO"
         )
@@ -283,7 +283,7 @@ class OpintosuorituksetPersistenceServiceImpl(
         osakokonaisuusDTO: OpintosuoritusOsakokonaisuusDTO,
         userId: String
     ): LocalDate? = osakokonaisuusDTO.suorituspaiva ?: run {
-        log.error(
+        log.warn(
             "${javaClass.name}: user id: $userId. Kelvollista suorituspäivämäärää ei ole asetettu" +
                 " opintosuorituksen osakokonaisuudelle $osakokonaisuusDTO"
         )
@@ -295,7 +295,7 @@ class OpintosuorituksetPersistenceServiceImpl(
         userId: String
     ): String? =
         opintosuoritusDTO.yliopistoOpintooikeusId ?: run {
-            log.error(
+            log.warn(
                 "${javaClass.name}: user id: $userId. Opinto-oikeus id:tä ei ole asetettu" +
                     " opintosuoritukselle $opintosuoritusDTO."
             )
@@ -307,7 +307,7 @@ class OpintosuorituksetPersistenceServiceImpl(
         userId: String
     ): Boolean? =
         opintosuoritusDTO.hyvaksytty ?: run {
-            log.error(
+            log.warn(
                 "${javaClass.name}: user id: $userId. Arviota (hyväksytty/hylätty) ei ole asetettu " +
                     "opintosuoritukselle $opintosuoritusDTO."
             )
@@ -319,7 +319,7 @@ class OpintosuorituksetPersistenceServiceImpl(
         userId: String
     ): Boolean? =
         osakokonaisuusDTO.hyvaksytty ?: run {
-            log.error(
+            log.warn(
                 "${javaClass.name}: user id: $userId. Arviota (hyväksytty/hylätty) ei ole asetettu opintosuorituksen" +
                     " osakokonaisuudelle $osakokonaisuusDTO"
             )

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
@@ -601,7 +601,7 @@ class OpintotietodataPersistenceServiceImpl(
                 erikoisalaRepository.findOneByVirtaPatevyyskoodi(it)
             }
             return erikoisalat.takeIf { it.size == 1 }?.first() ?: run {
-                log.error(
+                log.warn(
                     "$yliopisto, user id: $userId. Yhtäkään erikoisalaa ei löytynyt Elsan tietokannasta tai erikoisaloja " +
                         "oli enemmän kuin yksi per opinto-oikeus. Erikoisalat: $erikoisalaTunnisteList"
                 )

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
@@ -639,7 +639,7 @@ class OpintotietodataPersistenceServiceImpl(
         opintooikeudenTila: OpintooikeudenTila?, yliopisto: YliopistoEnum, userId: String
     ): OpintooikeudenTila? {
         return opintooikeudenTila ?: run {
-            log.error(
+            log.warn(
                 "$yliopisto, user id: $userId. Opinto-oikeuden tilaa ei ole asetettu."
             )
             return null

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
@@ -538,7 +538,7 @@ class OpintotietodataPersistenceServiceImpl(
     private fun checkOpintooikeusIdValueExistsOrLogError(
         id: String?, yliopisto: YliopistoEnum, userId: String
     ): String? = id ?: run {
-        log.error("$yliopisto, user id: $userId. Opinto-oikeus id:tä ei ole asetettu.")
+        log.warn("$yliopisto, user id: $userId. Opinto-oikeus id:tä ei ole asetettu.")
         return null
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/PeppiCommonOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/PeppiCommonOpintotietodataFetchingServiceImpl.kt
@@ -92,7 +92,7 @@ class PeppiCommonOpintotietodataFetchingServiceImpl(
     private fun convertPeppiAsetusString(peppiAsetus: String?, endpointUrl: String): String? {
         val splittedAsetus = peppiAsetus?.split("-")
         if (splittedAsetus?.size != 2) {
-            log.error("Rajapinnasta $endpointUrl ei saatu kelvollista asetustietoa. Asetus: $peppiAsetus")
+            log.warn("Rajapinnasta $endpointUrl ei saatu kelvollista asetustietoa. Asetus: $peppiAsetus")
             return null
         }
         return "${splittedAsetus[1]}/${splittedAsetus[0]}"

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/PeppiOuluClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/PeppiOuluClientBuilderImpl.kt
@@ -37,9 +37,9 @@ class PeppiOuluClientBuilderImpl(
                         )
                     )
                 )
-                .connectTimeout(5, TimeUnit.SECONDS)
-                .readTimeout(5, TimeUnit.SECONDS)
-                .writeTimeout(5, TimeUnit.SECONDS)
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(10, TimeUnit.SECONDS)
                 .build()
         }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/UserServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/UserServiceImpl.kt
@@ -179,10 +179,14 @@ class UserServiceImpl(
                 )
 
                 copyTokenUserAuthorities(existingUser, tokenUser)
-                existingUser.email = tokenUser.email?.lowercase()
+                val tokenUserMail = tokenUser.email?.lowercase()
                 copyTokenUserYliopistotAndErikoisalat(tokenKayttaja, existingKayttaja)
                 deleteTokenUser(tokenKayttaja, token, tokenUser)
                 kayttajaRepository.save(existingKayttaja)
+
+                if (existingUser.email == null) {
+                    existingUser.email = tokenUserMail
+                }
                 userRepository.save(existingUser)
             } else {
                 cipher.init(Cipher.ENCRYPT_MODE, originalKey)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKaytonAloitusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKaytonAloitusResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
+import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI
+import fi.elsapalvelu.elsa.security.YEK_KOULUTETTAVA
 import fi.elsapalvelu.elsa.service.OpintooikeusService
 import fi.elsapalvelu.elsa.service.UserService
 import fi.elsapalvelu.elsa.service.dto.KaytonAloitusDTO
@@ -49,8 +52,14 @@ class ErikoistuvaLaakariKaytonAloitusResource(
         }
 
         opintooikeusId?.let { id ->
-            if (validOpintooikeudet.find { it.id == id } == null) {
+            val validOikeus = validOpintooikeudet.find { it.id == id }
+            if (validOikeus == null) {
                 throw ResponseStatusException(HttpStatus.BAD_REQUEST)
+            }
+            if (validOikeus.erikoisalaId == YEK_ERIKOISALA_ID) {
+                userService.updateRooli(YEK_KOULUTETTAVA, user.id!!)
+            } else {
+                userService.updateRooli(ERIKOISTUVA_LAAKARI, user.id!!)
             }
             opintooikeusService.setOpintooikeusKaytossa(user.id!!, id)
         }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -76,6 +76,7 @@ logging:
     org.thymeleaf: WARN
     org.xnio: WARN
     sun.rmi: WARN
+    com.itextpdf.styledxmlparser.css.parse.syntax: OFF
 
 spring:
   application:


### PR DESCRIPTION
- PDF generoinnista voidaan piilottaa sisäiset tyylien virheviestit
- Kirjautumisen assertion validatorin päivitys käyttämään enemmän sisäistä logiikkaa
- Error lokiin tulee virheitä rajapinnasta saadusta virheellisestä datasta jolle ei voida tehdä mitään ja joka voidaan jättää huomioimatta -> siirretään warn lokiin
- Päivitetään rooli käytön aloituksessa ja opinto-oikeuden vanhetessa, jos uusi oikeus on eri roolilla (EL vs YEK)
- Tuntematonta käyttäjää ei tarvita error lokiin -> siirretään warn
- Korjaus kutsulinkin kautta kirjautumiseen jos käyttäjiä tarvitsee yhdistää (varmistetaan että sähköpostia ei yritetä päivittää käyttäjälle ennen kuin vanha on poistettu)
- Lisätty oulun pepin apollo clientille timeout aikaa

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
