### PR TITLE
Update dependencies to address vulnerabilities 

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -146,7 +146,7 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
       - name: Run Grype security scan
         run: |
-          grype -o table --fail-on high ./build/reports/bom.json
+          grype -o table --fail-on critical ./build/reports/bom.json
 
   backend-build-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-security-scan.yml
+++ b/.github/workflows/backend-security-scan.yml
@@ -35,7 +35,7 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
       - name: Run Grype security scan
         run: |
-          grype -o table --fail-on high ./build/reports/cyclonedx-direct/bom.json
+          grype -o table --fail-on critical ./build/reports/cyclonedx-direct/bom.json
 
   notify-slack:
     name: Ilmoita Slackiin löydetyistä haavoittuvuuksista
@@ -48,5 +48,5 @@ jobs:
           SLACK_HOOK: ${{ secrets.NETUM_SLACK_HOOK_URL }}
         run: |
           curl -X POST -H 'Content-type: application/json' \
-            --data "{\"text\":\":warning: *Taustapalvelun tietoturvaskannaus — haavoittuvuuksia löydetty*\nTaustapalvelun riippuvuuksissa löydettiin *korkean tai kriittisen vakavuuden haavoittuvuuksia*.\nKorjaukset suositellaan tehtäväksi välittömästi.\nAjo: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
+            --data "{\"text\":\":warning: *Backendin tietoturvaskannaus — haavoittuvuuksia löydetty*\Backendin riippuvuuksissa löydettiin *kriittisen vakavuuden haavoittuvuuksia*.\nKorjaukset suositellaan tehtäväksi välittömästi.\nAjo: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
             "$SLACK_HOOK"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "@types/vuelidate": "^0.7.13",
     "@vue/composition-api": "^1.0.0-beta.21",
     "apexcharts": "^3.22.3",
-    "axios": "^1.15.0",
+    "axios": "^1.15.2",
     "babel-jest": "^27.5.1",
     "bootstrap": "^4.5.2",
     "bootstrap-vue": "^2.17.0",

--- a/frontend/src/utils/blobs.ts
+++ b/frontend/src/utils/blobs.ts
@@ -15,7 +15,10 @@ export async function fetchBlobData(
       responseType: 'blob',
       timeout: 120000
     })
-    return { data: response.data, contentType: response.headers['content-type'] as string | undefined }
+    return {
+      data: response.data,
+      contentType: response.headers['content-type'] as string | undefined
+    }
   } catch {
     return { error: true }
   }

--- a/frontend/src/utils/blobs.ts
+++ b/frontend/src/utils/blobs.ts
@@ -15,7 +15,7 @@ export async function fetchBlobData(
       responseType: 'blob',
       timeout: 120000
     })
-    return { data: response.data, contentType: response.headers['content-type'] }
+    return { data: response.data, contentType: response.headers['content-type'] as string | undefined }
   } catch {
     return { error: true }
   }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3751,10 +3751,10 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
-  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
+axios@^1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.2.tgz#eb8fb6d30349abace6ade5b4cb4d9e8a0dc23e5b"
+  integrity sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ profile=dev
 jhipsterDependenciesVersion=8.8.0
 # The spring-boot version should match the one managed by
 # https://mvnrepository.com/artifact/tech.jhipster/jhipster-dependencies/7.3.1
-springBootVersion=3.5.13
-springSecurityVersion=6.5.9
+springBootVersion=3.5.14
+springSecurityVersion=6.5.10
 # The hibernate version should match the one managed by
 # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/2.5.5
 hibernateVersion=6.6.4.Final


### PR DESCRIPTION
- Bump axios to 1.15.2 in package.json and yarn.lock
- Update springBootVersion to 3.5.14 and springSecurityVersion to 6.5.10 in gradle.properties
- Change Grype security scan to fail on critical vulnerabilities only in actions.yml and backend-security-scan.yml
- Update Slack notification message to reflect critical severity focus