### PR TITLE
Add CloudWatch metrics export configuration

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/CloudWatchMeterRegistryConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/CloudWatchMeterRegistryConfiguration.kt
@@ -1,0 +1,52 @@
+package fi.elsapalvelu.elsa.config
+
+import io.awspring.cloud.autoconfigure.core.AwsClientBuilderConfigurer
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+
+/**
+ * Provides a [CloudWatchAsyncClient] bean configured via Spring Cloud AWS's
+ * [AwsClientBuilderConfigurer], ensuring Micrometer's CloudWatch meter-registry uses the
+ * correct region (`spring.cloud.aws.region.static`) and the ECS task-role credentials.
+ *
+ * **Why this is needed:**
+ * Micrometer's [io.micrometer.cloudwatch2.CloudWatchMeterRegistry] auto-configuration
+ * (`@ConditionalOnMissingBean(CloudWatchAsyncClient.class)`) falls back to
+ * `CloudWatchAsyncClient.create()` when no bean is present.  In AWS Fargate this call
+ * relies on the SDK's region-provider chain, which does NOT read
+ * `spring.cloud.aws.region.static` and requires `AWS_REGION` / `AWS_DEFAULT_REGION` to be
+ * set as an environment variable — variables that Fargate does not inject automatically
+ * (unlike Lambda).  Without a resolved region the async client is created but all
+ * `PutMetricData` calls fail silently, so no metrics appear in CloudWatch.
+ *
+ * By declaring this bean here (ahead of Micrometer's auto-configuration), we hand
+ * Micrometer an already-configured client and the problem is avoided entirely.
+ *
+ * Active only when `management.cloudwatch2.metrics.export.enabled=true` so it is a no-op
+ * in development / test where CloudWatch export is disabled.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(CloudWatchAsyncClient::class)
+@ConditionalOnProperty(
+    prefix = "management.cloudwatch2.metrics.export",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = false
+)
+class CloudWatchMeterRegistryConfiguration {
+
+    private val log = LoggerFactory.getLogger(CloudWatchMeterRegistryConfiguration::class.java)
+
+    @Bean
+    @ConditionalOnMissingBean(CloudWatchAsyncClient::class)
+    fun cloudWatchAsyncClient(configurer: AwsClientBuilderConfigurer): CloudWatchAsyncClient {
+        log.info("Creating CloudWatchAsyncClient via Spring Cloud AWS AwsClientBuilderConfigurer")
+        return configurer.configure(CloudWatchAsyncClient.builder()).build()
+    }
+}
+

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -109,6 +109,10 @@ management:
     metrics:
       export:
         enabled: true
-        namespace: ElsaBackend
+        # Namespace is overridden per-environment via the
+        # MANAGEMENT_CLOUDWATCH2_METRICS_EXPORT_NAMESPACE container env var
+        # (elsa-dev / elsa-staging / elsa-prod / elsa-sandbox).
+        # The value below is only a safety fallback when no env var is present.
+        namespace: ${MANAGEMENT_CLOUDWATCH2_METRICS_EXPORT_NAMESPACE:ElsaBackend}
         step: 1m
 


### PR DESCRIPTION
This pull request improves the reliability and configurability of CloudWatch metrics export in AWS environments, particularly Fargate, by ensuring that the Micrometer CloudWatch meter-registry uses the correct region and credentials. It introduces a custom configuration class to provide a properly configured `CloudWatchAsyncClient` and updates how the CloudWatch namespace is set in production.

**CloudWatch Metrics Export Improvements:**

* Added `CloudWatchMeterRegistryConfiguration` to create and provide a `CloudWatchAsyncClient` bean using Spring Cloud AWS's `AwsClientBuilderConfigurer`. This ensures the correct AWS region and credentials are used, preventing silent metric export failures in Fargate when required environment variables are missing. The configuration is only active when CloudWatch metrics export is enabled.

**Configuration Flexibility:**

* Updated `application-prod.yml` so the CloudWatch metrics namespace can be set via the `MANAGEMENT_CLOUDWATCH2_METRICS_EXPORT_NAMESPACE` environment variable, with a fallback to `ElsaBackend` if the variable is not set. This allows flexible per-environment configuration without code changes.
