### PR TITLE
PageImpl -> PagedModel konversio

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/JacksonConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/JacksonConfiguration.kt
@@ -5,8 +5,12 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.web.config.EnableSpringDataWebSupport
 
 @Configuration
+@EnableSpringDataWebSupport(
+    pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO
+)
 class JacksonConfiguration {
 
     /**


### PR DESCRIPTION
Korjaus varoitukseen:

> Serializing PageImpl instances as-is is not supported, meaning that there is no guarantee about the stability of the resulting JSON structure!
For a stable JSON structure, please use Spring Data's PagedModel or Spring HATEOAS and Spring Data's PagedResourcesAssembler.

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
