### PR TITLE
ELSA-890: Vaihdettu email!! --> email.toString()

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KayttajaQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KayttajaQueryService.kt
@@ -212,6 +212,6 @@ class KayttajaQueryService(
             },
             authorities = kayttaja.user?.authorities?.takeIf { it.isNotEmpty() }?.map { a -> a.name!! }?.toList(),
             kayttajatilinTila = kayttaja.tila,
-            sahkoposti = kayttaja.user?.email!!
+            sahkoposti = kayttaja.user?.email.toString(),
         )
 }


### PR DESCRIPTION
Vaihdettu email!! --> email.toString(), joka tarkoittaa, että vaikka email = null, mäppäys ei hajoa, mutta emailina palautuu null tekstinä. Korjaa ongelman, joka aiheutti, että tyhjä sähköposti hajottaa käyttäjien yhdistyksen.

Tarkistettu mapKayttajaErikoistujaKouluttaja() käyttö: sitä käytetään pelkästään käyttäjätilien yhdistämisen hakuun eli ei pitäisi tulla outouksia muualle. Virkailijat/tekniset pääkäyttäjät näkee null arvon käyttäjätilien yhdistyksessä.