### PR TITLE
ELSA-775: Korjattu otsikon ääkköset

### DIFF
--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -80,7 +80,7 @@ email.valmistumispyyntoPalautettuMuut.title = [ELSA-palvelu] Erikoistujan {0} va
 email.valmistumispyyntoHyvaksytty.title = [ELSA-palvelu] YEK-koulutuksen valmistumispyyntö on hyväksytty vastuuhenkilön toimesta
 
 email.uusikouluttajarooli.title = [ELSA-palvelu] Olet saanut kouluttajan oikeudet ELSA-järjestelmään
-email.opintooikeuspaattymassa.title = [ELSA-palvelu] Opinto-oikeutesi on p��ttym�ss�
+email.opintooikeuspaattymassa.title = [ELSA-palvelu] Opinto-oikeutesi on päättymässä
 
 koulutussopimus.title = Koejakson koulutussopimus
 koulutussopimus.erikoistuvalaakari = Erikoistuva lääkäri


### PR DESCRIPTION
Ä onkin merkittävä Ã¤ eikä ä, koska muuten tulee �