### PR TITLE
ELSA-911: Korjattu nimen automaattinen päivitys

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
@@ -410,7 +410,7 @@ class SecurityConfiguration(
         } else {
             // Tarkistetaan, että käyttäjän nimi on ajan tasalla
             if ((firstName != "" && lastName != "") &&
-                (existingUser.firstName != firstName && existingUser.lastName != lastName)) {
+                (existingUser.firstName != firstName || existingUser.lastName != lastName)) {
                 existingUser.firstName = firstName
                 existingUser.lastName = lastName
                 userRepository.save(existingUser)


### PR DESCRIPTION
Korjattu nimen automaattinen päivitys suomi.fi tiedon muuttuessa. Aiemmin toimi vain, jos molemmat nimet olivat vaihtuneet, nyt muutettu halutun kaltaiseksi eli vain etu-/sukunimen muuttuminen riittää.