### PR TITLE
ELSA-978: Päivitetään mahdollisesti muuttunut user referenssi

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
@@ -8,6 +8,7 @@ import fi.elsapalvelu.elsa.repository.*
 import fi.elsapalvelu.elsa.security.*
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
+import jakarta.persistence.EntityNotFoundException
 import jakarta.servlet.http.HttpServletResponse
 import kotlinx.coroutines.*
 import org.apache.commons.lang3.exception.ExceptionUtils
@@ -395,6 +396,7 @@ class SecurityConfiguration(
                 fetchAndUpdateOpintotietodataIfChanged(existingUser.id!!, hetu, firstName, lastName)
                 fetchAndHandleOpintosuorituksetNonBlocking(existingUser.id!!, hetu)
 
+                existingUser = userRepository.findByIdWithAuthorities(existingUser.id!!).orElseThrow { EntityNotFoundException("Käyttäjää ei löydy") }
                 if (hasErikoistuvaLaakariRole(existingUser) || hasYekKoulutettavaRole(existingUser)) {
                     opintooikeusService.checkOpintooikeusAndRoles(existingUser)
                 }


### PR DESCRIPTION
Korjaa ongelman, jossa käyttäjälle voi tulla väärä activeAuthority tai jhi_user_authority ei sisällä oikeita rooleja.

## Muistilista

- [ ] Testit
- [ ] Dokumentaatio
- [ ] Auditointitaulut
