### PR TITLE
Add MDC filter to log authenticated user ID for request correlation

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/RelyingPartyConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/RelyingPartyConfiguration.kt
@@ -2,6 +2,7 @@ package fi.elsapalvelu.elsa.config
 
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
 import org.opensaml.security.x509.X509Support
+import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -33,6 +34,8 @@ class RelyingPartyConfiguration(
     private val yliopistoRepository: YliopistoRepository
 ) {
 
+    private val log = LoggerFactory.getLogger(RelyingPartyConfiguration::class.java)
+
     @Bean
     @Throws(Exception::class)
     fun relyingPartyRegistrations(): RelyingPartyRegistrationRepository? {
@@ -60,28 +63,35 @@ class RelyingPartyConfiguration(
             val decryptionCredential: Saml2X509Credential =
                 Saml2X509Credential.decryption(rsa, certificate)
 
-            registrations.add(
-                RelyingPartyRegistrations
-                    .fromMetadataLocation(
-                        applicationProperties.getSecurity()
-                            .getSuomifi().samlSuomifiMetadataLocation!!
+            val registration = RelyingPartyRegistrations
+                .fromMetadataLocation(
+                    applicationProperties.getSecurity()
+                        .getSuomifi().samlSuomifiMetadataLocation!!
+                )
+                .registrationId("suomifi")
+                .assertingPartyMetadata { party ->
+                    party.entityId(
+                        applicationProperties.getSecurity().getSuomifi().samlSuomifiEntityId!!
                     )
-                    .registrationId("suomifi")
-                    .assertingPartyMetadata { party ->
-                        party.entityId(
-                            applicationProperties.getSecurity().getSuomifi().samlSuomifiEntityId!!
-                        )
-                    }
-                    .apply {
-                        applicationProperties.getSecurity().getSuomifi().samlSpEntityId
-                            ?.let { entityId(it) }
-                    }
-                    .signingX509Credentials { signing -> signing.add(signingCredential) }
-                    .decryptionX509Credentials { decryption -> decryption.add(decryptionCredential) }
-                    .singleLogoutServiceBinding(Saml2MessageBinding.REDIRECT)
-                    .singleLogoutServiceResponseLocation("{baseUrl}/logout/saml2/slo")
-                    .build()
-            )
+                }
+                .apply {
+                    applicationProperties.getSecurity().getSuomifi().samlSpEntityId
+                        ?.let { entityId(it) }
+                }
+                .signingX509Credentials { signing -> signing.add(signingCredential) }
+                .decryptionX509Credentials { decryption -> decryption.add(decryptionCredential) }
+                .singleLogoutServiceBinding(Saml2MessageBinding.REDIRECT)
+                .singleLogoutServiceResponseLocation("{baseUrl}/logout/saml2/slo")
+                .build()
+
+            val spEntityId = applicationProperties.getSecurity().getSuomifi().samlSpEntityId
+            if (spEntityId != null) {
+                log.info("Suomi.fi SP entity ID set to custom value: {}", spEntityId)
+            } else {
+                log.info("Suomi.fi SP entity ID using default: {}", registration.entityId)
+            }
+
+            registrations.add(registration)
         }
 
         // Haka

--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
@@ -112,6 +112,7 @@ class SecurityConfiguration(
                     .ignoringRequestMatchers("/api/logout")
             }
             .addFilterBefore(corsFilter, CsrfFilter::class.java)
+            .addFilterAfter(MdcUserIdFilter(), CorsFilter::class.java)
             .addFilterAfter(
                 ElsaSwitchUserFilter(
                     opintooikeusRepository,

--- a/src/main/kotlin/fi/elsapalvelu/elsa/security/MdcUserIdFilter.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/security/MdcUserIdFilter.kt
@@ -1,0 +1,43 @@
+package fi.elsapalvelu.elsa.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal
+import org.springframework.web.filter.OncePerRequestFilter
+
+private const val MDC_USER_ID_KEY = "userId"
+
+/**
+ * Adds the authenticated user's ID to SLF4J MDC for every request so that
+ * all log entries within a request can be correlated to a specific user.
+ *
+ * The key "userId" is available in Logback patterns as %X{userId}.
+ */
+class MdcUserIdFilter : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val userId = try {
+            val principal = SecurityContextHolder.getContext().authentication?.principal
+            if (principal is Saml2AuthenticatedPrincipal) principal.name else null
+        } catch (_: Exception) {
+            null
+        }
+
+        try {
+            if (userId != null) {
+                MDC.put(MDC_USER_ID_KEY, userId)
+            }
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.remove(MDC_USER_ID_KEY)
+        }
+    }
+}
+

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -65,6 +65,8 @@ management:
       application: ${spring.application.name}
 
 logging:
+  pattern:
+    correlation: "[userId=%X{userId:-}] "
   level:
     _org.springframework.web.servlet.HandlerMapping.Mappings": INFO
     angus.activation: WARN


### PR DESCRIPTION
<img width="1710" height="247" alt="Screenshot 2026-04-20 at 7 12 30" src="https://github.com/user-attachments/assets/12b8f355-e53e-4390-97ca-d1631d74805d" />


This pull request introduces a new filter to add the authenticated user's ID to the logging context for every request, improving traceability and correlation of log entries with users. The main changes include the implementation of the `MdcUserIdFilter`, integration of this filter into the security configuration, and updates to the logging pattern to display the user ID.

**Logging and Security Enhancements:**

* Added a new `MdcUserIdFilter` that injects the authenticated user's ID into the SLF4J MDC for each request, making the `userId` available in log entries. (`src/main/kotlin/fi/elsapalvelu/elsa/security/MdcUserIdFilter.kt`)
* Integrated the `MdcUserIdFilter` into the security filter chain, placing it immediately after the `CorsFilter` to ensure the user ID is available early in request processing. (`src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt`)

**Logging Configuration:**

* Updated the logging pattern in `application.yml` to include the `userId` from the MDC, allowing log statements to be correlated with the authenticated user. (`src/main/resources/config/application.yml`)