### PR TITLE
Korjaus YEK valmistumisien arkistointiin ja arkistoinnin metatietoihin

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/PublicityClass.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/PublicityClass.kt
@@ -1,0 +1,15 @@
+package fi.elsapalvelu.elsa.service.dto.arkistointi
+
+enum class PublicityClass(
+    val displayName: String,
+    val securityReason: String
+) {
+    PUBLIC(
+        displayName = "Julkinen",
+        securityReason = ""
+    ),
+    PARTIALLY_RESTRICTED(
+        displayName = "Osittain salassapidettävä",
+        securityReason = "JulkL 24.1"
+    );
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/RecordProperties.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/RecordProperties.kt
@@ -11,6 +11,6 @@ data class RecordProperties(
 
     var type: String,
 
-    var publicityClass: String
+    var publicityClass: PublicityClass
 
 ) : Serializable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Restriction.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Restriction.kt
@@ -16,5 +16,5 @@ class Restriction {
     var securityPeriod: String? = "100"
 
     @JacksonXmlProperty(localName = "SecurityReason")
-    var securityReason: String? = "Sisältää henkilötietoja"
+    var securityReason: String? = ""
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImpl.kt
@@ -83,7 +83,8 @@ class ArkistointiServiceImpl(
             record.retentionPeriod = it.retentionPeriod
             record.function = case.function
 
-            record.restriction.publicityClass = it.publicityClass
+            record.restriction.publicityClass = it.publicityClass.displayName
+            record.restriction.securityReason = it.publicityClass.securityReason
             record.restriction.person.name = name
             record.restriction.person.ssn = opintooikeus?.erikoistuvaLaakari?.syntymaaika
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonVastuuhenkilonArvioServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonVastuuhenkilonArvioServiceImpl.kt
@@ -12,6 +12,7 @@ import fi.elsapalvelu.elsa.service.dto.AsiakirjaDTO
 import fi.elsapalvelu.elsa.service.dto.KoejaksonVastuuhenkilonArvioDTO
 import fi.elsapalvelu.elsa.service.dto.TyoskentelyjaksotTableDTO
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseProperties
+import fi.elsapalvelu.elsa.service.dto.arkistointi.PublicityClass
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import fi.elsapalvelu.elsa.service.dto.sarakesign.SarakeSignRecipientDTO
@@ -343,7 +344,7 @@ class KoejaksonVastuuhenkilonArvioServiceImpl(
         } else if (arkistointiService.onKaytossa(yliopisto)) {
             val filePath = arkistointiService.muodostaSahke(
                 vastuuhenkilonArvio.opintooikeus,
-                listOf(RecordProperties(asiakirja, "-1", "Arviointi", "Julkinen")),
+                listOf(RecordProperties(asiakirja, "-1", "Arviointi", PublicityClass.PUBLIC)),
                 case = CaseProperties(
                     nativeId = vastuuhenkilonArvio.id!!.toString(),
                     type = "Koejakson arviointi",

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
@@ -327,27 +327,27 @@ class ValmistumispyyntoServiceImpl(
                         mapValmistumispyynnonTarkistus(valmistumispyynnonTarkistusMapper.toDto(it)),
                         valmistumispyynto
                     )
+                }
 
-                    if (arkistointiService.onKaytossa(yliopisto.nimi!!)) {
-                        val filePath = arkistointiService.muodostaSahke(
-                            valmistumispyynto.opintooikeus,
-                            listOf(
-                                RecordProperties(valmistumispyynto.yhteenvetoAsiakirja!!, "20", "Yhteenveto", "Julkinen"),
-                                RecordProperties(valmistumispyynto.liitteetAsiakirja!!, "10", "Liite", "Osittain salassapidettävä")
-                            ),
-                            case = CaseProperties(
-                                nativeId = valmistumispyynto.id!!.toString(),
-                                type = "Valmistuminen",
-                                function = "04.02.05"
-                            ),
-                            tarkastaja = valmistumispyynto.virkailija?.user?.getName(),
-                            tarkastusPaiva = valmistumispyynto.virkailijanKuittausaika,
-                            hyvaksyja = valmistumispyynto.vastuuhenkiloHyvaksyja?.user?.getName(),
-                            hyvaksymisPaiva = valmistumispyynto.vastuuhenkiloHyvaksyjaKuittausaika
-                        )
-                        val yek = valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID
-                        arkistointiService.laheta(yliopisto.nimi!!, filePath, yek)
-                    }
+                if (arkistointiService.onKaytossa(yliopisto.nimi!!)) {
+                    val filePath = arkistointiService.muodostaSahke(
+                        valmistumispyynto.opintooikeus,
+                        listOf(
+                            RecordProperties(valmistumispyynto.yhteenvetoAsiakirja!!, "20", "Yhteenveto", "Julkinen"),
+                            RecordProperties(valmistumispyynto.liitteetAsiakirja!!, "10", "Liite", "Osittain salassapidettävä")
+                        ),
+                        case = CaseProperties(
+                            nativeId = valmistumispyynto.id!!.toString(),
+                            type = "Valmistuminen",
+                            function = "04.02.05"
+                        ),
+                        tarkastaja = valmistumispyynto.virkailija?.user?.getName(),
+                        tarkastusPaiva = valmistumispyynto.virkailijanKuittausaika,
+                        hyvaksyja = valmistumispyynto.vastuuhenkiloHyvaksyja?.user?.getName(),
+                        hyvaksymisPaiva = valmistumispyynto.vastuuhenkiloHyvaksyjaKuittausaika
+                    )
+                    val yek = valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID
+                    arkistointiService.laheta(yliopisto.nimi!!, filePath, yek)
                 }
             }
         }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
@@ -21,6 +21,7 @@ import fi.elsapalvelu.elsa.service.constants.*
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.*
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseProperties
+import fi.elsapalvelu.elsa.service.dto.arkistointi.PublicityClass
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonHyvaksyjaRole
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
@@ -333,8 +334,8 @@ class ValmistumispyyntoServiceImpl(
                     val filePath = arkistointiService.muodostaSahke(
                         valmistumispyynto.opintooikeus,
                         listOf(
-                            RecordProperties(valmistumispyynto.yhteenvetoAsiakirja!!, "20", "Yhteenveto", "Julkinen"),
-                            RecordProperties(valmistumispyynto.liitteetAsiakirja!!, "10", "Liite", "Osittain salassapidettävä")
+                            RecordProperties(valmistumispyynto.yhteenvetoAsiakirja!!, "20", "Yhteenveto", PublicityClass.PUBLIC),
+                            RecordProperties(valmistumispyynto.liitteetAsiakirja!!, "10", "Liite", PublicityClass.PARTIALLY_RESTRICTED)
                         ),
                         case = CaseProperties(
                             nativeId = valmistumispyynto.id!!.toString(),


### PR DESCRIPTION
- Myös YEK valmistumiset tulee arkistoida
- Salassapitoperuste on tarvittaessa julkisuuslain pykäläkohta
## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
