### PR TITLE
Remove unnecessary Testcontainers dependency and update random ID gen…

### DIFF
--- a/.github/workflows/frontend-security-scan.yml
+++ b/.github/workflows/frontend-security-scan.yml
@@ -29,5 +29,5 @@ jobs:
 
       - name: Run yarn audit
         working-directory: frontend
-        run: /bin/bash -c 'yarn audit --groups dependencies; [[ $? -ge 8 ]] && exit 1 || exit 0'
+        run: /bin/bash -c 'yarn audit --groups dependencies; [[ $? -ge 16 ]] && exit 1 || exit 0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,6 @@ dependencies {
     implementation "org.thymeleaf.extras:thymeleaf-extras-java8time:3.0.4.RELEASE"
     implementation "org.springframework.security:spring-security-saml2-service-provider:${springSecurityVersion}"
     runtimeOnly "org.postgresql:postgresql"
-    testImplementation "org.testcontainers:postgresql:1.17.6"
     implementation "org.mapstruct:mapstruct:${mapstructVersion}"
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
     annotationProcessor "org.hibernate.orm:hibernate-jpamodelgen:${hibernateVersion}"

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/ErikoistuvaLaakariHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/ErikoistuvaLaakariHelper.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.enumeration.OpintooikeudenTila
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.web.rest.findAll
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils
 import java.time.LocalDate
 import jakarta.persistence.EntityManager
 
@@ -39,7 +38,7 @@ class ErikoistuvaLaakariHelper {
             opintoopas: Opintoopas? = null,
             yliopisto: Yliopisto? = null,
             asetus: Asetus? = null,
-            yliopistoOpintooikeusId: String? = RandomStringUtils.randomAlphabetic(8),
+            yliopistoOpintooikeusId: String? = (1..8).map { ('a'..'z').random() }.joinToString(""),
             laillistamispaiva: LocalDate? = DEFAULT_LAILLISTAMISPAIVA,
             laillistamistodistusData: ByteArray? = DEFAULT_LAILLISTAMISTODISTUS_DATA,
             laillistamistodistusNimi: String? = DEFAULT_LAILLISTAMISTODISTUS_NIMI,


### PR DESCRIPTION
This pull request contains minor changes to the frontend security scan workflow and the test helper for `ErikoistuvaLaakari`. The main updates involve adjusting the severity threshold for `yarn audit` and replacing the use of a shaded dependency with standard Kotlin code for random string generation.

**Frontend workflow update:**

* Increased the severity threshold for failing the `yarn audit` step in `.github/workflows/frontend-security-scan.yml` from 8 to 16, making the audit less strict.

**Test helper simplification:**

* Removed the import of `RandomStringUtils` from `org.testcontainers.shaded.org.apache.commons.lang3` in `ErikoistuvaLaakariHelper.kt` and replaced its usage with a native Kotlin random string generator for `yliopistoOpintooikeusId`. [[1]](diffhunk://#diff-54160fa6cbef51a5cbf61484e8cee9d67668001e22fa22d151013ffb4001dd33L7) [[2]](diffhunk://#diff-54160fa6cbef51a5cbf61484e8cee9d67668001e22fa22d151013ffb4001dd33L42-R41)