### PR TITLE
ELSA-922: Nostettu Postgresql version 12.3 --> 13.16 (sama kuin AWS)

### DIFF
--- a/src/main/docker/postgresql.yml
+++ b/src/main/docker/postgresql.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   elsabackend-postgresql:
-    image: postgres:12.3
+    image: postgres:13.16
     environment:
       - POSTGRES_USER=elsaBackend
       - POSTGRES_PASSWORD=


### PR DESCRIPTION
Kannattaa päivittää lokaalikanta 13.16 versioon, sillä IntelliJ käyttämät uusimmat postgresql ajurit eivät vaikuta tukevan vanhaa versiota