### PR TITLE
muutoksia heratteet ja tekstit

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonVastuuhenkilonArvioServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonVastuuhenkilonArvioServiceImpl.kt
@@ -87,13 +87,13 @@ class KoejaksonVastuuhenkilonArvioServiceImpl(
 
             vastuuhenkilonArvio = koejaksonVastuuhenkilonArvioRepository.save(vastuuhenkilonArvio)
 
-            // Sähköposti virkailijalle
+            /* Sähköposti virkailijalle. Poistetaan käytöstä kommentoimalla.
             mailService.sendEmailFromTemplate(
                 to = it.yliopisto?.nimi?.getOpintohallintoEmailAddress(applicationProperties),
                 templateName = "virkailijaKoejaksoTarkastettavissa.html",
                 titleKey = "email.virkailijakoejaksotarkastettavissa.title",
                 properties = mapOf(Pair(MailProperty.ID, vastuuhenkilonArvio.id!!.toString()))
-            )
+            ) */
 
             it.erikoistuvaLaakari?.kayttaja?.user?.let { user ->
                 user.email = koejaksonVastuuhenkilonArvioDTO.erikoistuvanSahkoposti

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/TerveyskeskuskoulutusjaksonHyvaksyntaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/TerveyskeskuskoulutusjaksonHyvaksyntaServiceImpl.kt
@@ -390,7 +390,7 @@ class TerveyskeskuskoulutusjaksonHyvaksyntaServiceImpl(
                 )
             )
             mailService.sendEmailFromTemplate(
-                to = hyvaksynta.virkailija?.user?.email,
+                to = hyvaksynta.opintooikeus?.yliopisto?.nimi?.getOpintohallintoEmailAddress(applicationProperties),
                 templateName = if (result.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID) "yekTkkjaksonHyvaksymishakemusHyvaksytty.html" else "tkkjaksonHyvaksymishakemusHyvaksytty.html",
                 titleKey = if (result.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID) "email.yektkkjaksonhyvaksymishakemushyvaksytty.title" else "email.tkkjaksonhyvaksymishakemushyvaksytty.title",
                 properties = mapOf(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
@@ -1000,8 +1000,8 @@ class ValmistumispyyntoServiceImpl(
         val opintooikeus = valmistumispyynto.opintooikeus
         mailService.sendEmailFromTemplate(
             getVastuuhenkiloHyvaksyja(opintooikeus?.yliopisto?.id!!, opintooikeus.erikoisala?.id!!).user!!,
-            templateName = "valmistumispyyntoTarkastettavissa.html",
-            titleKey = "email.valmistumispyyntoTarkastettavissa.title",
+            templateName = "valmistumispyyntoTarkastettavissaVastuuhenkilo.html",
+            titleKey = "email.valmistumispyyntoTarkastettavissaVastuuhenkilo.title",
             properties = mapOf(Pair(MailProperty.ID, valmistumispyynto.id.toString()))
         )
     }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KoejaksoResource.kt
@@ -53,7 +53,7 @@ open class KoejaksoResource(
 
             if (aloituskeskustelu.get().lahikouluttaja?.sopimusHyvaksytty != true) {
                 throw BadRequestAlertException(
-                    "Esimies ei saa muokata aloituskeskustelua, " +
+                    "Esihenkilö ei saa muokata aloituskeskustelua, " +
                         "jos kouluttaja ei ole allekirjoittanut sitä",
                     ENTITY_KOEJAKSON_ALOITUSKESKUSTELU,
                     "dataillegal.erimies-ei-saa-muokata-aloituskeskustelua-jos-kouluttaja-ei-ole-allekirjoittanut-sita"

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoejaksoResource.kt
@@ -285,8 +285,8 @@ class ErikoistuvaLaakariKoejaksoResource(
             || aloituskeskusteluDTO.lahikouluttaja?.kuittausaika != null
         ) {
             throw BadRequestAlertException(
-                "Erikoistuvan koejakson arviointi ei saa sisältää lähikouluttaja kuittausta. " +
-                    "Lähikouluttaja määrittelee sen.",
+                "Erikoistuvan koejakson arviointi ei saa sisältää kouluttajan kuittausta. " +
+                    "Kouluttaja määrittelee sen.",
                 ENTITY_KOEJAKSON_ALOITUSKESKUSTELU,
                 "dataillegal.erikoistuvan-koejakson-arviointi-ei-saa-sisaltaa-lahikouluttaja-kuittausta"
             )
@@ -295,8 +295,8 @@ class ErikoistuvaLaakariKoejaksoResource(
             || aloituskeskusteluDTO.lahiesimies?.kuittausaika != null
         ) {
             throw BadRequestAlertException(
-                "Erikoistuvan koejakson arviointi ei saa sisältää lähiesimiehen kuittausta. " +
-                    "Lähiesimies määrittelee sen.",
+                "Erikoistuvan koejakson arviointi ei saa sisältää lähiesihenkilön kuittausta. " +
+                    "Lähiesihenkilö määrittelee sen.",
                 ENTITY_KOEJAKSON_ALOITUSKESKUSTELU,
                 "dataillegal.erikoistuvan-koejakson-arviointi-ei-saa-sisaltaa-lahiesimiehen-kuisttausta"
             )
@@ -684,14 +684,14 @@ class ErikoistuvaLaakariKoejaksoResource(
         }
         if (kouluttaja?.sopimusHyvaksytty == true || kouluttaja?.kuittausaika != null) {
             throw BadRequestAlertException(
-                "Erikoistuvan koejakson arviointi ei saa sisältää lähikouluttaja kuittausta. Lähikouluttaja määrittelee sen.",
+                "Erikoistuvan koejakson arviointi ei saa sisältää kouluttaja kuittausta. Kouluttaja määrittelee sen.",
                 entity,
                 "dataillegal.erikoistuvan-koejakson-arviointi-ei-saa-sisaltaa-lahikouluttaja-kuittausta"
             )
         }
         if (esimies?.sopimusHyvaksytty == true || esimies?.kuittausaika != null) {
             throw BadRequestAlertException(
-                "Erikoistuvan koejakson arviointi ei saa sisältää lähiesimiehen kuittausta. Lähiesimies määrittelee sen.",
+                "Erikoistuvan koejakson arviointi ei saa sisältää lähiesihenkilön kuittausta. Lähiesihenkilö määrittelee sen.",
                 entity,
                 "dataillegal.erikoistuvan-koejakson-arviointi-ei-saa-sisaltaa-lahiesimiehen-kuittausta"
             )

--- a/src/main/resources/config/liquibase/data/erikoisala/anestesia/2022-06-06/arvioitava_kokonaisuus.csv
+++ b/src/main/resources/config/liquibase/data/erikoisala/anestesia/2022-06-06/arvioitava_kokonaisuus.csv
@@ -91,7 +91,7 @@ Erikoistuva osaa itsenäisesti seuraavat asiat potilastapauksen suhteen soveltuv
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
 </ul>
 
-<h4>Erikoistuvien lääkäreiden ja lähikouluttajien vertaisarviointipalaverit</h4>
+<h4>Erikoistuvien lääkäreiden ja kouluttajien vertaisarviointipalaverit</h4>
 <h4>Arviointimenetelmät</h4>
 <p>
 Oppimisprosessin keskiössä on oppija ja hänen tarpeensa. Oppimisprosessin aikana erikoistuva siirtyy seuraavalle luottamuksen asteelle kykyjensä ja ohjaajan arvion mukaan. Ohjaajan luottamus heijastaa erikoistuvan pätevyyttä, joka muodostuu arvioitujen toimenpidetaitojen lisäksi ei teknisistä taidoista.
@@ -213,7 +213,7 @@ Erikoistuva osaa itsenäisesti seuraavat asiat potilastapauksen suhteen soveltuv
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
 <li>Aihealueen koulutuksiin osallistuminen</li>
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
-<li>Erikoistuvien lääkäreiden ja lähikouluttajien vertaisarviointipalaverit.</li>
+<li>Erikoistuvien lääkäreiden ja kouluttajien vertaisarviointipalaverit.</li>
 </ul>
 
 <h4>Arviointimenetelmät</h4>
@@ -336,7 +336,7 @@ Erikoistuva osaa itsenäisesti seuraavat asiat potilastapauksen suhteen soveltuv
 <li>Potilasasiakirjamerkintöjen ja/tai potilastapausten läpikäyminen keskustellen</li>
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
 <li>Aihealueen koulutuksiin osallistuminen</li>
-<li>Erikoistuvien lääkäreiden ja lähikouluttajien vertaisarviointipalaverit</li>
+<li>Erikoistuvien lääkäreiden ja kouluttajien vertaisarviointipalaverit</li>
 </ul>
 
 <h4>Arviointimenetelmät</h4>
@@ -473,7 +473,7 @@ Erikoistuva osaa itsenäisesti seuraavat asiat potilastapauksen suhteen soveltuv
 <li>Potilasasiakirjamerkintöjen ja/tai potilastapausten läpikäyminen keskustellen</li>
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
 <li>Aihealueen koulutuksiin osallistuminen</li>
-<li>Erikoistuvien lääkäreiden ja lähikouluttajien vertaisarviointipalaverit</li>
+<li>Erikoistuvien lääkäreiden ja kouluttajien vertaisarviointipalaverit</li>
 </ul>
 
 <h4>Arviointimenetelmät</h4>
@@ -671,7 +671,7 @@ Erikoistuva osaa itsenäisesti seuraavat asiat potilastapauksen suhteen soveltuv
 <li>Potilasasiakirjamerkintöjen ja/tai potilastapausten läpikäyminen keskustellen</li>
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
 <li>Aihealueen koulutuksiin osallistuminen</li>
-<li>Erikoistuvien lääkäreiden ja lähikouluttajien vertaisarviointipalaverit</li>
+<li>Erikoistuvien lääkäreiden ja kouluttajien vertaisarviointipalaverit</li>
 </ul>
 
 <h4>Arviointimenetelmät</h4>
@@ -806,7 +806,7 @@ Erikoistuva osaa itsenäisesti seuraavat asiat potilastapauksen suhteen soveltuv
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
 <li>Aihealueen koulutuksiin osallistuminen</li>
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
-<li>Erikoistuvien lääkäreiden ja lähikouluttajien vertaisarviointipalaverit</li>
+<li>Erikoistuvien lääkäreiden ja kouluttajien vertaisarviointipalaverit</li>
 </ul>
 
 <h4>Arviointimenetelmät</h4>
@@ -933,7 +933,7 @@ Erikoistuva osaa itsenäisesti seuraavat asiat potilastapauksen suhteen soveltuv
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
 <li>Aihealueen koulutuksiin osallistuminen</li>
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
-<li>Erikoistuvien lääkäreiden ja lähikouluttajien vertaisarviointipalaverit</li>
+<li>Erikoistuvien lääkäreiden ja kouluttajien vertaisarviointipalaverit</li>
 </ul>
 
 <h4>Arviointimenetelmät</h4>
@@ -1063,7 +1063,7 @@ Erikoistuva osaa itsenäisesti seuraavat asiat potilastapauksen suhteen soveltuv
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
 <li>Aihealueen koulutuksiin osallistuminen</li>
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
-<li>Erikoistuvien lääkäreiden ja lähikouluttajien vertaisarviointipalaverit</li>
+<li>Erikoistuvien lääkäreiden ja kouluttajien vertaisarviointipalaverit</li>
 </ul>
 
 <h4>Arviointimenetelmät</h4>
@@ -1171,7 +1171,7 @@ Erikoistuva osaa itsenäisesti seuraavat asiat potilastapauksen suhteen soveltuv
 <li>Potilasasiakirjamerkintöjen ja/tai potilastapausten läpikäyminen keskustellen</li>
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
 <li>Aihealueen koulutuksiin osallistuminen</li>
-<li>Erikoistuvien lääkäreiden ja lähikouluttajien vertaisarviointipalaverit</li>
+<li>Erikoistuvien lääkäreiden ja kouluttajien vertaisarviointipalaverit</li>
 </ul>
 
 <h4>Arviointimenetelmät</h4>
@@ -1454,7 +1454,7 @@ Erikoistuva osaa itsenäisesti seuraavat asiat potilastapauksen suhteen soveltuv
 <li>Potilasasiakirjamerkintöjen ja/tai potilastapausten läpikäyminen keskustellen</li>
 <li>Oman organisaation ohjeistuksiin tutustuminen</li>
 <li>Aihealueen koulutuksiin osallistuminen</li>
-<li>Erikoistuvien lääkäreiden ja lähikouluttajien vertaisarviointipalaverit</li>
+<li>Erikoistuvien lääkäreiden ja kouluttajien vertaisarviointipalaverit</li>
 </ul>
 
 <h4>Arviointimenetelmät</h4>

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -74,6 +74,7 @@ email.seurantajaksoarvioitu.title = [ELSA-palvelu] Olet saanut ilmoituksen seura
 email.uusivalmistumispyynto.title = [Elsa-palvelu] Olet saanut uuden valmistumispyynnön
 email.yekValmistumispyyntoTarkastettavissa.title = [ELSA-palvelu] Olet saanut YEK valmistumispyynnön hyväksymishakemuksen tarkastettavaksi
 email.valmistumispyyntoTarkastettavissa.title = [ELSA-palvelu] Olet saanut  valmistumispyynnön hyväksymishakemuksen tarkastettavaksi
+email.valmistumispyyntoTarkastettavissaVastuuhenkilo.title = [ELSA-palvelu] Olet saanut  valmistumispyynnön hyväksymishakemuksen tarkastettavaksi
 email.valmistumispyyntoPalautettuErikoistuja.title = [ELSA-palvelu] Valmistumispyyntö on palautettu muokattavaksi
 email.valmistumispyyntoPalautettuMuut.title = [ELSA-palvelu] Erikoistujan {0} valmistumispyyntö on palautettu muokattavaksi
 email.valmistumispyyntoHyvaksytty.title = [ELSA-palvelu] YEK-koulutuksen valmistumispyyntö on hyväksytty vastuuhenkilön toimesta

--- a/src/main/resources/templates/mail/arviointiaMuokattuEmail.html
+++ b/src/main/resources/templates/mail/arviointiaMuokattuEmail.html
@@ -10,7 +10,7 @@
     Hei,
 </p>
 <p>
-    Olet saanut ELSA-palveluun uuden arvioinnin.
+    Kouluttajasi on muokannut aiemmin annettua arviointia.
 
     Pääset katsomaan uutta arviointia alla olevan linkin kautta:
 </p>

--- a/src/main/resources/templates/mail/katseluoikeudet.html
+++ b/src/main/resources/templates/mail/katseluoikeudet.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:lang="${#locale.language}" lang="fi">
 <head>
-    <title>[ELSA-palvelu] Olet saanut katseluoikeudet erikoistujan ELSA-järjestelmään</title>
+    <title>[ELSA-palvelu] Olet saanut katseluoikeudet erikoistujan ELSA-palveluun</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="icon" th:href="@{|${baseUrl}/favicon.ico|}"/>
 </head>

--- a/src/main/resources/templates/mail/uusiErikoistuvaLaakari.html
+++ b/src/main/resources/templates/mail/uusiErikoistuvaLaakari.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="fi" th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>[ELSA-palvelu] Olet saanut kutsun liittyä ELSA-järjestelmän käyttäjäksi</title>
+    <title>[ELSA-palvelu] Olet saanut kutsun liittyä ELSA-palvelun käyttäjäksi</title>
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
     <link rel="icon" th:href="@{|${baseUrl}/favicon.ico|}"/>
 </head>

--- a/src/main/resources/templates/mail/uusiKouluttaja.html
+++ b/src/main/resources/templates/mail/uusiKouluttaja.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="fi" th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>[ELSA-palvelu] Olet saanut kutsun liittyä ELSA-järjestelmän käyttäjäksi</title>
+    <title>[ELSA-palvelu] Olet saanut kutsun liittyä ELSA-palvelun käyttäjäksi</title>
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
     <link rel="icon" th:href="@{|${baseUrl}/favicon.ico|}"/>
 </head>

--- a/src/main/resources/templates/mail/uusiKouluttajaRooli.html
+++ b/src/main/resources/templates/mail/uusiKouluttajaRooli.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="fi" th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>[ELSA-palvelu] Olet saanut kouluttajan oikeudet ELSA-järjestelmään</title>
+    <title>[ELSA-palvelu] Olet saanut kouluttajan oikeudet ELSA-palveluun</title>
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
     <link rel="icon" th:href="@{|${baseUrl}/favicon.ico|}"/>
 </head>

--- a/src/main/resources/templates/mail/uusiVastuuhenkilo.html
+++ b/src/main/resources/templates/mail/uusiVastuuhenkilo.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="fi" th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>[ELSA-palvelu] Olet saanut kutsun liittyä ELSA-järjestelmän käyttäjäksi</title>
+    <title>[ELSA-palvelu] Olet saanut kutsun liittyä ELSA-palvelun käyttäjäksi</title>
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
     <link rel="icon" th:href="@{|${baseUrl}/favicon.ico|}"/>
 </head>

--- a/src/main/resources/templates/mail/uusivalmistumispyynto.html
+++ b/src/main/resources/templates/mail/uusivalmistumispyynto.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fi" th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<html lang="fi" th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
 <head>
     <title>[ELSA-palvelu] Olet saanut uuden valmistumispyynnön </title>
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
@@ -11,12 +11,13 @@
 </p>
 <p>
     Erikoistuva lääkäri/hammaslääkäri <span th:text="${name}"></span> on lähettänyt valmistumispyynnön.
-    Pääset tarkastelemaan valmistumispyyntöä ja arvioimaan erikoistujan osaamisen alla olevan linkin kautta:
+    Pääset tarkastelemaan valmistumispyyntöä alla olevan linkin kautta:
 </p>
 <p>
     <a th:with="url=(@{|${baseUrl}/valmistumispyynnon-arviointi/${id}|})" th:href="${url}"
        th:text="${url}"></a>
 </p>
+</p><u>Tässä vaiheessa arvioidaan vain, onko erikoistujan osaaminen erikoislääkäriltä vaadittavalla tasolla. </u></p>
 <p>
     HUOM! Tähän sähköpostiviestiin ei voi vastata.
 </p>

--- a/src/main/resources/templates/mail/valmistumispyyntoTarkastettavissaVastuuhenkilo.html
+++ b/src/main/resources/templates/mail/valmistumispyyntoTarkastettavissaVastuuhenkilo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="fi" th:lang="${#locale.language}" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>[ELSA-palvelu] Olet saanut valmistumispyynnön hyväksymishakemuksen tarkastettavaksi</title>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+    <link rel="icon" th:href="@{|${baseUrl}/favicon.ico|}"/>
+</head>
+<body>
+<p>
+    Hei,
+</p>
+<p>
+    Olet saanut ELSA-palveluun uuden valmistumispyynnön hyväksyttäväksi.
+
+    Pääset tarkastamaan valmistumispyynnön alla olevan linkin kautta:
+</p>
+<p>
+    <a th:href="${url}" th:text="${url}"
+       th:with="url=(@{|${baseUrl}/valmistumispyynnon-tarkistus/${id}|})"></a>
+</p>
+<p>
+    Opintohallinto on tarkistanut määrälliset vaatimukset, ja tässä vaiheessa arvioit koko koulutuksen kokonaisuutena.
+</p>
+<p>
+    ELSAssa hyväksymisen lisäksi valmistumisen yhteenveto tulee allekirjoittaa sähköisessä allekirjoituspalvelussa.
+    <strong>Saat allekirjoituspyynnön erillisessä sähköpostissa.</strong>
+</p>
+<p>
+    HUOM! Tähän sähköpostiviestiin ei voi vastata.
+</p>
+<p>
+    <span>Terveisin, </span>
+    <br/>
+    <em>ELSA-palvelu</em>
+</p>
+</body>
+</html>

--- a/src/main/resources/templates/mail/vastuuhenkilonArvioKuitattava.html
+++ b/src/main/resources/templates/mail/vastuuhenkilonArvioKuitattava.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:lang="${#locale.language}" lang="fi">
 <head>
-    <title>[ELSA-palvelu] Olet saanut koejakson arviointilomake E:n allekirjoitettavaksi</title>
+    <title>[ELSA-palvelu] Olet saanut koejakson arviointilomake E:n hyväksyttäväksi</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="icon" th:href="@{|${baseUrl}/favicon.ico|}"/>
 </head>
@@ -10,13 +10,18 @@
     Hei,
 </p>
 <p>
-    Olet saanut ELSA-palveluun koejakson arviointilomakkeen E täydennettäväksi.
+    Olet saanut ELSA-palveluun koejakson arviointilomakkeen E hyväksyttäväksi.
 
-    Pääset täydentämään koejakson arviointilomakkeen E alla olevan linkin kautta:
+    Pääset hyväksymään koejakson arviointilomakkeen E alla olevan linkin kautta:
 </p>
 <p>
     <a th:with="url=(@{|${baseUrl}/koejakso/vastuuhenkilon-arvio/${id}|})" th:href="${url}"
        th:text="${url}"></a>
+</p>
+<p>
+    ELSA-hyväksynnän lisäksi koejakson yhteenveto tulee allekirjoittaa sähköisessä allekirjoituspalvelussa.
+
+    <strong>Saat allekirjoituspyynnön erillisessä sähköpostissa.</strong>
 </p>
 <p>
     HUOM! Tähän sähköpostiviestiin ei voi vastata.


### PR DESCRIPTION
- Poistettu käytöstä heräte virkailijalle, kun vastuuhenk. on hyväksynyt koejakson.

- Tk-koul.jakson hyväksyntä vaihdettu virkailijan email -> opintohallinnon email.

- Uusi heräte ja sähköposti vastuuhenkilölle, valmistumispyyntoTarkastettavissaVastuuhenkilo
Aikaisemmin sama kuin virkailijalle, nyt vstuuhenkilölle uudet tekstit.

- Tekstimuutoksia.

