### PR TITLE
ELSAINSI-41 Sähköposti on lähetettävä vasta, kun transaktio on suoritettu onnistuneesti

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/MailService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/MailService.kt
@@ -67,9 +67,9 @@ class MailService(
                 setText(content, isHtml)
             }
             javaMailSender.send(mimeMessage)
-            log.info("Sent email to User '$to'")
+            log.info("Sent email to User $to subject: $subject")
         } catch (ex: Exception) {
-            log.error("Email could not be sent to user '$to'", ex)
+            log.error("Email could not be sent to user $to subject: $subject", ex)
         }
     }
 
@@ -83,7 +83,7 @@ class MailService(
         properties: Map<MailProperty, String>
     ) {
         if (user.email == null) {
-            log.debug("Sähköpostiosoitetta ei löydy käyttäjälle '${user.login}'")
+            log.info("Sähköpostiosoitetta ei löydy käyttäjälle '${user.login}'")
             return
         }
         var locale = Locale.forLanguageTag("fi")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/MailService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/MailService.kt
@@ -67,11 +67,9 @@ class MailService(
                 setText(content, isHtml)
             }
             javaMailSender.send(mimeMessage)
-            log.debug("Sent email to User '$to'")
-        } catch (ex: MailException) {
-            log.warn("Email could not be sent to user '$to': ${ex.message}")
-        } catch (ex: MessagingException) {
-            log.warn("Email could not be sent to user '$to': ${ex.message}")
+            log.info("Sent email to User '$to'")
+        } catch (ex: Exception) {
+            log.error("Email could not be sent to user '$to'", ex)
         }
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
@@ -63,7 +63,6 @@ class ValmistumispyyntoServiceImpl(
     private val tyoskentelyjaksoRepository: TyoskentelyjaksoRepository,
     private val tyoskentelyjaksoMapper: TyoskentelyjaksoMapper,
     private val opintosuoritusRepository: OpintosuoritusRepository,
-    private val mailService: MailService,
     private val transactionalMailService: TransactionalMailService,
     private val applicationProperties: ApplicationProperties,
     private val clock: Clock,
@@ -971,7 +970,7 @@ class ValmistumispyyntoServiceImpl(
         vastuuhenkiloOsaamisenArvioijaUser: User,
         valmistumispyynto: Valmistumispyynto
     ) {
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             vastuuhenkiloOsaamisenArvioijaUser,
             templateName = "uusivalmistumispyynto.html",
             titleKey = "email.uusivalmistumispyynto.title",
@@ -988,7 +987,7 @@ class ValmistumispyyntoServiceImpl(
         erikoistujanYliopisto: YliopistoEnum,
         valmistumispyyntoId: Long
     ) {
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             to = erikoistujanYliopisto.getOpintohallintoEmailAddress(applicationProperties),
             templateName = "valmistumispyyntoTarkastettavissa.html",
             titleKey = "email.valmistumispyyntoTarkastettavissa.title",
@@ -1000,7 +999,7 @@ class ValmistumispyyntoServiceImpl(
         erikoistujanYliopisto: YliopistoEnum,
         valmistumispyyntoId: Long
     ) {
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             to = erikoistujanYliopisto.getOpintohallintoEmailAddress(applicationProperties),
             templateName = "valmistumispyyntoTarkastettavissaYek.html",
             titleKey = "email.yekValmistumispyyntoTarkastettavissa.title",
@@ -1012,7 +1011,7 @@ class ValmistumispyyntoServiceImpl(
         valmistumispyynto: Valmistumispyynto
     ) {
         val opintooikeus = valmistumispyynto.opintooikeus
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             getVastuuhenkiloHyvaksyja(opintooikeus?.yliopisto?.id!!, opintooikeus.erikoisala?.id!!).user!!,
             templateName = "valmistumispyyntoTarkastettavissaVastuuhenkilo.html",
             titleKey = "email.valmistumispyyntoTarkastettavissaVastuuhenkilo.title",
@@ -1024,7 +1023,7 @@ class ValmistumispyyntoServiceImpl(
         valmistumispyynto: Valmistumispyynto
     ) {
         val opintooikeus = valmistumispyynto.opintooikeus
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             getVastuuhenkiloHyvaksyja(opintooikeus?.yliopisto?.id!!, opintooikeus.erikoisala?.id!!).user!!,
             templateName = "valmistumispyyntoTarkastettavissaYek.html",
             titleKey = "email.yekValmistumispyyntoTarkastettavissa.title",
@@ -1035,7 +1034,7 @@ class ValmistumispyyntoServiceImpl(
     private fun sendMailNotificationOsaamisenArvioijaPalauttanut(
         valmistumispyynto: Valmistumispyynto
     ) {
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user!!,
             templateName = "valmistumispyyntoPalautettuErikoistuja.html",
             titleKey = "email.valmistumispyyntoPalautettuErikoistuja.title",
@@ -1046,7 +1045,7 @@ class ValmistumispyyntoServiceImpl(
     private fun sendMailNotificationVirkailijaPalauttanut(
         valmistumispyynto: Valmistumispyynto
     ) {
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user!!,
             templateName = "valmistumispyyntoPalautettuErikoistuja.html",
             titleKey = "email.valmistumispyyntoPalautettuErikoistuja.title",
@@ -1057,7 +1056,7 @@ class ValmistumispyyntoServiceImpl(
     private fun sendMailNotificationHyvaksyjaPalauttanut(
         valmistumispyynto: Valmistumispyynto
     ) {
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user!!,
             templateName = "valmistumispyyntoPalautettuErikoistuja.html",
             titleKey = "email.valmistumispyyntoPalautettuErikoistuja.title",
@@ -1067,7 +1066,7 @@ class ValmistumispyyntoServiceImpl(
         val nimi = valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.getNimi()
 
         if (valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID) {
-            mailService.sendEmailFromTemplate(
+            transactionalMailService.sendEmailFromTemplate(
                 valmistumispyynto.opintooikeus?.yliopisto?.nimi?.getOpintohallintoEmailAddress(applicationProperties),
                 templateName = "valmistumispyyntoPalautettuMuutYek.html",
                 titleKey = "email.valmistumispyyntoPalautettuMuut.title",
@@ -1075,7 +1074,7 @@ class ValmistumispyyntoServiceImpl(
                 properties = mapOf(Pair(MailProperty.NAME, nimi.toString()))
             )
         } else {
-            mailService.sendEmailFromTemplate(
+            transactionalMailService.sendEmailFromTemplate(
                 valmistumispyynto.opintooikeus?.yliopisto?.nimi?.getOpintohallintoEmailAddress(applicationProperties),
                 templateName = "valmistumispyyntoPalautettuMuut.html",
                 titleKey = "email.valmistumispyyntoPalautettuMuut.title",

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
@@ -25,6 +25,7 @@ import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonHyvaksyjaRole
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
+import fi.elsapalvelu.elsa.service.mail.TransactionalMailService
 import fi.elsapalvelu.elsa.service.mapper.*
 import jakarta.persistence.EntityNotFoundException
 import org.slf4j.LoggerFactory
@@ -63,6 +64,7 @@ class ValmistumispyyntoServiceImpl(
     private val tyoskentelyjaksoMapper: TyoskentelyjaksoMapper,
     private val opintosuoritusRepository: OpintosuoritusRepository,
     private val mailService: MailService,
+    private val transactionalMailService: TransactionalMailService,
     private val applicationProperties: ApplicationProperties,
     private val clock: Clock,
     private val valmistumispyynnonTarkistusRepository: ValmistumispyynnonTarkistusRepository,
@@ -1086,14 +1088,14 @@ class ValmistumispyyntoServiceImpl(
     private fun sendMailNotificationHyvaksytty(
         valmistumispyynto: Valmistumispyynto
     ) {
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user!!,
             templateName = "valmistumispyyntoHyvaksytty.html",
             titleKey = "email.valmistumispyyntoHyvaksytty.title",
             properties = mapOf()
         )
 
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             valmistumispyynto.opintooikeus?.yliopisto?.nimi?.getOpintohallintoEmailAddress(applicationProperties),
             templateName = "valmistumispyyntoHyvaksyttyVirkailija.html",
             titleKey = "email.valmistumispyyntoHyvaksytty.title",
@@ -1106,14 +1108,14 @@ class ValmistumispyyntoServiceImpl(
     private fun sendMailNotificationHyvaksyttyYek(
         valmistumispyynto: Valmistumispyynto
     ) {
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user!!,
             templateName = "valmistumispyyntoHyvaksyttyYek.html",
             titleKey = "email.yekValmistumispyyntoHyvaksytty.title",
             properties = mapOf()
         )
 
-        mailService.sendEmailFromTemplate(
+        transactionalMailService.sendEmailFromTemplate(
             valmistumispyynto.opintooikeus?.yliopisto?.nimi?.getOpintohallintoEmailAddress(applicationProperties),
             templateName = "valmistumispyyntoHyvaksyttyYekVirkailija.html",
             titleKey = "email.yekValmistumispyyntoHyvaksytty.title",

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/mail/TransactionalMailService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/mail/TransactionalMailService.kt
@@ -1,0 +1,58 @@
+package fi.elsapalvelu.elsa.service.mail
+
+import fi.elsapalvelu.elsa.domain.User
+import fi.elsapalvelu.elsa.service.MailProperty
+import fi.elsapalvelu.elsa.service.MailService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+
+@Service
+class TransactionalMailService(
+    private val mailService: MailService
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun sendEmailFromTemplate(
+        user: User,
+        cc: List<String>? = listOf(),
+        templateName: String,
+        titleKey: String,
+        titleProperties: Array<String> = emptyArray(),
+        properties: Map<MailProperty, String>
+    ) = afterCommit {
+        mailService.sendEmailFromTemplate(user, cc, templateName, titleKey, titleProperties, properties)
+    }
+
+    fun sendEmailFromTemplate(
+        to: String?,
+        cc: List<String>? = listOf(),
+        templateName: String,
+        titleKey: String,
+        titleProperties: Array<String> = emptyArray(),
+        properties: Map<MailProperty, String>
+    ) = afterCommit {
+        mailService.sendEmailFromTemplate(to, cc, templateName, titleKey, titleProperties, properties)
+    }
+
+    fun sendFeedbackEmail(
+        to: String,
+        cc: List<String>? = listOf(),
+        templateName: String,
+        properties: Map<MailProperty, String>
+    ) = afterCommit {
+        mailService.sendFeedbackEmail(to, cc, templateName, properties)
+    }
+
+    private fun afterCommit(action: () -> Unit) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+                override fun afterCommit() = action()
+            })
+        } else {
+            log.debug("No active transaction, sending mail immediately")
+            action()
+        }
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/ValmistumispyyntoHyvaksyntaArkistointiIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/ValmistumispyyntoHyvaksyntaArkistointiIT.kt
@@ -4,6 +4,9 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fi.elsapalvelu.elsa.ElsaBackendApp
 import fi.elsapalvelu.elsa.domain.*
@@ -14,6 +17,7 @@ import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI
 import fi.elsapalvelu.elsa.security.OPINTOHALLINNON_VIRKAILIJA
 import fi.elsapalvelu.elsa.security.VASTUUHENKILO
 import fi.elsapalvelu.elsa.service.ArkistointiService
+import fi.elsapalvelu.elsa.service.MailService
 import fi.elsapalvelu.elsa.service.PdfService
 import fi.elsapalvelu.elsa.service.dto.ValmistumispyyntoHyvaksyntaFormDTO
 import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
@@ -89,6 +93,10 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
      */
     @MockitoBean
     private lateinit var pdfService: PdfService
+
+    @MockitoBean
+    private lateinit var mailService: MailService
+
 
     private lateinit var opintooikeus: Opintooikeus
     private lateinit var vastuuhenkilo: Kayttaja
@@ -182,6 +190,11 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
         val tarkistus = ValmistumispyynnonTarkistusHelper.createValmistumispyynnonTarkistusOdottaaHyvaksyntaa(valmistumispyynto)
         em.persist(tarkistus)
 
+        // Link tarkistus to valmistumispyynto to ensure the entity graph is correct
+        valmistumispyynto.valmistumispyynnonTarkistus = tarkistus
+        em.persist(valmistumispyynto)
+        em.flush()
+
         val sizeBefore = valmistumispyyntoRepository.findAll().size
 
         whenever(arkistointiService.onKaytossa(any(), any())).thenReturn(false)
@@ -201,6 +214,23 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
         assertThat(updated.vastuuhenkiloHyvaksyjaKuittausaika).isEqualTo(LocalDate.now())
         assertThat(updated.vastuuhenkiloHyvaksyjaPalautusaika).isNull()
         assertThat(updated.vastuuhenkiloHyvaksyjaKorjausehdotus).isNull()
+
+        verify(mailService).sendEmailFromTemplate(
+            any<User>(),
+            any<List<String>>(),
+            eq("valmistumispyyntoHyvaksytty.html"),
+            eq("email.valmistumispyyntoHyvaksytty.title"),
+            any<Array<String>>(),
+            any()
+        )
+        verify(mailService).sendEmailFromTemplate(
+            anyOrNull<String>(),
+            any<List<String>>(),
+            eq("valmistumispyyntoHyvaksyttyVirkailija.html"),
+            eq("email.valmistumispyyntoHyvaksytty.title"),
+            any<Array<String>>(),
+            any()
+        )
     }
 
     // -------------------------------------------------------------------------
@@ -307,6 +337,23 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
                     "must be null after archiving failure — data integrity is at risk if not null"
                 )
                 .isNull()
+
+            verify(mailService).sendEmailFromTemplate(
+                any<User>(),
+                any<List<String>>(),
+                eq("valmistumispyyntoHyvaksytty.html"),
+                eq("email.valmistumispyyntoHyvaksytty.title"),
+                any<Array<String>>(),
+                any()
+            )
+            verify(mailService).sendEmailFromTemplate(
+                anyOrNull<String>(),
+                any<List<String>>(),
+                eq("valmistumispyyntoHyvaksyttyVirkailija.html"),
+                eq("email.valmistumispyyntoHyvaksytty.title"),
+                any<Array<String>>(),
+                any()
+            )
         } finally {
             resourceLogger.detachAppender(logAppender)
         }
@@ -391,6 +438,23 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
             assertThat(dbState.get().vastuuhenkiloHyvaksyjaKuittausaika)
                 .withFailMessage("Transaction must roll back even when a JVM Error is thrown")
                 .isNull()
+
+            verify(mailService).sendEmailFromTemplate(
+                any<User>(),
+                any<List<String>>(),
+                eq("valmistumispyyntoHyvaksytty.html"),
+                eq("email.valmistumispyyntoHyvaksytty.title"),
+                any<Array<String>>(),
+                any()
+            )
+            verify(mailService).sendEmailFromTemplate(
+                anyOrNull<String>(),
+                any<List<String>>(),
+                eq("valmistumispyyntoHyvaksyttyVirkailija.html"),
+                eq("email.valmistumispyyntoHyvaksytty.title"),
+                any<Array<String>>(),
+                any()
+            )
         } finally {
             adviceLogger.detachAppender(logAppender)
         }
@@ -485,4 +549,3 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
         }
     }
 }
-

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/ValmistumispyyntoHyvaksyntaArkistointiIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/ValmistumispyyntoHyvaksyntaArkistointiIT.kt
@@ -6,6 +6,7 @@ import ch.qos.logback.core.read.ListAppender
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fi.elsapalvelu.elsa.ElsaBackendApp
@@ -212,22 +213,7 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
         assertThat(updated.vastuuhenkiloHyvaksyjaPalautusaika).isNull()
         assertThat(updated.vastuuhenkiloHyvaksyjaKorjausehdotus).isNull()
 
-        verify(mailService).sendEmailFromTemplate(
-            any<User>(),
-            any<List<String>>(),
-            eq("valmistumispyyntoHyvaksytty.html"),
-            eq("email.valmistumispyyntoHyvaksytty.title"),
-            any<Array<String>>(),
-            any()
-        )
-        verify(mailService).sendEmailFromTemplate(
-            anyOrNull<String>(),
-            any<List<String>>(),
-            eq("valmistumispyyntoHyvaksyttyVirkailija.html"),
-            eq("email.valmistumispyyntoHyvaksytty.title"),
-            any<Array<String>>(),
-            any()
-        )
+        verifyEmailSent()
     }
 
     // -------------------------------------------------------------------------
@@ -317,22 +303,7 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
                 )
                 .isNull()
 
-            verify(mailService).sendEmailFromTemplate(
-                any<User>(),
-                any<List<String>>(),
-                eq("valmistumispyyntoHyvaksytty.html"),
-                eq("email.valmistumispyyntoHyvaksytty.title"),
-                any<Array<String>>(),
-                any()
-            )
-            verify(mailService).sendEmailFromTemplate(
-                anyOrNull<String>(),
-                any<List<String>>(),
-                eq("valmistumispyyntoHyvaksyttyVirkailija.html"),
-                eq("email.valmistumispyyntoHyvaksytty.title"),
-                any<Array<String>>(),
-                any()
-            )
+            verifyEmailNotSent()
         } finally {
             resourceLogger.detachAppender(logAppender)
         }
@@ -404,22 +375,7 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
                 .withFailMessage("Transaction must roll back even when a JVM Error is thrown")
                 .isNull()
 
-            verify(mailService).sendEmailFromTemplate(
-                any<User>(),
-                any<List<String>>(),
-                eq("valmistumispyyntoHyvaksytty.html"),
-                eq("email.valmistumispyyntoHyvaksytty.title"),
-                any<Array<String>>(),
-                any()
-            )
-            verify(mailService).sendEmailFromTemplate(
-                anyOrNull<String>(),
-                any<List<String>>(),
-                eq("valmistumispyyntoHyvaksyttyVirkailija.html"),
-                eq("email.valmistumispyyntoHyvaksytty.title"),
-                any<Array<String>>(),
-                any()
-            )
+            verifyEmailNotSent()
         } finally {
             adviceLogger.detachAppender(logAppender)
         }
@@ -533,5 +489,44 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
                 )
             )
         }
+    }
+
+
+    private fun verifyEmailSent() {
+        verify(mailService).sendEmailFromTemplate(
+            any<User>(),
+            any<List<String>>(),
+            eq("valmistumispyyntoHyvaksytty.html"),
+            eq("email.valmistumispyyntoHyvaksytty.title"),
+            any<Array<String>>(),
+            any()
+        )
+        verify(mailService).sendEmailFromTemplate(
+            anyOrNull<String>(),
+            any<List<String>>(),
+            eq("valmistumispyyntoHyvaksyttyVirkailija.html"),
+            eq("email.valmistumispyyntoHyvaksytty.title"),
+            any<Array<String>>(),
+            any()
+        )
+    }
+
+    private fun verifyEmailNotSent() {
+        verify(mailService, never()).sendEmailFromTemplate(
+            any<User>(),
+            any<List<String>>(),
+            any<String>(),
+            any<String>(),
+            any<Array<String>>(),
+            any()
+        )
+        verify(mailService, never()).sendEmailFromTemplate(
+            anyOrNull<String>(),
+            any<List<String>>(),
+            any<String>(),
+            any<String>(),
+            any<Array<String>>(),
+            any()
+        )
     }
 }

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/ValmistumispyyntoHyvaksyntaArkistointiIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/ValmistumispyyntoHyvaksyntaArkistointiIT.kt
@@ -139,6 +139,17 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
 
         transactionTemplate.execute {
             em.createNativeQuery("DELETE FROM valmistumispyynnon_tarkistus WHERE valmistumispyynto_id = $vpId").executeUpdate()
+            // Null out the asiakirja FK columns before deleting the asiakirja rows themselves,
+            // because valmistumispyynto has FK references (yhteenveto_asiakirja_id etc.) to asiakirja.
+            em.createNativeQuery(
+                "UPDATE valmistumispyynto SET yhteenveto_asiakirja_id = NULL, " +
+                    "liitteet_asiakirja_id = NULL, erikoistujan_tiedot_asiakirja_id = NULL " +
+                    "WHERE id = $vpId"
+            ).executeUpdate()
+            // Delete asiakirja rows created by PDF generation (which commit to DB when the test
+            // is not @Transactional). asiakirja has a FK to opintooikeus, so must be deleted
+            // before opintooikeus.
+            em.createNativeQuery("DELETE FROM asiakirja WHERE opintooikeus_id = $ooId").executeUpdate()
             em.createNativeQuery("DELETE FROM valmistumispyynto WHERE id = $vpId").executeUpdate()
             em.createNativeQuery("DELETE FROM rel_kayttaja__yliopisto WHERE yliopisto_id = $yId").executeUpdate()
             em.createNativeQuery(
@@ -178,29 +189,15 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
      * but with an explicit @MockBean so it is self-contained and documents the intended flow.
      */
     @Test
-    @Transactional
     fun updateValmistumispyyntoByHyvaksyjaUserId_happyPath_kuittausaikaSavedAndReturns200() {
-        initTest()
-
-        val valmistumispyynto = ValmistumispyyntoHelper.createValmistumispyyntoOdottaaHyvaksyntaa(
-            opintooikeus, anotherVastuuhenkilo, virkailija
-        )
-        em.persist(valmistumispyynto)
-
-        val tarkistus = ValmistumispyynnonTarkistusHelper.createValmistumispyynnonTarkistusOdottaaHyvaksyntaa(valmistumispyynto)
-        em.persist(tarkistus)
-
-        // Link tarkistus to valmistumispyynto to ensure the entity graph is correct
-        valmistumispyynto.valmistumispyynnonTarkistus = tarkistus
-        em.persist(valmistumispyynto)
-        em.flush()
+        val valmistumispyyntoId: Long = initTestInTransaction()
 
         val sizeBefore = valmistumispyyntoRepository.findAll().size
 
         whenever(arkistointiService.onKaytossa(any(), any())).thenReturn(false)
 
         restMockMvc.perform(
-            put("$ARKISTOINTI_HYVAKSYNTA_ENDPOINT/{id}", valmistumispyynto.id)
+            put("$ARKISTOINTI_HYVAKSYNTA_ENDPOINT/{id}", valmistumispyyntoId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(convertObjectToJsonBytes(ValmistumispyyntoHyvaksyntaFormDTO(null)))
                 .with(csrf())
@@ -258,25 +255,7 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
     @Test
     fun updateValmistumispyyntoByHyvaksyjaUserId_whenMuodostaSahkeThrows_returns5xxLogsErrorAndRollsBack() {
 
-        // --- Setup: run inside a dedicated transaction that is committed before the service call ---
-        // This is necessary because this test method is NOT @Transactional (by design — we need
-        // to verify the DB rollback via a fresh read after the service's own transaction fails).
-        // em.persist() requires an active transaction; TransactionTemplate provides one and commits it.
-        val valmistumispyyntoId: Long = transactionTemplate.execute {
-            initTest()
-            val valmistumispyynto = ValmistumispyyntoHelper.createValmistumispyyntoOdottaaHyvaksyntaa(
-                opintooikeus, anotherVastuuhenkilo, virkailija
-            )
-            em.persist(valmistumispyynto)
-            val tarkistus = ValmistumispyynnonTarkistusHelper.createValmistumispyynnonTarkistusOdottaaHyvaksyntaa(valmistumispyynto)
-            em.persist(tarkistus)
-            em.flush()
-            committedValmistumispyyntoId = valmistumispyynto.id!!
-            committedOpintooikeusId = opintooikeus.id
-            committedErikoistuvaLaakariId = opintooikeus.erikoistuvaLaakari?.id
-            committedYliopistoId = opintooikeus.yliopisto?.id
-            valmistumispyynto.id!!
-        }!!
+        val valmistumispyyntoId: Long = initTestInTransaction()
 
         // Capture ERROR logs from the controller (where log.error is emitted on rethrow)
         val resourceLogger = LoggerFactory.getLogger(
@@ -381,21 +360,7 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
     @Test
     fun updateValmistumispyyntoByHyvaksyjaUserId_whenMuodostaSahkeThrowsError_returns5xxLogsErrorAndRollsBack() {
 
-        val valmistumispyyntoId: Long = transactionTemplate.execute {
-            initTest()
-            val valmistumispyynto = ValmistumispyyntoHelper.createValmistumispyyntoOdottaaHyvaksyntaa(
-                opintooikeus, anotherVastuuhenkilo, virkailija
-            )
-            em.persist(valmistumispyynto)
-            val tarkistus = ValmistumispyynnonTarkistusHelper.createValmistumispyynnonTarkistusOdottaaHyvaksyntaa(valmistumispyynto)
-            em.persist(tarkistus)
-            em.flush()
-            committedValmistumispyyntoId = valmistumispyynto.id!!
-            committedOpintooikeusId = opintooikeus.id
-            committedErikoistuvaLaakariId = opintooikeus.erikoistuvaLaakari?.id
-            committedYliopistoId = opintooikeus.yliopisto?.id
-            valmistumispyynto.id!!
-        }!!
+        val valmistumispyyntoId: Long = initTestInTransaction()
 
         // BadRequestExceptionAdvice.handleError is where log.error fires for Error subclasses
         val adviceLogger = LoggerFactory.getLogger(
@@ -459,6 +424,27 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
             adviceLogger.detachAppender(logAppender)
         }
     }
+
+    private fun initTestInTransaction(): Long = transactionTemplate.execute {
+        // --- Setup: run inside a dedicated transaction that is committed before the service call ---
+        // This is necessary because this test method is NOT @Transactional (by design — we need
+        // to verify the DB rollback via a fresh read after the service's own transaction fails).
+        // em.persist() requires an active transaction; TransactionTemplate provides one and commits it.
+        initTest()
+        val valmistumispyynto = ValmistumispyyntoHelper.createValmistumispyyntoOdottaaHyvaksyntaa(
+            opintooikeus, anotherVastuuhenkilo, virkailija
+        )
+        em.persist(valmistumispyynto)
+        val tarkistus =
+            ValmistumispyynnonTarkistusHelper.createValmistumispyynnonTarkistusOdottaaHyvaksyntaa(valmistumispyynto)
+        em.persist(tarkistus)
+        em.flush()
+        committedValmistumispyyntoId = valmistumispyynto.id!!
+        committedOpintooikeusId = opintooikeus.id
+        committedErikoistuvaLaakariId = opintooikeus.erikoistuvaLaakari?.id
+        committedYliopistoId = opintooikeus.yliopisto?.id
+        valmistumispyynto.id!!
+    }!!
 
     // -------------------------------------------------------------------------
     // Setup helpers (mirrors VastuuhenkiloValmistumispyyntoResourceIT.initTest)


### PR DESCRIPTION
This pull request introduces a new `TransactionalMailService` to ensure that emails are only sent after a successful database transaction commit, and refactors the existing codebase to use this new service. Additionally, it improves logging for email operations and enhances test reliability and coverage.

### Transactional Email Sending

* Added a new `TransactionalMailService` (`src/main/kotlin/fi/elsapalvelu/elsa/service/mail/TransactionalMailService.kt`) that wraps `MailService` and registers email sending actions to occur only after a successful transaction commit. If no transaction is active, emails are sent immediately.
* Refactored `ValmistumispyyntoServiceImpl` to use `TransactionalMailService` instead of `MailService` for all email sending, ensuring emails are not sent if the transaction fails. [[1]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L65-R66) [[2]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L972-R973) [[3]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L989-R990) [[4]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L1001-R1002) [[5]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L1013-R1014) [[6]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L1025-R1026) [[7]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L1036-R1037) [[8]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L1047-R1048) [[9]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L1058-R1059) [[10]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L1068-R1077) [[11]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L1089-R1097) [[12]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L1109-R1117)

### Logging Improvements

* Changed email sending log messages in `MailService` to provide more information (including subject) and to use `info` and `error` levels instead of `debug` and `warn`. Also consolidated exception handling to catch all exceptions.
* Adjusted logging when a user does not have an email address from `debug` to `info` for better visibility.

### Testing Enhancements

* Updated integration tests to use the new `TransactionalMailService` pattern by mocking `MailService` and verifying email sending behavior, including negative cases. [[1]](diffhunk://#diff-73addb39df0614c9a59c7681bc17b432cd56bcea00438c66757e15fdb2f8acacR7-R10) [[2]](diffhunk://#diff-73addb39df0614c9a59c7681bc17b432cd56bcea00438c66757e15fdb2f8acacR21) [[3]](diffhunk://#diff-73addb39df0614c9a59c7681bc17b432cd56bcea00438c66757e15fdb2f8acacR98-R101) [[4]](diffhunk://#diff-73addb39df0614c9a59c7681bc17b432cd56bcea00438c66757e15fdb2f8acacR215-R216)
* Improved test data cleanup by nulling out foreign key references before deleting rows, preventing constraint violations and making tests more robust.
* Simplified test setup by introducing a helper function for initializing test data within a transaction. [[1]](diffhunk://#diff-73addb39df0614c9a59c7681bc17b432cd56bcea00438c66757e15fdb2f8acacL173-R201) [[2]](diffhunk://#diff-73addb39df0614c9a59c7681bc17b432cd56bcea00438c66757e15fdb2f8acacL231-R244)

These changes collectively ensure that emails related to graduation requests are sent only after all related database changes are successfully committed, improving reliability and consistency of notifications.
