### PR TITLE
Rename createWithoutOpintotietodata method and restrict usage only to development mode

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
@@ -365,7 +365,7 @@ class SecurityConfiguration(
 
                 // Lokaalissa ympäristössä luodaan uusi käyttäjä, jos sitä ei löydy.
                 if (existingUser == null && env.activeProfiles.contains(SPRING_PROFILE_DEVELOPMENT)) {
-                    opintotietodataPersistenceService.createWithoutOpintotietodata(cipher, originalKey, hetu, firstName, lastName)
+                    opintotietodataPersistenceService.createWithoutOpintotietodataOnlyDevDoNotUseInProd(cipher, originalKey, hetu, firstName, lastName)
                     existingUser = userService.findExistingUser(cipher, originalKey, hetu, null)
                 }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/OpintotietodataPersistenceService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/OpintotietodataPersistenceService.kt
@@ -15,7 +15,7 @@ interface OpintotietodataPersistenceService {
         opintotietodataDTOs: List<OpintotietodataDTO>
     )
 
-    fun createWithoutOpintotietodata(
+    fun createWithoutOpintotietodataOnlyDevDoNotUseInProd(
         cipher: Cipher,
         originalKey: SecretKey,
         hetu: String?,

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
@@ -22,8 +22,10 @@ import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
 import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
+import org.springframework.core.env.Environment
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import tech.jhipster.config.JHipsterConstants.SPRING_PROFILE_DEVELOPMENT
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -48,7 +50,8 @@ class OpintotietodataPersistenceServiceImpl(
     private val clock: Clock,
     private val opintooikeusHerateRepository: OpintooikeusHerateRepository,
     private val mailService: MailService,
-    private val applicationProperties: ApplicationProperties
+    private val applicationProperties: ApplicationProperties,
+    private val env: Environment
 ) : OpintotietodataPersistenceService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -172,9 +175,12 @@ class OpintotietodataPersistenceServiceImpl(
         }
     }
 
-    override fun createWithoutOpintotietodata(
+    override fun createWithoutOpintotietodataOnlyDevDoNotUseInProd(
         cipher: Cipher, originalKey: SecretKey, hetu: String?, etunimi: String, sukunimi: String
     ) {
+        if (!env.activeProfiles.contains(SPRING_PROFILE_DEVELOPMENT)) {
+            throw IllegalStateException("This is allowed only in DEVELOPMENT mode.")
+        }
         val erikoistuvaLaakari = createErikoistuvaLaakari(
             cipher,
             originalKey,

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImpl.kt
@@ -178,8 +178,8 @@ class OpintotietodataPersistenceServiceImpl(
     override fun createWithoutOpintotietodataOnlyDevDoNotUseInProd(
         cipher: Cipher, originalKey: SecretKey, hetu: String?, etunimi: String, sukunimi: String
     ) {
-        if (!env.activeProfiles.contains(SPRING_PROFILE_DEVELOPMENT)) {
-            throw IllegalStateException("This is allowed only in DEVELOPMENT mode.")
+        check(env.activeProfiles.contains(SPRING_PROFILE_DEVELOPMENT)) {
+            "This is allowed only in DEVELOPMENT mode."
         }
         val erikoistuvaLaakari = createErikoistuvaLaakari(
             cipher,

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImplTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/OpintotietodataPersistenceServiceImplTest.kt
@@ -1,0 +1,152 @@
+package fi.elsapalvelu.elsa.service.impl
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
+import fi.elsapalvelu.elsa.config.ApplicationProperties
+import fi.elsapalvelu.elsa.domain.*
+import fi.elsapalvelu.elsa.domain.enumeration.ErikoisalaTyyppi
+import fi.elsapalvelu.elsa.domain.enumeration.KayttajatilinTila
+import fi.elsapalvelu.elsa.domain.enumeration.OpintooikeudenTila
+import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
+import fi.elsapalvelu.elsa.repository.*
+import fi.elsapalvelu.elsa.service.MailService
+import fi.elsapalvelu.elsa.service.UserService
+import fi.elsapalvelu.elsa.service.dto.UserDTO
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.springframework.core.env.Environment
+import tech.jhipster.config.JHipsterConstants.SPRING_PROFILE_DEVELOPMENT
+import tech.jhipster.config.JHipsterConstants.SPRING_PROFILE_PRODUCTION
+import java.time.Clock
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Optional
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+
+class OpintotietodataPersistenceServiceImplTest {
+
+    @Mock private lateinit var userService: UserService
+    @Mock private lateinit var userRepository: UserRepository
+    @Mock private lateinit var erikoistuvaLaakariRepository: ErikoistuvaLaakariRepository
+    @Mock private lateinit var kayttajaRepository: KayttajaRepository
+    @Mock private lateinit var yliopistoRepository: YliopistoRepository
+    @Mock private lateinit var erikoisalaRepository: ErikoisalaRepository
+    @Mock private lateinit var opintoopasRepository: OpintoopasRepository
+    @Mock private lateinit var opintooikeusRepository: OpintooikeusRepository
+    @Mock private lateinit var asetusRepository: AsetusRepository
+    @Mock private lateinit var erikoisalaSisuTutkintoohjelmaRepository: ErikoisalaSisuTutkintoohjelmaRepository
+    @Mock private lateinit var opintooikeusHerateRepository: OpintooikeusHerateRepository
+    @Mock private lateinit var mailService: MailService
+    @Mock private lateinit var applicationProperties: ApplicationProperties
+    @Mock private lateinit var env: Environment
+    @Mock private lateinit var cipher: Cipher
+    @Mock private lateinit var originalKey: SecretKey
+
+    private val clock: Clock = Clock.fixed(
+        LocalDate.of(2024, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant(),
+        ZoneId.systemDefault()
+    )
+
+    private lateinit var service: OpintotietodataPersistenceServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        service = OpintotietodataPersistenceServiceImpl(
+            userService,
+            userRepository,
+            erikoistuvaLaakariRepository,
+            kayttajaRepository,
+            yliopistoRepository,
+            erikoisalaRepository,
+            opintoopasRepository,
+            opintooikeusRepository,
+            asetusRepository,
+            erikoisalaSisuTutkintoohjelmaRepository,
+            clock,
+            opintooikeusHerateRepository,
+            mailService,
+            applicationProperties,
+            env
+        )
+    }
+
+    @Test
+    fun `createWithoutOpintotietodataOnlyDevDoNotUseInProd throws IllegalStateException when not in dev profile`() {
+        whenever(env.activeProfiles).thenReturn(arrayOf(SPRING_PROFILE_PRODUCTION))
+
+        assertThrows(IllegalStateException::class.java) {
+            service.createWithoutOpintotietodataOnlyDevDoNotUseInProd(
+                cipher, originalKey, "010190-1234", "Testi", "Henkilö"
+            )
+        }
+    }
+
+    @Test
+    fun `createWithoutOpintotietodataOnlyDevDoNotUseInProd does not throw when in dev profile`() {
+        whenever(env.activeProfiles).thenReturn(arrayOf(SPRING_PROFILE_DEVELOPMENT))
+
+        val userId = "test-user-id"
+        val user = stubUser(userId)
+        val userDTO = UserDTO(id = userId, login = "testi.henkilo")
+
+        whenever(userService.createUser(any(), any(), any(), any(), any())).thenReturn(userDTO)
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(user))
+
+        val kayttaja = Kayttaja(user = user, tila = KayttajatilinTila.AKTIIVINEN)
+        whenever(kayttajaRepository.save(any())).thenReturn(kayttaja)
+
+        val erikoistuvaLaakari = ErikoistuvaLaakari(
+            kayttaja = kayttaja,
+            syntymaaika = LocalDate.now(ZoneId.systemDefault()).minusYears(40)
+        )
+        whenever(erikoistuvaLaakariRepository.save(any())).thenReturn(erikoistuvaLaakari)
+
+        val erikoisala = Erikoisala(id = 46L, nimi = "Testala", tyyppi = ErikoisalaTyyppi.LAAKETIEDE)
+        val yliopisto = Yliopisto(nimi = YliopistoEnum.HELSINGIN_YLIOPISTO)
+        val opintoopas = Opintoopas(id = 15L, erikoisala = erikoisala)
+        val asetus = Asetus(id = 5L, nimi = "Asetus 2020")
+
+        whenever(yliopistoRepository.findById(1)).thenReturn(Optional.of(yliopisto))
+        whenever(erikoisalaRepository.findById(46)).thenReturn(Optional.of(erikoisala))
+        whenever(opintoopasRepository.findById(15)).thenReturn(Optional.of(opintoopas))
+        whenever(asetusRepository.findById(5)).thenReturn(Optional.of(asetus))
+
+        val savedOpintooikeus = Opintooikeus(
+            id = 1L,
+            opintooikeudenMyontamispaiva = LocalDate.now(ZoneId.systemDefault()),
+            opintooikeudenPaattymispaiva = LocalDate.now(ZoneId.systemDefault()).plusYears(10),
+            erikoistuvaLaakari = erikoistuvaLaakari,
+            yliopisto = yliopisto,
+            erikoisala = erikoisala,
+            opintoopas = opintoopas,
+            asetus = asetus,
+            tila = OpintooikeudenTila.AKTIIVINEN
+        )
+        whenever(opintooikeusRepository.save(any())).thenReturn(savedOpintooikeus)
+        whenever(userRepository.save(any())).thenReturn(user)
+
+        assertDoesNotThrow {
+            service.createWithoutOpintotietodataOnlyDevDoNotUseInProd(
+                cipher, originalKey, "010190-1234", "Testi", "Henkilö"
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun stubUser(id: String): User = User(
+        id = id,
+        login = "testi.henkilo",
+        firstName = "Testi",
+        lastName = "Henkilö",
+        authorities = mutableSetOf()
+    )
+}


### PR DESCRIPTION
This pull request introduces a safety improvement to the user creation logic in development environments. Specifically, it renames a method to clarify its intended use for development only and enforces a runtime check to prevent its use outside of development mode.

**Development-only user creation safety:**

* Renamed the method `createWithoutOpintotietodata` to `createWithoutOpintotietodataOnlyDevDoNotUseInProd` in both the interface and implementation to make its intended usage in development environments explicit. [[1]](diffhunk://#diff-8c679870cd4d42d9774e4cf9573d4194a9610128fb9e502042b167875afa2c9bL18-R18) [[2]](diffhunk://#diff-19835b16131875979bb6ff061c388d3dbf9aa80fc6c976d18ea02cd5388d7e08L368-R368)
* Added a runtime check in `createWithoutOpintotietodataOnlyDevDoNotUseInProd` to throw an exception if the method is called outside of the `SPRING_PROFILE_DEVELOPMENT` profile, preventing accidental use in production.
* Injected the `Environment` dependency into `OpintotietodataPersistenceServiceImpl` to enable environment profile checks. [[1]](diffhunk://#diff-df303b98f8a39ea11da3c747db31d1e837af05bdc3d0f5b4449e6ffa6629a946L51-R54) [[2]](diffhunk://#diff-df303b98f8a39ea11da3c747db31d1e837af05bdc3d0f5b4449e6ffa6629a946R25-R28)