### PR TITLE
CSRF 403 virheen korjaus (axios v0 -> v1) (#531)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -448,7 +448,7 @@ jobs:
           git checkout $RELEASE_BRANCH
           auto-changelog -u --hide-empty-releases --template https://raw.githubusercontent.com/Eura2021/eura2021-kong-charts/master/chlog.hbs
           git add CHANGELOG.md
-          git commit -m 'CHANGELOG updated [CI SKIP]' --allow-empty CHANGELOG.md
+          git commit -m 'CHANGELOG updated [skip ci]' --allow-empty CHANGELOG.md
           git push origin $RELEASE_BRANCH
 
   notify-staging:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v2.0.0](https://github.com/elsa-hanke/elsa-backend/compare/v0.0.16...v2.0.0) - 21 April 2026
+
+- Release/v0.0.x merge [`#530`](https://github.com/elsa-hanke/elsa-backend/pull/530)(21 April 2026)
+- ELSA-1127 Valmistumispyynnön hyväksyminen ei onnistu [`#524`](https://github.com/elsa-hanke/elsa-backend/pull/524)(20 April 2026)
+
 ## [v0.0.16](https://github.com/elsa-hanke/elsa-backend/compare/v0.0.15...v0.0.16) - 21 April 2026
 
 ## [v0.0.15](https://github.com/elsa-hanke/elsa-backend/compare/v0.0.14...v0.0.15) - 21 April 2026

--- a/frontend/src/utils/cookies.ts
+++ b/frontend/src/utils/cookies.ts
@@ -5,5 +5,9 @@ export function setCookie(name: string, value: string, maxAge: number) {
 export function getCookie(name: string) {
   const value = `; ${document.cookie}`
   const parts = value.split(`; ${name}=`) as string[] | undefined
-  return parts && parts.length === 2 ? parts?.pop()?.split(';').shift() : undefined
+  // Use index [1] (first occurrence) to match the cookie the server reads via
+  // WebUtils.getCookie(), which also returns the first cookie with that name.
+  // This handles duplicate XSRF-TOKEN cookies (e.g. a stale one scoped to a
+  // subdomain alongside the current one scoped to the parent domain).
+  return parts && parts.length >= 2 ? parts[1].split(';').shift() : undefined
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
@@ -6,6 +6,7 @@ import fi.elsapalvelu.elsa.domain.User
 import fi.elsapalvelu.elsa.domain.enumeration.KayttajatilinTila
 import fi.elsapalvelu.elsa.repository.*
 import fi.elsapalvelu.elsa.security.*
+import fi.elsapalvelu.elsa.security.StaleXsrfCookieClearingFilter
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
 import jakarta.persistence.EntityNotFoundException
@@ -112,6 +113,12 @@ class SecurityConfiguration(
                     .ignoringRequestMatchers("/api/logout")
             }
             .addFilterBefore(corsFilter, CsrfFilter::class.java)
+            .addFilterAfter(
+                applicationProperties.getCsrf().cookie.domain?.let {
+                    StaleXsrfCookieClearingFilter(it)
+                } ?: StaleXsrfCookieClearingFilter(""),
+                CsrfFilter::class.java
+            )
             .addFilterAfter(MdcUserIdFilter(), CorsFilter::class.java)
             .addFilterAfter(
                 ElsaSwitchUserFilter(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/security/StaleXsrfCookieClearingFilter.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/security/StaleXsrfCookieClearingFilter.kt
@@ -1,0 +1,73 @@
+package fi.elsapalvelu.elsa.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * Clears stale XSRF-TOKEN cookies that are scoped to a parent domain when the
+ * application is configured to use a more specific subdomain for its CSRF cookie.
+ *
+ * Background: the CSRF cookie domain was previously set to 'elsapalvelu.fi' for all
+ * environments. After it was changed to per-subdomain (e.g. 'kehitys.elsapalvelu.fi'),
+ * browsers that visited the app before the change still carry the old parent-domain
+ * XSRF-TOKEN cookie alongside the new subdomain one. Spring's WebUtils.getCookie()
+ * returns the first matching cookie, which is the stale parent-domain one, causing
+ * CSRF validation to fail with a 403.
+ *
+ * This filter detects when a request carries an XSRF-TOKEN cookie on a different
+ * (parent) domain than the configured csrf cookie domain and expires it, so that
+ * after one request the browser drops the stale cookie permanently.
+ */
+class StaleXsrfCookieClearingFilter(private val csrfCookieDomain: String) :
+    OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        clearStaleCookiesIfNeeded(request, response)
+        filterChain.doFilter(request, response)
+    }
+
+    private fun clearStaleCookiesIfNeeded(request: HttpServletRequest, response: HttpServletResponse) {
+        val cookies = request.cookies ?: return
+
+        // Count how many XSRF-TOKEN cookies are in the request.
+        // More than one means there is at least one stale cookie on a different domain.
+        val xsrfCookies = cookies.filter { it.name == XSRF_TOKEN_COOKIE_NAME }
+        if (xsrfCookies.size <= 1) return
+
+        // Derive the parent domain from the configured csrf cookie domain.
+        // e.g. 'kehitys.elsapalvelu.fi' -> parent candidates are 'elsapalvelu.fi'
+        val parentDomains = parentDomainsOf(csrfCookieDomain)
+
+        parentDomains.forEach { parentDomain ->
+            val expiring = Cookie(XSRF_TOKEN_COOKIE_NAME, "")
+            expiring.domain = parentDomain
+            expiring.path = "/"
+            expiring.maxAge = 0
+            expiring.secure = true
+            response.addCookie(expiring)
+        }
+    }
+
+    /**
+     * Returns all parent domain suffixes for a given hostname.
+     * e.g. 'kehitys.elsapalvelu.fi' -> ['elsapalvelu.fi']
+     */
+    private fun parentDomainsOf(domain: String): List<String> {
+        val parts = domain.split(".")
+        // Need at least 3 parts (sub.example.com) to have a meaningful parent
+        if (parts.size <= 2) return emptyList()
+        return (1 until parts.size - 1).map { i -> parts.drop(i).joinToString(".") }
+    }
+
+    companion object {
+        private const val XSRF_TOKEN_COOKIE_NAME = "XSRF-TOKEN"
+    }
+}
+

--- a/src/test/kotlin/fi/elsapalvelu/elsa/security/StaleXsrfCookieClearingFilterTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/security/StaleXsrfCookieClearingFilterTest.kt
@@ -1,0 +1,121 @@
+package fi.elsapalvelu.elsa.security
+
+import jakarta.servlet.http.Cookie
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+class StaleXsrfCookieClearingFilterTest {
+
+    private fun filter(domain: String = "kehitys.elsapalvelu.fi") =
+        StaleXsrfCookieClearingFilter(domain)
+
+    private fun run(
+        filter: StaleXsrfCookieClearingFilter,
+        vararg cookies: Cookie
+    ): MockHttpServletResponse {
+        val request = MockHttpServletRequest().apply { setCookies(*cookies) }
+        val response = MockHttpServletResponse()
+        filter.doFilter(request, response, MockFilterChain())
+        return response
+    }
+
+    private fun xsrf(value: String) = Cookie("XSRF-TOKEN", value)
+
+    @Test
+    fun `does nothing when no cookies at all`() {
+        val response = run(filter())
+        assertThat(response.cookies).isEmpty()
+    }
+
+    @Test
+    fun `does nothing when only one XSRF-TOKEN cookie present`() {
+        val response = run(filter(), xsrf("only-token"))
+        assertThat(response.cookies).isEmpty()
+    }
+
+    @Test
+    fun `expires parent domain cookie when two XSRF-TOKEN cookies present`() {
+        val response = run(filter(), xsrf("stale-parent-token"), xsrf("current-subdomain-token"))
+
+        val expiringCookies = response.cookies.filter { it.name == "XSRF-TOKEN" }
+        assertThat(expiringCookies).hasSize(1)
+
+        val expiring = expiringCookies.single()
+        assertThat(expiring.domain).isEqualTo("elsapalvelu.fi")
+        assertThat(expiring.maxAge).isEqualTo(0)
+        assertThat(expiring.value).isEmpty()
+        assertThat(expiring.path).isEqualTo("/")
+        assertThat(expiring.secure).isTrue()
+    }
+
+    @Test
+    fun `expires all intermediate parent domains for a deeply nested subdomain`() {
+        // e.g. sub.kehitys.elsapalvelu.fi -> parents: kehitys.elsapalvelu.fi, elsapalvelu.fi
+        val deepFilter = filter("sub.kehitys.elsapalvelu.fi")
+        val response = run(deepFilter, xsrf("token-a"), xsrf("token-b"))
+
+        val expiredDomains = response.cookies.filter { it.name == "XSRF-TOKEN" }.map { it.domain }
+        assertThat(expiredDomains).containsExactlyInAnyOrder("kehitys.elsapalvelu.fi", "elsapalvelu.fi")
+    }
+
+    @Test
+    fun `does not expire anything when csrfCookieDomain is a top-level two-part domain (prod)`() {
+        // 'elsapalvelu.fi' has no parent to clear — avoids wiping prod unnecessarily
+        val prodFilter = filter("elsapalvelu.fi")
+        val response = run(prodFilter, xsrf("token-a"), xsrf("token-b"))
+        assertThat(response.cookies).isEmpty()
+    }
+
+    @Test
+    fun `does not add expiry cookies when csrfCookieDomain is blank`() {
+        val response = run(filter(""), xsrf("token-a"), xsrf("token-b"))
+        assertThat(response.cookies).isEmpty()
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-XSRF cookies must not be touched
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `ignores non-XSRF cookies when counting duplicates`() {
+        // Only one XSRF-TOKEN plus unrelated cookies — should do nothing
+        val response = run(
+            filter(),
+            Cookie("JSESSIONID", "abc"),
+            xsrf("only-xsrf"),
+            Cookie("AWSALB", "xyz")
+        )
+        assertThat(response.cookies).isEmpty()
+    }
+
+    @Test
+    fun `only expires XSRF-TOKEN, never other cookie names`() {
+        val response = run(filter(), xsrf("stale"), xsrf("current"))
+        assertThat(response.cookies.map { it.name }).containsOnly("XSRF-TOKEN")
+    }
+
+    // -------------------------------------------------------------------------
+    // Filter chain must always continue
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `filter chain is always invoked regardless of cookie state`() {
+        val chain = MockFilterChain()
+        val request = MockHttpServletRequest().apply { setCookies(xsrf("only-token")) }
+        filter().doFilter(request, MockHttpServletResponse(), chain)
+        // MockFilterChain records the request it was called with; null means it was never called
+        assertThat(chain.request).isNotNull()
+    }
+
+    @Test
+    fun `filter chain is invoked even when stale cookie is cleared`() {
+        val chain = MockFilterChain()
+        val request = MockHttpServletRequest().apply { setCookies(xsrf("stale"), xsrf("current")) }
+        filter().doFilter(request, MockHttpServletResponse(), chain)
+        assertThat(chain.request).isNotNull()
+    }
+}
+


### PR DESCRIPTION
## Juurisyy

Selain lähetti jokaisen API-pyynnön mukana **kaksi samannimistä `XSRF-TOKEN`-evästettä**, joilla oli eri domain-attribuutti:

| Eväste | Domain | Alkuperä |
|--------|--------|----------|
| `XSRF-TOKEN=e6341d18...` | `.elsapalvelu.fi` | Vanha, vanhentunut — jäänyt selaimeen ajalta, jolloin backend asetti evästeen kaikille ympäristöille yhteiseen parent-domainiin |
| `XSRF-TOKEN=61659087...` | `.kehitys.elsapalvelu.fi` | Nykyinen — backend asettaa tämän nyt ympäristökohtaisesti |

Selain ei korvaa eri domainille asetettua evästettä uudella, vaan pitää molemmat rinnakkain. Kun infrakonfiguraatiota muutettiin ympäristökohtaiseksi (`APPLICATION_CSRF_COOKIE_DOMAIN=kehitys.elsapalvelu.fi`), vanhaa parent-domain-evästettä ei poistettu käyttäjien selaimista.

## Miksi toimi aiemmin (axios 0.x) mutta hajosi (axios 1.x)

**Axios 0.x** luki `XSRF-TOKEN`-evästeen ja asetti `X-XSRF-TOKEN`-headerin automaattisesti **kaikissa pyynnöissä**, myös cross-origin-pyynnöissä (`kehitys.elsapalvelu.fi` → `api.kehitys.elsapalvelu.fi`). Tämä peitti alleen manuaalisen `getCookie`-funktion bugin.

**Axios 1.x** muutti käytöstään tietoturvasyistä: automaattinen XSRF-käsittely toimii enää vain same-origin-pyynnöissä. Cross-origin-pyynnöissä headeria ei enää aseta axios itse, vaan vastuu siirtyi kokonaan manuaaliselle interceptorille — jossa oli bugi.

## Kolme tehtyjä korjausta

### 1. Frontend: `getCookie`-funktion bugi (`frontend/src/utils/cookies.ts`)

Vanha koodi:
```typescript
return parts && parts.length === 2 ? parts?.pop()?.split(';').shift() : undefined
```

Kun selaimessa oli kaksi `XSRF-TOKEN`-evästettä, `split` tuotti **3 osaa** eikä 2, jolloin funktio palautti `undefined`. `X-XSRF-TOKEN`-headeria ei lähetetty lainkaan → Spring Security hylkäsi pyynnön 403-virheellä.

Korjaus: tarkistus muutettiin `>= 2` ja käytetään ensimmäistä osumaa (`parts[1]`), joka vastaa sitä evästettä jonka myös palvelin lukee `WebUtils.getCookie()`-kutsullaan.

```typescript
return parts && parts.length >= 2 ? parts[1].split(';').shift() : undefined
```

### 2. Backend: vanhentunut eväste poistetaan automaattisesti (`StaleXsrfCookieClearingFilter.kt`)

Luotiin uusi Spring-filtteri, joka tarkistaa jokaisessa pyynnössä onko mukana useampi kuin yksi `XSRF-TOKEN`-eväste. Jos on, filtteri lähettää vastauksessa `max-age=0`-direktiivin parent-domain-evästeelle, jolloin selain poistaa sen välittömästi pysyvästi.

Ensimmäisen pyynnön jälkeen käyttäjän selaimessa on enää yksi `XSRF-TOKEN`-eväste eikä ongelmaa voi enää syntyä.

### 3. Yksikkötestit (`StaleXsrfCookieClearingFilterTest.kt`)

Filterille kirjoitettiin 10 yksikkötestiä, jotka varmistavat mm.:
- Filtteri ei tee mitään kun evästeitä on vain yksi
- Vanhentunut parent-domain-eväste poistetaan oikein (oikea domain, `max-age=0`, secure, path `/`)
- Muihin evästeisiin (JSESSIONID, AWSALB) ei kosketa
- Pyyntöketju jatkuu aina normaalisti

## Yhteenveto

```
Ongelma:  2x XSRF-TOKEN eri domaineille
           ↓
axios 0.x: built-in XSRF peitti bugin  →  toimi
axios 1.x: built-in XSRF vain same-origin →  bugi paljastui → 403
           ↓
Korjaus 1 (frontend):  getCookie lukee oikean evästeen (parts[1])
Korjaus 2 (backend):   filtteri poistaa vanhan parent-domain-evästeen selaimesta pysyvästi