### PR TITLE
expand e2e tests for koulutussopimus approval process

### DIFF
--- a/e2e/cypress/e2e/koejakso/koulutussopimus.cy.ts
+++ b/e2e/cypress/e2e/koejakso/koulutussopimus.cy.ts
@@ -25,18 +25,6 @@ const KOULUTTAJA_SUKUNIMI    = 'Hummaamistes'
 const VASTUUHENKILO_ETUNIMI  = 'Mia'
 const VASTUUHENKILO_SUKUNIMI = 'Ålands'
 
-function apiRequest(options: Partial<Cypress.RequestOptions>) {
-  return cy.getCookie('XSRF-TOKEN').then((cookie) =>
-    cy.request({
-      ...options,
-      headers: {
-        'X-XSRF-TOKEN': decodeURIComponent(cookie?.value ?? ''),
-        ...(options.headers ?? {}),
-      },
-    })
-  )
-}
-
 describe('Koulutussopimus', () => {
   // ── Esialustetaan tietokanta testisarjaa varten ──────────────────────────────
   before(() => {
@@ -167,12 +155,12 @@ describe('Koulutussopimus', () => {
     cy.then(() => {
       const sopimusId = Cypress.env('koulutussopimusId')
 
-      // ── Käyttötapaus 7: Kouluttaja hyväksyy koulutussopimuksen ──────────────
+      // -- Käyttötapaus 7: Kouluttaja hyväksyy koulutussopimuksen --
       // 1. Kouluttaja kirjautuu ELSA-palveluun verification-tokenin kautta
       cy.loginAsKouluttaja(Cypress.env('kouluttajaToken'))
 
       // 2. Kouluttaja hakee koulutussopimuksen tiedot
-      apiRequest({
+      cy.apiRequest({
         method: 'GET',
         url: `/api/kouluttaja/koejakso/koulutussopimus/${sopimusId}`,
       }).then(({ status, body }) => {
@@ -189,7 +177,7 @@ describe('Koulutussopimus', () => {
           sahkoposti: KOULUTTAJA_EMAIL,
         }))
 
-        apiRequest({
+        cy.apiRequest({
           method: 'PUT',
           url: '/api/kouluttaja/koejakso/koulutussopimus',
           body: {
@@ -203,12 +191,12 @@ describe('Koulutussopimus', () => {
         })
       })
 
-      // ── Käyttötapaus 8: Vastuuhenkilö hyväksyy koulutussopimuksen ───────────
+      // -- Käyttötapaus 8: Vastuuhenkilö hyväksyy koulutussopimuksen --
       // 1. Vastuuhenkilö kirjautuu ELSA-palveluun verification-tokenin kautta
       cy.loginAsVastuuhenkilo(Cypress.env('vastuuhenkiloToken'))
 
       // 2. Vastuuhenkilö hakee koulutussopimuksen tiedot
-      apiRequest({
+      cy.apiRequest({
         method: 'GET',
         url: `/api/vastuuhenkilo/koejakso/koulutussopimus/${sopimusId}`,
       }).then(({ status, body }) => {
@@ -217,7 +205,7 @@ describe('Koulutussopimus', () => {
         // 3–4. Vastuuhenkilö tarkistaa tiedot ja hyväksyy
         // (korjausehdotus=null → hyväksyntä, ei palautus)
         // Huom: vastuuhenkilo.sahkoposti täytyy sisällyttää DTO:hon, muuten palvelu nollaa käyttäjän sähköpostin
-        apiRequest({
+        cy.apiRequest({
           method: 'PUT',
           url: '/api/vastuuhenkilo/koejakso/koulutussopimus',
           body: {

--- a/e2e/cypress/e2e/koejakso/koulutussopimus.cy.ts
+++ b/e2e/cypress/e2e/koejakso/koulutussopimus.cy.ts
@@ -3,22 +3,39 @@ import { E2E_ERIKOISTUVA_EMAIL, KOULUTTAJA_EMAIL, VASTUUHENKILO_EMAIL } from '..
 export {}
 
 // Käyttötapaus 6.
-// Koejakson koulutussopimuksen täyttäminen ja lähettäminen, erikoistuja
+// Koejakson koulutustodistuksen tekeminen, erikoistuja
 // Käyttäjä: Erikoistuja
-// Tavoite: Lähettää koulutussopimus kouluttajan hyväksyttäväksi
-// Laukaisija: Erikoistuja aloittaa koejakson
-// Esiehto: Erikoistujalla on opinto-oikeus opintotietojärjestelmässä.
+// Tavoite: Lähettää koejakson koulutussopimus
+// Laukaisija: Erikoistuja on saanut opinto-oikeuden ja on aloittamassa koejaksoa
+// Esiehto: Erikoistuvalla on opinto-oikeus opintotietojärjestelmässä.
 //          Erikoistuja on lisännyt kouluttajalle katseluoikeudet.
-// Käyttötapauksen kulku:
-// 1. Erikoistuja siirtyy koejakso-sivulle
-// 2. Erikoistuja avaa koulutussopimus-lomakkeen
-// 3. Erikoistuja täyttää lomakkeen tiedot
-// 4. Erikoistuja lähettää lomakkeen kouluttajan hyväksyttäväksi
+//
+// Käyttötapaus 7.
+// Kouluttaja hyväksyy koulutussopimuksen
+// Käyttäjä: Kouluttaja
+// Suoritetaan API-kutsulla verification-tokenin kautta (valmistumispyynto-patternin mukaan)
+//
+// Käyttötapaus 8.
+// Vastuuhenkilö hyväksyy koulutussopimuksen
+// Käyttäjä: Vastuuhenkilö
+// Suoritetaan API-kutsulla verification-tokenin kautta
 
-const KOULUTTAJA_ETUNIMI     = 'E2E'
-const KOULUTTAJA_SUKUNIMI    = 'Kouluttaja'
-const VASTUUHENKILO_ETUNIMI  = 'E2E'
-const VASTUUHENKILO_SUKUNIMI = 'Vastuuhenkilo'
+const KOULUTTAJA_ETUNIMI     = 'Lassekalevi'
+const KOULUTTAJA_SUKUNIMI    = 'Hummaamistes'
+const VASTUUHENKILO_ETUNIMI  = 'Mia'
+const VASTUUHENKILO_SUKUNIMI = 'Ålands'
+
+function apiRequest(options: Partial<Cypress.RequestOptions>) {
+  return cy.getCookie('XSRF-TOKEN').then((cookie) =>
+    cy.request({
+      ...options,
+      headers: {
+        'X-XSRF-TOKEN': decodeURIComponent(cookie?.value ?? ''),
+        ...(options.headers ?? {}),
+      },
+    })
+  )
+}
 
 describe('Koulutussopimus', () => {
   // ── Esialustetaan tietokanta testisarjaa varten ──────────────────────────────
@@ -28,17 +45,23 @@ describe('Koulutussopimus', () => {
     // Siivotaan vanhat koejakso-lomakkeet ennen erikoistuvan poistoa (FK-turvallisuus)
     cy.task('db:cleanupKoejakso', { erikoistuvaEmail: E2E_ERIKOISTUVA_EMAIL })
     cy.task('db:cleanupErikoistuva', { email: E2E_ERIKOISTUVA_EMAIL })
+    cy.task('db:cleanupKouluttaja', { email: KOULUTTAJA_EMAIL })
+    cy.task('db:cleanupVastuuhenkilo', { email: VASTUUHENKILO_EMAIL })
 
-    // Siemennetään tukikäyttäjät
+    // Siemennetään tukikäyttäjät ja talletetaan verification-tokenit Cypress.env:iin
     cy.task('db:seedKouluttaja', {
       email: KOULUTTAJA_EMAIL,
       etunimi: KOULUTTAJA_ETUNIMI,
       sukunimi: KOULUTTAJA_SUKUNIMI,
+    }).then((result: any) => {
+      Cypress.env('kouluttajaToken', result?.token)
     })
     cy.task('db:seedVastuuhenkilo', {
       email: VASTUUHENKILO_EMAIL,
       etunimi: VASTUUHENKILO_ETUNIMI,
       sukunimi: VASTUUHENKILO_SUKUNIMI,
+    }).then((result: any) => {
+      Cypress.env('vastuuhenkiloToken', result?.token)
     })
 
     // Kirjautuminen luo erikoistuvan ja opinto-oikeuden (createWithoutOpintotietodata)
@@ -51,7 +74,7 @@ describe('Koulutussopimus', () => {
     })
   })
 
-  // ── Käyttötapaus 6: Erikoistuja lähettää koulutussopimuksen ─────────────────
+  // ── Käyttötapaukset 6, 7, 8: koko koulutussopimusprosessi ───────────────────
 
   it('Käyttötapaus 6: Erikoistuja täyttää ja lähettää koulutussopimuksen', () => {
     // Siivotaan mahdollinen edellinen koulutussopimus jotta testi on idempotentti
@@ -62,6 +85,8 @@ describe('Koulutussopimus', () => {
     const mm = String(today.getMonth() + 1).padStart(2, '0')
     const yyyy = today.getFullYear()
     const todayStr = `${dd}.${mm}.${yyyy}`
+
+    // ── Käyttötapaus 6: Erikoistuja täyttää ja lähettää koulutussopimuksen ────
 
     // 1. Erikoistuja siirtyy koejakso-sivulle
     cy.visit('/koejakso')
@@ -107,7 +132,7 @@ describe('Koulutussopimus', () => {
       .type(todayStr)
       .blur()
 
-    // Kouluttajan valinta – valitaan siemennetty kouluttaja
+    // 5. Kouluttajan valinta – valitaan siemennetty kouluttaja
     cy.contains('label', 'Kouluttaja')
       .parent()
       .find('.multiselect')
@@ -116,14 +141,18 @@ describe('Koulutussopimus', () => {
       .contains(`${KOULUTTAJA_ETUNIMI} ${KOULUTTAJA_SUKUNIMI}`)
       .click({ force: true })
 
-    // 4. Erikoistuja lähettää lomakkeen
+    // 6. Erikoistuja lähettää lomakkeen
     cy.intercept('POST', '**/erikoistuva-laakari/koejakso/koulutussopimus').as('koulutussopimusPost')
     cy.intercept('GET', '**/erikoistuva-laakari/koejakso').as('koejaksoAfterSubmit')
 
     cy.contains('button', 'Hyväksy ja lähetä').click()
     cy.get('#confirm-send').find('button').contains('Hyväksy ja lähetä').click()
 
-    cy.wait('@koulutussopimusPost').its('response.statusCode').should('eq', 201)
+    cy.wait('@koulutussopimusPost').then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body?.id).to.be.a('number')
+      Cypress.env('koulutussopimusId', response?.body?.id)
+    })
     cy.wait('@koejaksoAfterSubmit')
 
     // Vahvistetaan onnistuminen – lomake siirtyy odottamaan hyväksyntöjä readonly-tilaan
@@ -134,5 +163,76 @@ describe('Koulutussopimus', () => {
     ).should('be.visible')
     cy.contains('E2E Testisairaala').should('be.visible')
     cy.contains(`${KOULUTTAJA_ETUNIMI} ${KOULUTTAJA_SUKUNIMI}`).should('be.visible')
+
+    cy.then(() => {
+      const sopimusId = Cypress.env('koulutussopimusId')
+
+      // ── Käyttötapaus 7: Kouluttaja hyväksyy koulutussopimuksen ──────────────
+      // 1. Kouluttaja kirjautuu ELSA-palveluun verification-tokenin kautta
+      cy.loginAsKouluttaja(Cypress.env('kouluttajaToken'))
+
+      // 2. Kouluttaja hakee koulutussopimuksen tiedot
+      apiRequest({
+        method: 'GET',
+        url: `/api/kouluttaja/koejakso/koulutussopimus/${sopimusId}`,
+      }).then(({ status, body }) => {
+        expect(status).to.eq(200)
+
+        // 3–4. Kouluttaja täyttää koulutuspaikan tiedot ja lähettää hyväksynnän
+        // (korjausehdotus=null → hyväksyntä, ei palautus korjattavaksi)
+        // Huom: sahkoposti täytyy sisällyttää DTO:hon, muuten palvelu nollaa käyttäjän sähköpostin
+        const kouluttajat = (body.kouluttajat ?? []).map((k: any) => ({
+          ...k,
+          toimipaikka: 'E2E Testisairaala',
+          lahiosoite: 'Testikatu 1',
+          postitoimipaikka: '00100 Helsinki',
+          sahkoposti: KOULUTTAJA_EMAIL,
+        }))
+
+        apiRequest({
+          method: 'PUT',
+          url: '/api/kouluttaja/koejakso/koulutussopimus',
+          body: {
+            ...body,
+            kouluttajat,
+            korjausehdotus: null,
+          },
+        }).then(({ status, body }) => {
+          expect(status).to.eq(200)
+          expect(body.kouluttajat?.some((k: any) => k.sopimusHyvaksytty === true)).to.eq(true)
+        })
+      })
+
+      // ── Käyttötapaus 8: Vastuuhenkilö hyväksyy koulutussopimuksen ───────────
+      // 1. Vastuuhenkilö kirjautuu ELSA-palveluun verification-tokenin kautta
+      cy.loginAsVastuuhenkilo(Cypress.env('vastuuhenkiloToken'))
+
+      // 2. Vastuuhenkilö hakee koulutussopimuksen tiedot
+      apiRequest({
+        method: 'GET',
+        url: `/api/vastuuhenkilo/koejakso/koulutussopimus/${sopimusId}`,
+      }).then(({ status, body }) => {
+        expect(status).to.eq(200)
+
+        // 3–4. Vastuuhenkilö tarkistaa tiedot ja hyväksyy
+        // (korjausehdotus=null → hyväksyntä, ei palautus)
+        // Huom: vastuuhenkilo.sahkoposti täytyy sisällyttää DTO:hon, muuten palvelu nollaa käyttäjän sähköpostin
+        apiRequest({
+          method: 'PUT',
+          url: '/api/vastuuhenkilo/koejakso/koulutussopimus',
+          body: {
+            ...body,
+            korjausehdotus: null,
+            vastuuhenkilo: {
+              ...(body.vastuuhenkilo ?? {}),
+              sahkoposti: VASTUUHENKILO_EMAIL,
+            },
+          },
+        }).then(({ status, body }) => {
+          expect(status).to.eq(200)
+          expect(body.vastuuhenkilo?.sopimusHyvaksytty).to.eq(true)
+        })
+      })
+    })
   })
 })

--- a/e2e/cypress/e2e/valmistumispyynto/valmistumispyynto.cy.ts
+++ b/e2e/cypress/e2e/valmistumispyynto/valmistumispyynto.cy.ts
@@ -23,18 +23,6 @@ const VASTUUHENKILO_SUKUNIMI = 'Ålands'
 const VIRKAILIJA_ETUNIMI     = 'Daniel'
 const VIRKAILIJA_SUKUNIMI    = 'Siekkinen'
 
-function apiRequest(options: Partial<Cypress.RequestOptions>) {
-  return cy.getCookie('XSRF-TOKEN').then((cookie) =>
-    cy.request({
-      ...options,
-      headers: {
-        'X-XSRF-TOKEN': decodeURIComponent(cookie?.value ?? ''),
-        ...(options.headers ?? {}),
-      },
-    })
-  )
-}
-
 describe('Valmistumispyyntö', () => {
   // ── Esialustetaan tietokanta testisarjaa varten ──────────────────────────────
   before(() => {
@@ -169,11 +157,11 @@ describe('Valmistumispyyntö', () => {
 
       // 3. Vastuuhenkilö arvioi erikoistujan osaamisen.
       cy.loginAsVastuuhenkilo(Cypress.env('vastuuhenkiloToken'))
-      apiRequest({
+      cy.apiRequest({
         method: 'GET',
         url: `/api/vastuuhenkilo/valmistumispyynnon-arviointi/${valmistumispyyntoId}`,
       }).its('status').should('eq', 200)
-      apiRequest({
+      cy.apiRequest({
         method: 'PUT',
         url: `/api/vastuuhenkilo/valmistumispyynnon-arviointi/${valmistumispyyntoId}`,
         body: {
@@ -187,11 +175,11 @@ describe('Valmistumispyyntö', () => {
 
       // 4. Virkailija tarkistaa valmistumispyynnön tiedot.
       cy.loginAsVirkailija(Cypress.env('virkailijaToken'))
-      apiRequest({
+      cy.apiRequest({
         method: 'GET',
         url: `/api/virkailija/valmistumispyynnon-tarkistus/${valmistumispyyntoId}`,
       }).its('status').should('eq', 200)
-      apiRequest({
+      cy.apiRequest({
         method: 'PUT',
         url: `/api/virkailija/valmistumispyynnon-tarkistus/${valmistumispyyntoId}`,
         form: true,
@@ -219,14 +207,14 @@ describe('Valmistumispyyntö', () => {
 
       // 5. Vastuuhenkilö hyväksyy valmistumisen.
       cy.loginAsVastuuhenkilo(Cypress.env('vastuuhenkiloToken'))
-      apiRequest({
+      cy.apiRequest({
         method: 'GET',
         url: `/api/vastuuhenkilo/valmistumispyynnon-hyvaksynta/${valmistumispyyntoId}`,
       }).then(({ status, body }) => {
         expect(status).to.eq(200)
         expect(body.valmistumispyynto.tila).to.eq('ODOTTAA_VASTUUHENKILON_HYVAKSYNTAA')
       })
-      apiRequest({
+      cy.apiRequest({
         method: 'PUT',
         url: `/api/vastuuhenkilo/valmistumispyynnon-hyvaksynta/${valmistumispyyntoId}`,
         body: {},

--- a/e2e/cypress/plugins/db-tasks/kayttaja-utils.ts
+++ b/e2e/cypress/plugins/db-tasks/kayttaja-utils.ts
@@ -1,0 +1,26 @@
+import type { Client } from 'pg'
+
+export async function ensureYliopistoLink(client: Client, kayttajaId: number): Promise<any> {
+  await client.query(
+    `INSERT INTO rel_kayttaja__yliopisto (kayttaja_id, yliopisto_id)
+     VALUES ($1, 1) ON CONFLICT DO NOTHING`,
+    [kayttajaId]
+  )
+}
+
+export async function ensureYliopistoErikoisalaLink(client: Client, kayttajaId: number): Promise<number> {
+  const existing = await client.query(
+    `SELECT id FROM kayttaja_yliopisto_erikoisala
+     WHERE kayttaja_id = $1 AND yliopisto_id = 1 AND erikoisala_id = 46`,
+    [kayttajaId]
+  )
+  if (existing.rows.length > 0) return existing.rows[0].id
+
+  return (
+    await client.query(
+      `INSERT INTO kayttaja_yliopisto_erikoisala (kayttaja_id, yliopisto_id, erikoisala_id)
+       VALUES ($1, 1, 46) RETURNING id`,
+      [kayttajaId]
+    )
+  ).rows[0].id
+}

--- a/e2e/cypress/plugins/db-tasks/kouluttaja.ts
+++ b/e2e/cypress/plugins/db-tasks/kouluttaja.ts
@@ -1,88 +1,15 @@
-import { randomUUID } from 'crypto'
 import type { Client } from 'pg'
 import { dbClient, withDb } from './db-client'
+import {
+  fetchUserIdsByEmailOrLogin,
+  ensureUserAuthority,
+  createVerificationToken,
+  createUserWithRole,
+  cleanupUser,
+} from './user-utils'
+import { ensureYliopistoErikoisalaLink } from './kayttaja-utils'
 
-async function createVerificationToken(client: Client, userId: string): Promise<string> {
-  const token = randomUUID()
-  await client.query(`DELETE FROM verification_token WHERE user_id = $1`, [userId])
-  await client.query(
-    `INSERT INTO verification_token (id, user_id) VALUES ($1, $2)`,
-    [token, userId]
-  )
-  return token
-}
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-async function fetchKouluttajaIds(
-  client: Client,
-  email: string
-): Promise<{ userId: string; kayttajaId: number } | null> {
-  // Search by email OR login: the app may nullify the email column when the
-  // kouluttaja approves a form with an empty sahkoposti field in the DTO,
-  // so login (immutable, set to email at creation) is a reliable fallback key.
-  const result = await client.query(
-    `SELECT u.id AS user_id, k.id AS kayttaja_id
-     FROM jhi_user u
-     LEFT JOIN kayttaja k ON k.user_id = u.id
-     WHERE u.email = $1 OR u.login = $1`,
-    [email]
-  )
-  if (result.rows.length === 0) return null
-  return { userId: result.rows[0].user_id, kayttajaId: result.rows[0].kayttaja_id }
-}
-
-async function ensureYliopistoErikoisalaLink(client: Client, kayttajaId: number): Promise<void> {
-  await client.query(
-    `INSERT INTO kayttaja_yliopisto_erikoisala (kayttaja_id, yliopisto_id, erikoisala_id)
-     SELECT $1, 1, 46
-     WHERE NOT EXISTS (
-       SELECT 1 FROM kayttaja_yliopisto_erikoisala
-       WHERE kayttaja_id = $1 AND yliopisto_id = 1 AND erikoisala_id = 46
-     )`,
-    [kayttajaId]
-  )
-}
-
-async function ensureUserAuthority(client: Client, userId: string): Promise<void> {
-  await client.query(
-    `INSERT INTO jhi_user_authority (user_id, authority_name)
-     VALUES ($1, 'ROLE_KOULUTTAJA') ON CONFLICT DO NOTHING`,
-    [userId]
-  )
-}
-
-async function createKouluttajaUser(
-  client: Client,
-  email: string,
-  etunimi: string,
-  sukunimi: string
-): Promise<number> {
-  const userId = randomUUID()
-  const nimi = `${etunimi} ${sukunimi}`
-
-  await client.query(
-    `INSERT INTO jhi_user
-       (id, login, first_name, last_name, email, activated, lang_key,
-        created_by, last_modified_by, active_authority)
-     VALUES ($1,$2,$3,$4,$5,true,'fi','system','system','ROLE_KOULUTTAJA')`,
-    [userId, email, etunimi, sukunimi, email]
-  )
-  await ensureUserAuthority(client, userId)
-
-  const kayttajaId: number = (
-    await client.query(
-      `INSERT INTO kayttaja (nimike, user_id, tila)
-       VALUES ($1,$2,'AKTIIVINEN')
-       RETURNING id`,
-      [nimi, userId]
-    )
-  ).rows[0].id
-
-  await ensureYliopistoErikoisalaLink(client, kayttajaId)
-
-  return kayttajaId
-}
+const ROLE = 'ROLE_KOULUTTAJA'
 
 // ─── Exported tasks ───────────────────────────────────────────────────────────
 
@@ -96,70 +23,68 @@ async function createKouluttajaUser(
  */
 export const kouluttajaTasks = {
   async 'db:seedKouluttaja'({
-                              email,
-                              etunimi,
-                              sukunimi,
-                            }: {
+    email,
+    etunimi,
+    sukunimi,
+  }: {
     email: string
     etunimi: string
     sukunimi: string
   }): Promise<{ kayttajaId: number; token?: string } | null> {
-    return withDb(dbClient, async (client: any) => {
-      // JPA's @ManyToMany joins on jhi_authority.name, so this row must exist
-      // or JPQL queries won't find the kouluttaja (the left join produces NULL).
+    return withDb(dbClient, async (client: Client) => {
       await client.query(
-        `INSERT INTO jhi_authority (name) VALUES ('ROLE_KOULUTTAJA') ON CONFLICT DO NOTHING`
+        `INSERT INTO jhi_authority (name) VALUES ($1) ON CONFLICT DO NOTHING`,
+        [ROLE]
       )
 
-      const existing = await fetchKouluttajaIds(client, email)
-
+      const existing = await fetchUserIdsByEmailOrLogin(client, email)
       if (existing) {
-        // User already exists — ensure both the yliopisto link and authority row
-        // are present in case a previous partial run left them missing.
         await ensureYliopistoErikoisalaLink(client, existing.kayttajaId)
-        await ensureUserAuthority(client, existing.userId)
+        await ensureUserAuthority(client, existing.userId, ROLE)
         return { kayttajaId: existing.kayttajaId }
       }
 
-      const kayttajaId = await createKouluttajaUser(client, email, etunimi, sukunimi)
-      const created = await fetchKouluttajaIds(client, email)
+      const kayttajaId = await createUserWithRole(client, {
+        email,
+        etunimi,
+        sukunimi,
+        role: ROLE,
+        linkFn: ensureYliopistoErikoisalaLink,
+      })
+      const created = await fetchUserIdsByEmailOrLogin(client, email)
       const token = await createVerificationToken(client, created!.userId)
       return { kayttajaId, token }
     })
   },
 
-  /**
-   * Poistaa esialustetun kouluttajan tiedot. Turvallinen kutsua, vaikka käyttäjää
-   * ei olisikaan.
-   */
   async 'db:cleanupKouluttaja'({ email }: { email: string }): Promise<null> {
-    return withDb(dbClient, async (client: any) => {
-      const ids = await fetchKouluttajaIds(client, email)
+    return withDb(dbClient, async (client: Client) => {
+      const ids = await fetchUserIdsByEmailOrLogin(client, email)
       if (!ids) return null
       const { userId, kayttajaId } = ids
-
-      if (kayttajaId) {
-        await client.query(
-          `DELETE FROM rel_kayttaja_yliopisto_erikoisala__tehtavatyyppi
-           WHERE kayttaja_yliopisto_erikoisala_id IN (
-             SELECT id FROM kayttaja_yliopisto_erikoisala WHERE kayttaja_id = $1
-           )`,
-          [kayttajaId]
-        )
-        await client.query(
-          `DELETE FROM kayttaja_yliopisto_erikoisala WHERE kayttaja_id = $1`,
-          [kayttajaId]
-        )
-        await client.query(
-          `DELETE FROM kouluttajavaltuutus WHERE valtuutettu_id = $1`,
-          [kayttajaId]
-        )
-        await client.query(`DELETE FROM kayttaja WHERE id = $1`, [kayttajaId])
-      }
-
-      await client.query(`DELETE FROM jhi_user_authority WHERE user_id = $1`, [userId])
-      await client.query(`DELETE FROM verification_token WHERE user_id = $1`, [userId])
-      await client.query(`DELETE FROM jhi_user WHERE id = $1`, [userId])
+      // Clean up tehtavatyyppi, kayttaja_yliopisto_erikoisala, kouluttajavaltuutus, kayttaja
+      await cleanupUser(
+        client,
+        userId,
+        kayttajaId,
+        async (client, kayttajaId) => {
+          await client.query(
+            `DELETE FROM rel_kayttaja_yliopisto_erikoisala__tehtavatyyppi
+             WHERE kayttaja_yliopisto_erikoisala_id IN (
+               SELECT id FROM kayttaja_yliopisto_erikoisala WHERE kayttaja_id = $1
+             )`,
+            [kayttajaId]
+          )
+          await client.query(
+            `DELETE FROM kayttaja_yliopisto_erikoisala WHERE kayttaja_id = $1`,
+            [kayttajaId]
+          )
+          await client.query(
+            `DELETE FROM kouluttajavaltuutus WHERE valtuutettu_id = $1`,
+            [kayttajaId]
+          )
+        }
+      )
       return null
     })
   },

--- a/e2e/cypress/plugins/db-tasks/kouluttaja.ts
+++ b/e2e/cypress/plugins/db-tasks/kouluttaja.ts
@@ -2,17 +2,30 @@ import { randomUUID } from 'crypto'
 import type { Client } from 'pg'
 import { dbClient, withDb } from './db-client'
 
+async function createVerificationToken(client: Client, userId: string): Promise<string> {
+  const token = randomUUID()
+  await client.query(`DELETE FROM verification_token WHERE user_id = $1`, [userId])
+  await client.query(
+    `INSERT INTO verification_token (id, user_id) VALUES ($1, $2)`,
+    [token, userId]
+  )
+  return token
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 async function fetchKouluttajaIds(
   client: Client,
   email: string
 ): Promise<{ userId: string; kayttajaId: number } | null> {
+  // Search by email OR login: the app may nullify the email column when the
+  // kouluttaja approves a form with an empty sahkoposti field in the DTO,
+  // so login (immutable, set to email at creation) is a reliable fallback key.
   const result = await client.query(
     `SELECT u.id AS user_id, k.id AS kayttaja_id
      FROM jhi_user u
      LEFT JOIN kayttaja k ON k.user_id = u.id
-     WHERE u.email = $1`,
+     WHERE u.email = $1 OR u.login = $1`,
     [email]
   )
   if (result.rows.length === 0) return null
@@ -90,7 +103,7 @@ export const kouluttajaTasks = {
     email: string
     etunimi: string
     sukunimi: string
-  }): Promise<{ kayttajaId: number } | null> {
+  }): Promise<{ kayttajaId: number; token?: string } | null> {
     return withDb(dbClient, async (client: any) => {
       // JPA's @ManyToMany joins on jhi_authority.name, so this row must exist
       // or JPQL queries won't find the kouluttaja (the left join produces NULL).
@@ -109,7 +122,9 @@ export const kouluttajaTasks = {
       }
 
       const kayttajaId = await createKouluttajaUser(client, email, etunimi, sukunimi)
-      return { kayttajaId }
+      const created = await fetchKouluttajaIds(client, email)
+      const token = await createVerificationToken(client, created!.userId)
+      return { kayttajaId, token }
     })
   },
 
@@ -143,6 +158,7 @@ export const kouluttajaTasks = {
       }
 
       await client.query(`DELETE FROM jhi_user_authority WHERE user_id = $1`, [userId])
+      await client.query(`DELETE FROM verification_token WHERE user_id = $1`, [userId])
       await client.query(`DELETE FROM jhi_user WHERE id = $1`, [userId])
       return null
     })

--- a/e2e/cypress/plugins/db-tasks/user-utils.ts
+++ b/e2e/cypress/plugins/db-tasks/user-utils.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto'
+import { randomUUID } from 'node:crypto'
 import type { Client } from 'pg'
 
 export async function fetchUserIdsByEmailOrLogin(

--- a/e2e/cypress/plugins/db-tasks/user-utils.ts
+++ b/e2e/cypress/plugins/db-tasks/user-utils.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from 'crypto'
+import type { Client } from 'pg'
+
+export async function fetchUserIdsByEmailOrLogin(
+  client: Client,
+  emailOrLogin: string
+): Promise<{ userId: string; kayttajaId: number } | null> {
+  const result = await client.query(
+    `SELECT u.id AS user_id, k.id AS kayttaja_id
+     FROM jhi_user u
+     LEFT JOIN kayttaja k ON k.user_id = u.id
+     WHERE u.email = $1 OR u.login = $1`,
+    [emailOrLogin]
+  )
+  if (result.rows.length === 0) return null
+  return { userId: result.rows[0].user_id, kayttajaId: result.rows[0].kayttaja_id }
+}
+
+export async function ensureUserAuthority(
+  client: Client,
+  userId: string,
+  role: string
+): Promise<void> {
+  await client.query(
+    `INSERT INTO jhi_user_authority (user_id, authority_name)
+     VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+    [userId, role]
+  )
+}
+
+export async function createVerificationToken(
+  client: Client,
+  userId: string
+): Promise<string> {
+  const token = randomUUID()
+  await client.query(`DELETE FROM verification_token WHERE user_id = $1`, [userId])
+  await client.query(
+    `INSERT INTO verification_token (id, user_id) VALUES ($1, $2)`,
+    [token, userId]
+  )
+  return token
+}
+
+export async function createUserWithRole(
+  client: Client,
+  {
+    email,
+    etunimi,
+    sukunimi,
+    role,
+    linkFn,
+  }: {
+    email: string
+    etunimi: string
+    sukunimi: string
+    role: string
+    linkFn: (client: Client, kayttajaId: number) => Promise<number>
+  }
+): Promise<number> {
+  const userId = randomUUID()
+  const nimi = `${etunimi} ${sukunimi}`
+
+  await client.query(
+    `INSERT INTO jhi_user
+       (id, login, first_name, last_name, email, activated, lang_key,
+        created_by, last_modified_by, active_authority)
+     VALUES ($1,$2,$3,$4,$5,true,'fi','system','system',$6)`,
+    [userId, email, etunimi, sukunimi, email, role]
+  )
+  await ensureUserAuthority(client, userId, role)
+
+  const kayttajaId: number = (
+    await client.query(
+      `INSERT INTO kayttaja (nimike, user_id, tila)
+       VALUES ($1,$2,'AKTIIVINEN')
+       RETURNING id`,
+      [nimi, userId]
+    )
+  ).rows[0].id
+
+  await linkFn(client, kayttajaId)
+
+  return kayttajaId
+}
+
+export async function cleanupUser(
+  client: Client,
+  userId: string,
+  kayttajaId: number | null,
+  linkCleanupFn?: (client: Client, kayttajaId: number) => Promise<void>
+): Promise<void> {
+  if (kayttajaId) {
+    if (linkCleanupFn) {
+      await linkCleanupFn(client, kayttajaId)
+    }
+    await client.query(`DELETE FROM kayttaja WHERE id = $1`, [kayttajaId])
+  }
+  await client.query(`DELETE FROM verification_token WHERE user_id = $1`, [userId])
+  await client.query(`DELETE FROM jhi_user_authority WHERE user_id = $1`, [userId])
+  await client.query(`DELETE FROM jhi_user WHERE id = $1`, [userId])
+}
+

--- a/e2e/cypress/plugins/db-tasks/vastuuhenkilo.ts
+++ b/e2e/cypress/plugins/db-tasks/vastuuhenkilo.ts
@@ -1,9 +1,15 @@
-import { randomUUID } from 'crypto'
 import type { Client } from 'pg'
 import { dbClient, withDb } from './db-client'
+import {
+  fetchUserIdsByEmailOrLogin,
+  ensureUserAuthority,
+  createVerificationToken,
+  createUserWithRole,
+  cleanupUser,
+} from './user-utils'
+import { ensureYliopistoErikoisalaLink } from './kayttaja-utils'
 
 const ROLE = 'ROLE_VASTUUHENKILO'
-
 const TEHTAVATYYPPIT = [
   'KOEJAKSOSOPIMUSTEN_JA_KOEJAKSOJEN_HYVAKSYMINEN',
   'VALMISTUMISPYYNNON_OSAAMISEN_ARVIOINTI',
@@ -11,52 +17,7 @@ const TEHTAVATYYPPIT = [
   'YEK_VALMISTUMINEN',
 ] as const
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-async function fetchVastuuhenkiloIds(
-  client: Client,
-  email: string
-): Promise<{ userId: string; kayttajaId: number } | null> {
-  // Search by email OR login: the app may nullify the email column when the
-  // vastuuhenkilo approves a form with an empty sahkoposti field in the DTO,
-  // so login (which is immutable and set to the email at creation) is the
-  // reliable fallback key.
-  const result = await client.query(
-    `SELECT u.id AS user_id, k.id AS kayttaja_id
-     FROM jhi_user u
-     LEFT JOIN kayttaja k ON k.user_id = u.id
-     WHERE u.email = $1 OR u.login = $1`,
-    [email]
-  )
-  if (result.rows.length === 0) return null
-  return { userId: result.rows[0].user_id, kayttajaId: result.rows[0].kayttaja_id }
-}
-
-/**
- * Ensures the kayttaja_yliopisto_erikoisala row exists and returns its id.
- * Returns the existing row's id if already present.
- */
-async function ensureYliopistoErikoisalaLink(client: Client, kayttajaId: number): Promise<number> {
-  const existing = await client.query(
-    `SELECT id FROM kayttaja_yliopisto_erikoisala
-     WHERE kayttaja_id = $1 AND yliopisto_id = 1 AND erikoisala_id = 46`,
-    [kayttajaId]
-  )
-  if (existing.rows.length > 0) return existing.rows[0].id
-
-  return (
-    await client.query(
-      `INSERT INTO kayttaja_yliopisto_erikoisala (kayttaja_id, yliopisto_id, erikoisala_id)
-       VALUES ($1, 1, 46) RETURNING id`,
-      [kayttajaId]
-    )
-  ).rows[0].id
-}
-
-/**
- * Lisää vastuuhenkilön tehtävätyyppi-linkitykset kayttaja_yliopisto_erikoisala-riville.
- * Idempotentti ON CONFLICT DO NOTHING -lausekkeen avulla.
- */
+// Helper for tehtavatyyppi seeding (remains local)
 async function seedTehtavatyyppit(client: Client, yeId: number): Promise<void> {
   const types = await client.query(
     `SELECT id FROM vastuuhenkilon_tehtavatyyppi WHERE nimi = ANY($1)`,
@@ -72,56 +33,6 @@ async function seedTehtavatyyppit(client: Client, yeId: number): Promise<void> {
   }
 }
 
-async function ensureUserAuthority(client: Client, userId: string): Promise<void> {
-  await client.query(
-    `INSERT INTO jhi_user_authority (user_id, authority_name)
-     VALUES ($1, $2) ON CONFLICT DO NOTHING`,
-    [userId, ROLE]
-  )
-}
-
-async function createVerificationToken(client: Client, userId: string): Promise<string> {
-  const token = randomUUID()
-  await client.query(`DELETE FROM verification_token WHERE user_id = $1`, [userId])
-  await client.query(
-    `INSERT INTO verification_token (id, user_id) VALUES ($1, $2)`,
-    [token, userId]
-  )
-  return token
-}
-
-async function createVastuuhenkiloUser(
-  client: Client,
-  email: string,
-  etunimi: string,
-  sukunimi: string
-): Promise<number> {
-  const userId = randomUUID()
-  const nimi = `${etunimi} ${sukunimi}`
-
-  await client.query(
-    `INSERT INTO jhi_user
-       (id, login, first_name, last_name, email, activated, lang_key,
-        created_by, last_modified_by, active_authority)
-     VALUES ($1,$2,$3,$4,$5,true,'fi','system','system',$6)`,
-    [userId, email, etunimi, sukunimi, email, ROLE]
-  )
-  await ensureUserAuthority(client, userId)
-
-  const kayttajaId: number = (
-    await client.query(
-      `INSERT INTO kayttaja (nimike, user_id, tila)
-       VALUES ($1,$2,'AKTIIVINEN') RETURNING id`,
-      [nimi, userId]
-    )
-  ).rows[0].id
-
-  const yeId = await ensureYliopistoErikoisalaLink(client, kayttajaId)
-  await seedTehtavatyyppit(client, yeId)
-
-  return kayttajaId
-}
-
 // ─── Exported tasks ───────────────────────────────────────────────────────────
 
 /**
@@ -133,62 +44,72 @@ async function createVastuuhenkiloUser(
  */
 export const vastuuhenkiloTasks = {
   async 'db:seedVastuuhenkilo'({
-                                 email,
-                                 etunimi,
-                                 sukunimi,
-                               }: {
+    email,
+    etunimi,
+    sukunimi,
+  }: {
     email: string
     etunimi: string
     sukunimi: string
   }): Promise<{ kayttajaId: number; token?: string } | null> {
-    return withDb(dbClient, async (client: any) => {
+    return withDb(dbClient, async (client: Client) => {
       await client.query(
         `INSERT INTO jhi_authority (name) VALUES ($1) ON CONFLICT DO NOTHING`,
         [ROLE]
       )
 
-      const existing = await fetchVastuuhenkiloIds(client, email)
-
+      const existing = await fetchUserIdsByEmailOrLogin(client, email)
       if (existing) {
-        // User already exists — ensure yliopisto/erikoisala link and tehtavatyyppit
-        // are present in case a previous partial run left them missing.
         const yeId = await ensureYliopistoErikoisalaLink(client, existing.kayttajaId)
         await seedTehtavatyyppit(client, yeId)
-        await ensureUserAuthority(client, existing.userId)
+        await ensureUserAuthority(client, existing.userId, ROLE)
         return { kayttajaId: existing.kayttajaId }
       }
 
-      const kayttajaId = await createVastuuhenkiloUser(client, email, etunimi, sukunimi)
-      const created = await fetchVastuuhenkiloIds(client, email)
+      // Custom linkFn for vastuuhenkilo: ensure link and seed tehtavatyyppit
+      const linkFn = async (client: Client, kayttajaId: number) => {
+        const yeId = await ensureYliopistoErikoisalaLink(client, kayttajaId)
+        await seedTehtavatyyppit(client, yeId)
+        return yeId
+      }
+
+      const kayttajaId = await createUserWithRole(client, {
+        email,
+        etunimi,
+        sukunimi,
+        role: ROLE,
+        linkFn,
+      })
+      const created = await fetchUserIdsByEmailOrLogin(client, email)
       const token = await createVerificationToken(client, created!.userId)
       return { kayttajaId, token }
     })
   },
 
   async 'db:cleanupVastuuhenkilo'({ email }: { email: string }): Promise<null> {
-    return withDb(dbClient, async (client:any) => {
-      const ids = await fetchVastuuhenkiloIds(client, email)
+    return withDb(dbClient, async (client: Client) => {
+      const ids = await fetchUserIdsByEmailOrLogin(client, email)
       if (!ids) return null
       const { userId, kayttajaId } = ids
-
-      if (kayttajaId) {
-        await client.query(
-          `DELETE FROM rel_kayttaja_yliopisto_erikoisala__tehtavatyyppi
-           WHERE kayttaja_yliopisto_erikoisala_id IN (
-             SELECT id FROM kayttaja_yliopisto_erikoisala WHERE kayttaja_id = $1
-           )`,
-          [kayttajaId]
-        )
-        await client.query(
-          `DELETE FROM kayttaja_yliopisto_erikoisala WHERE kayttaja_id = $1`,
-          [kayttajaId]
-        )
-        await client.query(`DELETE FROM kayttaja WHERE id = $1`, [kayttajaId])
-      }
-
-      await client.query(`DELETE FROM verification_token WHERE user_id = $1`, [userId])
-      await client.query(`DELETE FROM jhi_user_authority WHERE user_id = $1`, [userId])
-      await client.query(`DELETE FROM jhi_user WHERE id = $1`, [userId])
+      // Clean up tehtavatyyppi, kayttaja_yliopisto_erikoisala, kayttaja
+      await cleanupUser(
+        client,
+        userId,
+        kayttajaId,
+        async (client, kayttajaId) => {
+          await client.query(
+            `DELETE FROM rel_kayttaja_yliopisto_erikoisala__tehtavatyyppi
+             WHERE kayttaja_yliopisto_erikoisala_id IN (
+               SELECT id FROM kayttaja_yliopisto_erikoisala WHERE kayttaja_id = $1
+             )`,
+            [kayttajaId]
+          )
+          await client.query(
+            `DELETE FROM kayttaja_yliopisto_erikoisala WHERE kayttaja_id = $1`,
+            [kayttajaId]
+          )
+        }
+      )
       return null
     })
   },

--- a/e2e/cypress/plugins/db-tasks/vastuuhenkilo.ts
+++ b/e2e/cypress/plugins/db-tasks/vastuuhenkilo.ts
@@ -17,11 +17,15 @@ async function fetchVastuuhenkiloIds(
   client: Client,
   email: string
 ): Promise<{ userId: string; kayttajaId: number } | null> {
+  // Search by email OR login: the app may nullify the email column when the
+  // vastuuhenkilo approves a form with an empty sahkoposti field in the DTO,
+  // so login (which is immutable and set to the email at creation) is the
+  // reliable fallback key.
   const result = await client.query(
     `SELECT u.id AS user_id, k.id AS kayttaja_id
      FROM jhi_user u
      LEFT JOIN kayttaja k ON k.user_id = u.id
-     WHERE u.email = $1`,
+     WHERE u.email = $1 OR u.login = $1`,
     [email]
   )
   if (result.rows.length === 0) return null

--- a/e2e/cypress/plugins/db-tasks/virkailija.ts
+++ b/e2e/cypress/plugins/db-tasks/virkailija.ts
@@ -1,83 +1,15 @@
-import { randomUUID } from 'crypto'
 import type { Client } from 'pg'
 import { dbClient, withDb } from './db-client'
+import {
+  fetchUserIdsByEmailOrLogin,
+  ensureUserAuthority,
+  createVerificationToken,
+  createUserWithRole,
+  cleanupUser,
+} from './user-utils'
+import { ensureYliopistoLink } from './kayttaja-utils'
 
 const ROLE = 'ROLE_OPINTOHALLINNON_VIRKAILIJA'
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-async function fetchVirkalijaIds(
-  client: Client,
-  email: string
-): Promise<{ userId: string; kayttajaId: number } | null> {
-  const result = await client.query(
-    `SELECT u.id AS user_id, k.id AS kayttaja_id
-     FROM jhi_user u
-     LEFT JOIN kayttaja k ON k.user_id = u.id
-     WHERE u.email = $1`,
-    [email]
-  )
-  if (result.rows.length === 0) return null
-  return { userId: result.rows[0].user_id, kayttajaId: result.rows[0].kayttaja_id }
-}
-
-async function ensureYliopistoLink(client: Client, kayttajaId: number): Promise<void> {
-  await client.query(
-    `INSERT INTO rel_kayttaja__yliopisto (kayttaja_id, yliopisto_id)
-     VALUES ($1, 1) ON CONFLICT DO NOTHING`,
-    [kayttajaId]
-  )
-}
-
-async function ensureUserAuthority(client: Client, userId: string): Promise<void> {
-  await client.query(
-    `INSERT INTO jhi_user_authority (user_id, authority_name)
-     VALUES ($1, $2) ON CONFLICT DO NOTHING`,
-    [userId, ROLE]
-  )
-}
-
-async function createVerificationToken(client: Client, userId: string): Promise<string> {
-  const token = randomUUID()
-  await client.query(`DELETE FROM verification_token WHERE user_id = $1`, [userId])
-  await client.query(
-    `INSERT INTO verification_token (id, user_id) VALUES ($1, $2)`,
-    [token, userId]
-  )
-  return token
-}
-
-async function createVirkalijaUser(
-  client: Client,
-  email: string,
-  etunimi: string,
-  sukunimi: string
-): Promise<number> {
-  const userId = randomUUID()
-  const nimi = `${etunimi} ${sukunimi}`
-
-  await client.query(
-    `INSERT INTO jhi_user
-       (id, login, first_name, last_name, email, activated, lang_key,
-        created_by, last_modified_by, active_authority)
-     VALUES ($1,$2,$3,$4,$5,true,'fi','system','system',$6)`,
-    [userId, email, etunimi, sukunimi, email, ROLE]
-  )
-  await ensureUserAuthority(client, userId)
-
-  const kayttajaId: number = (
-    await client.query(
-      `INSERT INTO kayttaja (nimike, user_id, tila)
-       VALUES ($1,$2,'AKTIIVINEN')
-       RETURNING id`,
-      [nimi, userId]
-    )
-  ).rows[0].id
-
-  await ensureYliopistoLink(client, kayttajaId)
-
-  return kayttajaId
-}
 
 // ─── Exported tasks ───────────────────────────────────────────────────────────
 
@@ -90,55 +22,57 @@ async function createVirkalijaUser(
  */
 export const virkailijaTasks = {
   async 'db:seedVirkailija'({
-                              email,
-                              etunimi,
-                              sukunimi,
-                            }: {
+    email,
+    etunimi,
+    sukunimi,
+  }: {
     email: string
     etunimi: string
     sukunimi: string
   }): Promise<{ kayttajaId: number; token?: string } | null> {
-    return withDb(dbClient, async (client: any) => {
-      // Virkailijan auktorisointi edellyttää, että rooli löytyy jhi_authority-taulusta
+    return withDb(dbClient, async (client: Client) => {
       await client.query(
         `INSERT INTO jhi_authority (name) VALUES ($1) ON CONFLICT DO NOTHING`,
         [ROLE]
       )
 
-      const existing = await fetchVirkalijaIds(client, email)
-
+      const existing = await fetchUserIdsByEmailOrLogin(client, email)
       if (existing) {
-        // User already exists — ensure both the yliopisto link and authority row
-        // are present in case a previous partial run left them missing.
         await ensureYliopistoLink(client, existing.kayttajaId)
-        await ensureUserAuthority(client, existing.userId)
+        await ensureUserAuthority(client, existing.userId, ROLE)
         return { kayttajaId: existing.kayttajaId }
       }
 
-      const kayttajaId = await createVirkalijaUser(client, email, etunimi, sukunimi)
-      const created = await fetchVirkalijaIds(client, email)
+      const kayttajaId = await createUserWithRole(client, {
+        email,
+        etunimi,
+        sukunimi,
+        role: ROLE,
+        linkFn: ensureYliopistoLink,
+      })
+      const created = await fetchUserIdsByEmailOrLogin(client, email)
       const token = await createVerificationToken(client, created!.userId)
       return { kayttajaId, token }
     })
   },
 
   async 'db:cleanupVirkailija'({ email }: { email: string }): Promise<null> {
-    return withDb(dbClient, async (client: any) => {
-      const ids = await fetchVirkalijaIds(client, email)
+    return withDb(dbClient, async (client: Client) => {
+      const ids = await fetchUserIdsByEmailOrLogin(client, email)
       if (!ids) return null
       const { userId, kayttajaId } = ids
-
-      if (kayttajaId) {
-        await client.query(
-          `DELETE FROM rel_kayttaja__yliopisto WHERE kayttaja_id = $1`,
-          [kayttajaId]
-        )
-        await client.query(`DELETE FROM kayttaja WHERE id = $1`, [kayttajaId])
-      }
-
-      await client.query(`DELETE FROM verification_token WHERE user_id = $1`, [userId])
-      await client.query(`DELETE FROM jhi_user_authority WHERE user_id = $1`, [userId])
-      await client.query(`DELETE FROM jhi_user WHERE id = $1`, [userId])
+      // Clean up link and user
+      await cleanupUser(
+        client,
+        userId,
+        kayttajaId,
+        async (client, kayttajaId) => {
+          await client.query(
+            `DELETE FROM rel_kayttaja__yliopisto WHERE kayttaja_id = $1`,
+            [kayttajaId]
+          )
+        }
+      )
       return null
     })
   },

--- a/e2e/cypress/support/commands/api.ts
+++ b/e2e/cypress/support/commands/api.ts
@@ -1,0 +1,28 @@
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Makes an API request with XSRF token automatically included.
+       * @param options Partial<Cypress.RequestOptions>
+       */
+      apiRequest(options: Partial<Cypress.RequestOptions>): Chainable<any>
+    }
+  }
+}
+
+// ── apiRequest ───────────────────────────────────────────────────────────────
+Cypress.Commands.add('apiRequest', (options: Partial<Cypress.RequestOptions>) => {
+  return cy.getCookie('XSRF-TOKEN').then((cookie) =>
+    cy.request({
+      ...options,
+      headers: {
+        'X-XSRF-TOKEN': decodeURIComponent(cookie?.value ?? ''),
+        ...(options.headers ?? {}),
+      },
+    })
+  )
+})
+
+export {}
+

--- a/e2e/cypress/support/commands/auth.ts
+++ b/e2e/cypress/support/commands/auth.ts
@@ -33,7 +33,7 @@ declare global {
        * Intended for use after the kouluttaja has been seeded via db:seedKouluttaja
        * and their account activated via the verification-token invite flow.
        */
-      loginAsKouluttaja(): void
+      loginAsKouluttaja(token?: string): void
 
       loginAsVastuuhenkilo(token?: string): void
 
@@ -93,13 +93,13 @@ Cypress.Commands.add('loginAsErikoistuva', () => {
 })
 
 // ── loginAsKouluttaja ────────────────────────────────────────────────────────
-Cypress.Commands.add('loginAsKouluttaja', () => {
+Cypress.Commands.add('loginAsKouluttaja', (token?: string) => {
   cy.session(
-    'kouluttaja',
+    ['kouluttaja', token ?? 'linked'],
     () => {
       // The kouluttaja account must have been pre-seeded via db:seedKouluttaja and
       // linked to this SSN through the verification-token invite flow beforehand.
-      cy.loginWithSuomifi(SSN_KOULUTTAJA)
+      cy.loginWithSuomifi(SSN_KOULUTTAJA, undefined, token)
       cy.location('origin', { timeout: 60000 }).should(
         'eq',
         new URL(Cypress.config('baseUrl') as string).origin

--- a/e2e/cypress/support/commands/credentials.ts
+++ b/e2e/cypress/support/commands/credentials.ts
@@ -3,7 +3,7 @@ export const E2E_ERIKOISTUVA_EMAIL = 'e2e-erikoistuva@test.elsa'
 export const SSN_ERIKOISTUVA = '210281-9988'
 
 // Kouluttajan SSN (Suomi.fi-tunnistautumista varten – varalla)
-export const SSN_KOULUTTAJA = '150685-100N'
+export const SSN_KOULUTTAJA = '190956-9974'
 export const SSN_VASTUUHENKILO = '010190-900P'
 export const SSN_VIRKAILIJA = '031084-999W'
 

--- a/e2e/cypress/support/commands/index.ts
+++ b/e2e/cypress/support/commands/index.ts
@@ -2,4 +2,4 @@ export { E2E_ERIKOISTUVA_EMAIL } from './credentials'
 
 import './auth'
 import './ui'
-
+import './api'

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/pg": "^8.11.0",
-    "cypress": "^15.13.0",
+    "cypress": "^15.14.0",
     "pg": "^8.13.0",
     "typescript": "^6.0.0"
   }

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -72,37 +72,34 @@
   dependencies:
     "@types/node" "*"
 
-aggregate-error@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
-  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
+ansi-escapes@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
+  integrity sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==
   dependencies:
-    clean-stack "^2.0.0"
-    indent-string "^4.0.0"
-
-ansi-colors@^4.1.1:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
-  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
-
-ansi-escapes@^4.3.0:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
-  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
-  dependencies:
-    type-fest "^0.21.3"
+    environment "^1.0.0"
 
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
+
+ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^6.2.1, ansi-styles@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 arch@^2.2.0:
   version "2.2.0"
@@ -120,11 +117,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
-
-astral-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
-  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -181,7 +173,7 @@ buffer@^5.7.1:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-cachedir@^2.3.0:
+cachedir@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.4.0.tgz#7fef9cf7367233d7c88068fe6e34ed0d355a610d"
   integrity sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==
@@ -220,17 +212,12 @@ ci-info@^4.1.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.4.0.tgz#7d54eff9f54b45b62401c26032696eb59c8bd18c"
   integrity sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==
 
-clean-stack@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
-  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
-
-cli-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
-  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+cli-cursor@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
+  integrity sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==
   dependencies:
-    restore-cursor "^3.1.0"
+    restore-cursor "^5.0.0"
 
 cli-table3@0.6.1:
   version "0.6.1"
@@ -241,13 +228,13 @@ cli-table3@0.6.1:
   optionalDependencies:
     colors "1.4.0"
 
-cli-truncate@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
-  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
+cli-truncate@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-5.2.0.tgz#c8e72aaca8339c773d128c36e0a17c6315b694eb"
+  integrity sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==
   dependencies:
-    slice-ansi "^3.0.0"
-    string-width "^4.2.0"
+    slice-ansi "^8.0.0"
+    string-width "^8.2.0"
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -261,7 +248,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^2.0.16:
+colorette@^2.0.20:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
@@ -302,10 +289,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@^15.13.0:
-  version "15.13.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.13.0.tgz#e3c5487efd815e7f1e6f0ec76e4f7b4f9fe7cd21"
-  integrity sha512-hJ9sY++TUC/HlUzHVJpIrDyqKMjlhx5PTXl/A7eA91JNEtUWkJAqefQR5mo9AtLra/9+m+JJaMg2U5Qd0a74Fw==
+cypress@^15.14.0:
+  version "15.14.2"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.14.2.tgz#3890ec5a2340480ec055732cd28cf9983ea846e9"
+  integrity sha512-xMWg/iEImeIThRQZdnf3BFJT1a84apM/R91Feoa4vVWGuYWDphMT5jLhRVTBVlCgi+6axegF1zqhNyjhug2SsQ==
   dependencies:
     "@cypress/request" "^3.0.10"
     "@cypress/xvfb" "^1.2.4"
@@ -316,25 +303,22 @@ cypress@^15.13.0:
     blob-util "^2.0.2"
     bluebird "^3.7.2"
     buffer "^5.7.1"
-    cachedir "^2.3.0"
+    cachedir "^2.4.0"
     chalk "^4.1.0"
     ci-info "^4.1.0"
-    cli-cursor "^3.1.0"
     cli-table3 "0.6.1"
     commander "^6.2.1"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
     debug "^4.3.4"
-    enquirer "^2.3.6"
     eventemitter2 "6.4.7"
     execa "4.1.0"
     executable "^4.1.1"
     extract-zip "2.0.1"
-    figures "^3.2.0"
     fs-extra "^9.1.0"
     hasha "5.2.2"
     is-installed-globally "~0.4.0"
-    listr2 "^3.8.3"
+    listr2 "^9.0.5"
     lodash "^4.17.23"
     log-symbols "^4.0.0"
     minimist "^1.2.8"
@@ -399,6 +383,11 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+emoji-regex@^10.3.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
+  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -411,13 +400,10 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enquirer@^2.3.6:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.4.1.tgz#93334b3fbd74fc7097b224ab4a8fb7e40bf4ae56"
-  integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==
-  dependencies:
-    ansi-colors "^4.1.1"
-    strip-ansi "^6.0.1"
+environment@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
 es-define-property@^1.0.1:
   version "1.0.1"
@@ -446,15 +432,15 @@ es-set-tostringtag@^2.1.0:
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
 
-escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
-
 eventemitter2@6.4.7:
   version "6.4.7"
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
   integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
+
+eventemitter3@^5.0.1:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
+  integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
 
 execa@4.1.0:
   version "4.1.0"
@@ -511,13 +497,6 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
-figures@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
-  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
-  dependencies:
-    escape-string-regexp "^1.0.5"
-
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -548,6 +527,11 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+get-east-asian-width@^1.0.0, get-east-asian-width@^1.3.1, get-east-asian-width@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz#216900f91df11a8b2c198c3e1d93d6c035a776b9"
+  integrity sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==
 
 get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
@@ -655,11 +639,6 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-indent-string@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
-  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
-
 ini@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
@@ -669,6 +648,13 @@ is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+is-fullwidth-code-point@^5.0.0, is-fullwidth-code-point@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz#046b2a6d4f6b156b2233d3207d4b5a9783999b98"
+  integrity sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==
+  dependencies:
+    get-east-asian-width "^1.3.1"
 
 is-installed-globally@~0.4.0:
   version "0.4.0"
@@ -742,19 +728,17 @@ jsprim@^2.0.2:
     json-schema "0.4.0"
     verror "1.10.0"
 
-listr2@^3.8.3:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.14.0.tgz#23101cc62e1375fd5836b248276d1d2b51fdbe9e"
-  integrity sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==
+listr2@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-9.0.5.tgz#92df7c4416a6da630eb9ef46da469b70de97b316"
+  integrity sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==
   dependencies:
-    cli-truncate "^2.1.0"
-    colorette "^2.0.16"
-    log-update "^4.0.0"
-    p-map "^4.0.0"
-    rfdc "^1.3.0"
-    rxjs "^7.5.1"
-    through "^2.3.8"
-    wrap-ansi "^7.0.0"
+    cli-truncate "^5.0.0"
+    colorette "^2.0.20"
+    eventemitter3 "^5.0.1"
+    log-update "^6.1.0"
+    rfdc "^1.4.1"
+    wrap-ansi "^9.0.0"
 
 lodash.once@^4.1.1:
   version "4.1.1"
@@ -774,15 +758,16 @@ log-symbols@^4.0.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
-log-update@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
-  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
+log-update@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-6.1.0.tgz#1a04ff38166f94647ae1af562f4bd6a15b1b7cd4"
+  integrity sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==
   dependencies:
-    ansi-escapes "^4.3.0"
-    cli-cursor "^3.1.0"
-    slice-ansi "^4.0.0"
-    wrap-ansi "^6.2.0"
+    ansi-escapes "^7.0.0"
+    cli-cursor "^5.0.0"
+    slice-ansi "^7.1.0"
+    strip-ansi "^7.1.0"
+    wrap-ansi "^9.0.0"
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -810,6 +795,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mimic-function@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
+  integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
 minimist@^1.2.8:
   version "1.2.8"
@@ -847,17 +837,17 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
+onetime@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
+  integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
+  dependencies:
+    mimic-function "^5.0.0"
+
 ospath@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
   integrity sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==
-
-p-map@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
-  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
-  dependencies:
-    aggregate-error "^3.0.0"
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
@@ -994,25 +984,18 @@ request-progress@^3.0.0:
   dependencies:
     throttleit "^1.0.0"
 
-restore-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
-  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+restore-cursor@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
+  integrity sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==
   dependencies:
-    onetime "^5.1.0"
-    signal-exit "^3.0.2"
+    onetime "^7.0.0"
+    signal-exit "^4.1.0"
 
-rfdc@^1.3.0:
+rfdc@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
-
-rxjs@^7.5.1:
-  version "7.8.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
-  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
-  dependencies:
-    tslib "^2.1.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.1"
@@ -1081,23 +1064,26 @@ signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-slice-ansi@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
-  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
+signal-exit@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-slice-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
-  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+slice-ansi@^7.1.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-7.1.2.tgz#adf7be70aa6d72162d907cd0e6d5c11f507b5403"
+  integrity sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==
   dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
+    ansi-styles "^6.2.1"
+    is-fullwidth-code-point "^5.0.0"
+
+slice-ansi@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-8.0.0.tgz#22d0b66d18bc5c57f488bfcf36cbde3bef731537"
+  integrity sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==
+  dependencies:
+    ansi-styles "^6.2.3"
+    is-fullwidth-code-point "^5.1.0"
 
 split2@^4.1.0:
   version "4.2.0"
@@ -1119,7 +1105,7 @@ sshpk@^1.18.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1128,12 +1114,36 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+string-width@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
+  dependencies:
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
+
+string-width@^8.2.0:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-8.2.1.tgz#165089cfa527cc88fbc23dd73313f5e334af1ea1"
+  integrity sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==
+  dependencies:
+    get-east-asian-width "^1.5.0"
+    strip-ansi "^7.1.2"
+
+strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.1.0, strip-ansi@^7.1.2:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
 
 strip-final-newline@^2.0.0:
   version "2.0.0"
@@ -1163,11 +1173,6 @@ throttleit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.1.tgz#304ec51631c3b770c65c6c6f76938b384000f4d5"
   integrity sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==
-
-through@^2.3.8:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
 tldts-core@^6.1.86:
   version "6.1.86"
@@ -1203,11 +1208,6 @@ tslib@1.14.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -1219,11 +1219,6 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
-
-type-fest@^0.21.3:
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
-  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.8.0:
   version "0.8.1"
@@ -1271,23 +1266,14 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wrap-ansi@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
-  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+wrap-ansi@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
+  integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
   dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This pull request refactors and enhances the end-to-end (E2E) test setup for the "koulutussopimus" (training agreement) process, making the test data seeding more robust and modular. The main focus is on improving test reliability and maintainability by extracting and reusing user management utilities, as well as expanding the E2E test to cover the full approval workflow involving multiple user roles.

**Key improvements and refactoring:**

**E2E test enhancements:**
- Expanded the E2E test (`koulutussopimus.cy.ts`) to cover the full training agreement process, including the erikoistuja (trainee) submitting the agreement, and both the kouluttaja (trainer) and vastuuhenkilo (responsible person) approving it via API calls using verification tokens. This ensures the end-to-end flow is tested as it occurs in production. [[1]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0L6-R38) [[2]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0R48-R64) [[3]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0L54-R77) [[4]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0R89-R90) [[5]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0L110-R135) [[6]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0L119-R155) [[7]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0R166-R236)

**Test data seeding and cleanup refactoring:**
- Extracted common user management functions (fetch, create, authority assignment, verification token generation, and cleanup) into a shared utility module `user-utils.ts`, and reused these in both the `kouluttaja` and `vastuuhenkilo` database task modules. This reduces code duplication and ensures consistency across user roles. [[1]](diffhunk://#diff-7ed9b6e3c561d57d1510c198063d345fdcf4effab365afff94b882fa99133a91R1-R102) [[2]](diffhunk://#diff-0e3cc173a9554ea2ab6cab39a5cc1b581427c0b4955f9dd6febf35859de580e6L1-R12) [[3]](diffhunk://#diff-9515ab15c7646d375c30845442a1cb0d0f64374f809c121100959d45600b85b0L1-R20) [[4]](diffhunk://#diff-9515ab15c7646d375c30845442a1cb0d0f64374f809c121100959d45600b85b0L71-L120)
- Simplified and centralized the logic for linking users to "yliopisto" (university) and "erikoisala" (specialty) in `kayttaja-utils.ts`, making the seeding process more reliable and idempotent.

**Database cleanup improvements:**
- Improved cleanup functions for test users to ensure all related data (including verification tokens and authorities) are removed, preventing test data leakage between runs. [[1]](diffhunk://#diff-0e3cc173a9554ea2ab6cab39a5cc1b581427c0b4955f9dd6febf35859de580e6L93-R70) [[2]](diffhunk://#diff-0e3cc173a9554ea2ab6cab39a5cc1b581427c0b4955f9dd6febf35859de580e6L142-R87)

These changes make the E2E tests more robust, easier to maintain, and better aligned with real-world workflows.

**References:**  
[[1]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0L6-R38) [[2]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0R48-R64) [[3]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0L54-R77) [[4]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0R89-R90) [[5]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0L110-R135) [[6]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0L119-R155) [[7]](diffhunk://#diff-5c5701ad4aec96045279b92379503620f224dfa1a04136142f43efdc8a7e27c0R166-R236) [[8]](diffhunk://#diff-047872286615a0d064171399f3e50a7e187474e5d663197794983607fdad5ac7R1-R26) [[9]](diffhunk://#diff-0e3cc173a9554ea2ab6cab39a5cc1b581427c0b4955f9dd6febf35859de580e6L1-R12) [[10]](diffhunk://#diff-0e3cc173a9554ea2ab6cab39a5cc1b581427c0b4955f9dd6febf35859de580e6L93-R70) [[11]](diffhunk://#diff-0e3cc173a9554ea2ab6cab39a5cc1b581427c0b4955f9dd6febf35859de580e6L142-R87) [[12]](diffhunk://#diff-7ed9b6e3c561d57d1510c198063d345fdcf4effab365afff94b882fa99133a91R1-R102) [[13]](diffhunk://#diff-9515ab15c7646d375c30845442a1cb0d0f64374f809c121100959d45600b85b0L1-R20) [[14]](diffhunk://#diff-9515ab15c7646d375c30845442a1cb0d0f64374f809c121100959d45600b85b0L71-L120)