### PR TITLE
Add metrics for archiving and PDF generation operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Justfile-komennot 
 
-Projektissa on valmiita kehityskomentoja `Justfile`-tiedostossa.
+Projektissa on valmiita kehityskomentoja `Justfile`-tiedostossa
 
 - `just br` (build-run): ajaa ensin buildin ja käynnistää sen jälkeen backendin sekä frontendin
 - `just r` (run): käynnistää backendin ja frontendin ilman build-vaihetta.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Justfile-komennot 
 
-Projektissa on valmiita kehityskomentoja `Justfile`-tiedostossa
+Projektissa on valmiita kehityskomentoja `Justfile`-tiedostossa.
 
 - `just br` (build-run): ajaa ensin buildin ja käynnistää sen jälkeen backendin sekä frontendin
 - `just r` (run): käynnistää backendin ja frontendin ilman build-vaihetta.

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImpl.kt
@@ -9,6 +9,7 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.service.AlertPublisherService
 import fi.elsapalvelu.elsa.service.ArkistointiService
 import fi.elsapalvelu.elsa.service.dto.arkistointi.*
+import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
 import org.apache.commons.codec.digest.DigestUtils
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -24,7 +25,8 @@ class ArkistointiServiceImpl(
     private val applicationProperties: ApplicationProperties,
     private val tampereLouhiService: TampereLouhiService,
     private val helsinkiSiiloService: HelsinkiSiiloService,
-    private val alertPublisherService: AlertPublisherService
+    private val alertPublisherService: AlertPublisherService,
+    private val arkistointiMetrics: ArkistointiMetricsService
 ) : ArkistointiService {
     private val log = LoggerFactory.getLogger(ArkistointiServiceImpl::class.java)
 
@@ -227,34 +229,42 @@ class ArkistointiServiceImpl(
         caseType: CaseType,
         yek: Boolean
     ) {
-        when (yliopisto) {
-            YliopistoEnum.TAMPEREEN_YLIOPISTO -> {
-                try {
-                    tampereLouhiService.laheta(filePath, yek)
-                } catch (e: Exception) {
-                    alertPublisherService.publishAlert(
-                        subject = "Tampere arkistointi epäonnistui",
-                        message = "Arkistointitiedoston lähetys Louhi SFTP-palvelimelle epäonnistui. " +
-                            "Tiedosto: $filePath, CaseType: ${caseType.value}. Virhe: ${e.message}"
-                    )
-                    throw e
+        arkistointiMetrics.activeArkistointiOperations.incrementAndGet()
+        try {
+            when (yliopisto) {
+                YliopistoEnum.TAMPEREEN_YLIOPISTO -> {
+                    try {
+                        tampereLouhiService.laheta(filePath, yek)
+                    } catch (e: Exception) {
+                        alertPublisherService.publishAlert(
+                            subject = "Tampere arkistointi epäonnistui",
+                            message = "Arkistointitiedoston lähetys Louhi SFTP-palvelimelle epäonnistui. " +
+                                "Tiedosto: $filePath, CaseType: ${caseType.value}. Virhe: ${e.message}"
+                        )
+                        arkistointiMetrics.recordError(yliopisto, caseType)
+                        throw e
+                    }
                 }
-            }
 
-            YliopistoEnum.HELSINGIN_YLIOPISTO -> {
-                try {
-                    helsinkiSiiloService.laheta(filePath, caseType)
-                } catch (e: Exception) {
-                    alertPublisherService.publishAlert(
-                        subject = "Helsinki arkistointi epäonnistui",
-                        message = "Arkistointitiedoston lähetys HY Siilo-palveluun epäonnistui. " +
-                            "Tiedosto: $filePath, CaseType: ${caseType.value}. Virhe: ${e.message}"
-                    )
-                    throw e
+                YliopistoEnum.HELSINGIN_YLIOPISTO -> {
+                    try {
+                        helsinkiSiiloService.laheta(filePath, caseType)
+                    } catch (e: Exception) {
+                        alertPublisherService.publishAlert(
+                            subject = "Helsinki arkistointi epäonnistui",
+                            message = "Arkistointitiedoston lähetys HY Siilo-palveluun epäonnistui. " +
+                                "Tiedosto: $filePath, CaseType: ${caseType.value}. Virhe: ${e.message}"
+                        )
+                        arkistointiMetrics.recordError(yliopisto, caseType)
+                        throw e
+                    }
                 }
-            }
 
-            else -> log.info("Integraatiota arkistointiin ei ole tuettu yliopistossa ${yliopisto.name}")
+                else -> log.info("Integraatiota arkistointiin ei ole tuettu yliopistossa ${yliopisto.name}")
+            }
+            arkistointiMetrics.recordSuccess(yliopisto, caseType)
+        } finally {
+            arkistointiMetrics.activeArkistointiOperations.updateAndGet { maxOf(0, it - 1) }
         }
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/PdfServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/PdfServiceImpl.kt
@@ -14,6 +14,10 @@ import com.itextpdf.layout.properties.UnitValue
 import com.itextpdf.pdfa.PdfADocument
 import fi.elsapalvelu.elsa.domain.Asiakirja
 import fi.elsapalvelu.elsa.service.PdfService
+import fi.elsapalvelu.elsa.service.metrics.PdfGenerationMetricsService
+import fi.elsapalvelu.elsa.service.metrics.PdfGenerationMetricsService.Companion.OP_LUO_PDF
+import fi.elsapalvelu.elsa.service.metrics.PdfGenerationMetricsService.Companion.OP_YHDISTA_ASIAKIRJAT
+import fi.elsapalvelu.elsa.service.metrics.PdfGenerationMetricsService.Companion.OP_YHDISTA_PDF
 import org.apache.pdfbox.Loader
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -26,7 +30,8 @@ import java.io.*
 
 @Service
 class PdfServiceImpl(
-    private val templateEngine: SpringTemplateEngine
+    private val templateEngine: SpringTemplateEngine,
+    private val pdfMetrics: PdfGenerationMetricsService
 ) : PdfService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -48,60 +53,64 @@ class PdfServiceImpl(
     var notoSansFont: Resource? = null
 
     override fun luoPdf(template: String, context: Context, outputStream: OutputStream) {
-        val content = sanitizeContent(templateEngine.process(template, context))
-        val pdf = PdfADocument(
-            PdfWriter(outputStream),
-            PdfAConformanceLevel.PDF_A_2B,
-            PdfOutputIntent(
-                "Custom", "", "https://www.color.org",
-                "sRGB IEC61966-2.1", colorProfile?.inputStream
+        pdfMetrics.trackOperation(OP_LUO_PDF) {
+            val content = sanitizeContent(templateEngine.process(template, context))
+            val pdf = PdfADocument(
+                PdfWriter(outputStream),
+                PdfAConformanceLevel.PDF_A_2B,
+                PdfOutputIntent(
+                    "Custom", "", "https://www.color.org",
+                    "sRGB IEC61966-2.1", colorProfile?.inputStream
+                )
             )
-        )
-        val provider = FontProvider()
-        provider.addFont(liberationSerifFont?.file?.absolutePath)
-        provider.addFont(liberationSerifFontBold?.file?.absolutePath)
-        provider.addFont(notoSansFont?.file?.absolutePath)
-        provider.addFont(notoSansFontItalic?.file?.absolutePath)
+            val provider = FontProvider()
+            provider.addFont(liberationSerifFont?.file?.absolutePath)
+            provider.addFont(liberationSerifFontBold?.file?.absolutePath)
+            provider.addFont(notoSansFont?.file?.absolutePath)
+            provider.addFont(notoSansFontItalic?.file?.absolutePath)
 
-        val properties = ConverterProperties()
-        properties.fontProvider = provider
+            val properties = ConverterProperties()
+            properties.fontProvider = provider
 
-        HtmlConverter.convertToPdf(content, pdf, properties)
+            HtmlConverter.convertToPdf(content, pdf, properties)
+        }
     }
 
     override fun yhdistaAsiakirjat(
         asiakirjat: List<Asiakirja>,
         outputStream: OutputStream
     ) {
-        val result = PdfDocument(PdfWriter(outputStream))
-        val resultDocument = Document(result)
-        asiakirjat.filter { it.tyyppi == MediaType.APPLICATION_PDF_VALUE }.forEach {
-            try {
-                val sanitizedData = sanitizePdf(it.asiakirjaData?.data)
-                PdfDocument(PdfReader(ByteArrayInputStream(sanitizedData))).use { srcDoc ->
-                    for (i in 1..srcDoc.numberOfPages) {
-                        val page = srcDoc.getPage(i).copyTo(result)
-                        result.addPage(page)
-                    }
-                }
-            } catch (e: IOException) {
-                log.warn("Asiakirjan ${it.id} lisäys epäonnistui", e)
-            }
-        }
-        asiakirjat.filter { it.tyyppi == MediaType.IMAGE_JPEG_VALUE || it.tyyppi == MediaType.IMAGE_PNG_VALUE }
-            .forEach {
+        pdfMetrics.trackOperation(OP_YHDISTA_ASIAKIRJAT) {
+            val result = PdfDocument(PdfWriter(outputStream))
+            val resultDocument = Document(result)
+            asiakirjat.filter { it.tyyppi == MediaType.APPLICATION_PDF_VALUE }.forEach {
                 try {
-                    val image = Image(ImageDataFactory.create(it.asiakirjaData?.data))
-                    result.addNewPage()
-                    image.width = UnitValue(1, result.getPage(result.numberOfPages).pageSize.width)
-                    image.setFixedPosition(result.numberOfPages, 0F, 0F)
-                    image.objectFit = ObjectFit.SCALE_DOWN
-                    resultDocument.add(image)
+                    val sanitizedData = sanitizePdf(it.asiakirjaData?.data)
+                    PdfDocument(PdfReader(ByteArrayInputStream(sanitizedData))).use { srcDoc ->
+                        for (i in 1..srcDoc.numberOfPages) {
+                            val page = srcDoc.getPage(i).copyTo(result)
+                            result.addPage(page)
+                        }
+                    }
                 } catch (e: IOException) {
                     log.warn("Asiakirjan ${it.id} lisäys epäonnistui", e)
                 }
             }
-        resultDocument.close()
+            asiakirjat.filter { it.tyyppi == MediaType.IMAGE_JPEG_VALUE || it.tyyppi == MediaType.IMAGE_PNG_VALUE }
+                .forEach {
+                    try {
+                        val image = Image(ImageDataFactory.create(it.asiakirjaData?.data))
+                        result.addNewPage()
+                        image.width = UnitValue(1, result.getPage(result.numberOfPages).pageSize.width)
+                        image.setFixedPosition(result.numberOfPages, 0F, 0F)
+                        image.objectFit = ObjectFit.SCALE_DOWN
+                        resultDocument.add(image)
+                    } catch (e: IOException) {
+                        log.warn("Asiakirjan ${it.id} lisäys epäonnistui", e)
+                    }
+                }
+            resultDocument.close()
+        }
     }
 
     fun sanitizePdf(data: ByteArray?): ByteArray {
@@ -119,14 +128,16 @@ class PdfServiceImpl(
         newPdf: InputStream,
         outputStream: OutputStream
     ) {
-        val result = PdfDocument(PdfReader(source), PdfWriter(outputStream))
-        val resultDocument = Document(result)
-        val merger = PdfMerger(result)
+        pdfMetrics.trackOperation(OP_YHDISTA_PDF) {
+            val result = PdfDocument(PdfReader(source), PdfWriter(outputStream))
+            val resultDocument = Document(result)
+            val merger = PdfMerger(result)
 
-        val newDocument = PdfDocument(PdfReader(newPdf))
-        merger.merge(newDocument, 1, newDocument.numberOfPages)
+            val newDocument = PdfDocument(PdfReader(newPdf))
+            merger.merge(newDocument, 1, newDocument.numberOfPages)
 
-        resultDocument.close()
+            resultDocument.close()
+        }
     }
 
     private fun sanitizeContent(input: String): String =

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/ActiveSessionsMetricsService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/ActiveSessionsMetricsService.kt
@@ -21,10 +21,16 @@ class ActiveSessionsMetricsService(registry: MeterRegistry) : ElsaMetricsService
         description = "Number of currently active authenticated user sessions (proxy for logged-in users)"
     )
 
+    private val totalSessions = counter(
+        "http.sessions.total",
+        "Total number of successful authenticated logins since application start"
+    )
+
     @EventListener
     fun onAuthenticationSuccess(event: InteractiveAuthenticationSuccessEvent) {
         val count = activeSessions.incrementAndGet()
-        log.debug("User authenticated ({}), active sessions={}", event.authentication.name, count)
+        totalSessions.increment()
+        log.debug("User authenticated ({}), active sessions={}, total logins={}", event.authentication.name, count, totalSessions.count())
     }
 
     @EventListener

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/ArkistointiMetricsService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/ArkistointiMetricsService.kt
@@ -1,0 +1,62 @@
+package fi.elsapalvelu.elsa.service.metrics
+
+import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
+import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.context.annotation.Lazy
+import org.springframework.stereotype.Service
+
+/**
+ * Tracks archiving (arkistointi) workload and volume in real time.
+ *
+ * Gauges
+ * ──────
+ * arkistointi.active                      – number of archiving operations currently in flight
+ *                                           (muodostaSahke + laheta).  Shows peak concurrency
+ *                                           and helps size thread-pool capacity.
+ *
+ * Counters  (tagged by yliopisto + caseType so any monitoring stack can slice/dice)
+ * ────────────────────────────────────────────────────────────────────────────────
+ * arkistointi.requests.total              – successfully completed archiving calls.
+ *                                           Use a per-day rate to answer "how many items are
+ *                                           archived daily?" – exactly the daily-volume insight
+ *                                           requested.
+ * arkistointi.errors.total                – failed archiving calls.
+ *                                           A rising error rate can trigger an alert before the
+ *                                           engineering team notices in logs.
+ */
+@Service
+@Lazy(false)
+class ArkistointiMetricsService(registry: MeterRegistry) : ElsaMetricsService(registry) {
+
+    /** Number of archiving operations (package-build + send) currently executing. */
+    val activeArkistointiOperations = atomicGauge(
+        "arkistointi.active",
+        "Number of archiving operations (muodostaSahke / laheta) currently executing"
+    )
+
+    /**
+     * Records one completed archiving cycle tagged by university and case type.
+     * Call this after a successful `laheta` call in ArkistointiService.
+     */
+    fun recordSuccess(yliopisto: YliopistoEnum, caseType: CaseType) {
+        counter(
+            "arkistointi.requests.total",
+            "Total completed archiving operations",
+            "yliopisto", yliopisto.name, "caseType", caseType.value
+        ).increment()
+    }
+
+    /**
+     * Records one failed archiving cycle tagged by university and case type.
+     * Call this inside the catch block that wraps `laheta` in ArkistointiService.
+     */
+    fun recordError(yliopisto: YliopistoEnum, caseType: CaseType) {
+        counter(
+            "arkistointi.errors.total",
+            "Total failed archiving operations",
+            "yliopisto", yliopisto.name, "caseType", caseType.value
+        ).increment()
+    }
+}
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/ArkistointiMetricsService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/ArkistointiMetricsService.kt
@@ -6,57 +6,21 @@ import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 
-/**
- * Tracks archiving (arkistointi) workload and volume in real time.
- *
- * Gauges
- * ──────
- * arkistointi.active                      – number of archiving operations currently in flight
- *                                           (muodostaSahke + laheta).  Shows peak concurrency
- *                                           and helps size thread-pool capacity.
- *
- * Counters  (tagged by yliopisto + caseType so any monitoring stack can slice/dice)
- * ────────────────────────────────────────────────────────────────────────────────
- * arkistointi.requests.total              – successfully completed archiving calls.
- *                                           Use a per-day rate to answer "how many items are
- *                                           archived daily?" – exactly the daily-volume insight
- *                                           requested.
- * arkistointi.errors.total                – failed archiving calls.
- *                                           A rising error rate can trigger an alert before the
- *                                           engineering team notices in logs.
- */
 @Service
 @Lazy(false)
 class ArkistointiMetricsService(registry: MeterRegistry) : ElsaMetricsService(registry) {
 
-    /** Number of archiving operations (package-build + send) currently executing. */
     val activeArkistointiOperations = atomicGauge(
         "arkistointi.active",
         "Number of archiving operations (muodostaSahke / laheta) currently executing"
     )
 
-    /**
-     * Records one completed archiving cycle tagged by university and case type.
-     * Call this after a successful `laheta` call in ArkistointiService.
-     */
     fun recordSuccess(yliopisto: YliopistoEnum, caseType: CaseType) {
-        counter(
-            "arkistointi.requests.total",
-            "Total completed archiving operations",
-            "yliopisto", yliopisto.name, "caseType", caseType.value
-        ).increment()
+        counter("arkistointi.requests.total", "Total completed archiving operations", "yliopisto", yliopisto.name, "caseType", caseType.value).increment()
     }
 
-    /**
-     * Records one failed archiving cycle tagged by university and case type.
-     * Call this inside the catch block that wraps `laheta` in ArkistointiService.
-     */
     fun recordError(yliopisto: YliopistoEnum, caseType: CaseType) {
-        counter(
-            "arkistointi.errors.total",
-            "Total failed archiving operations",
-            "yliopisto", yliopisto.name, "caseType", caseType.value
-        ).increment()
+        counter("arkistointi.errors.total", "Total failed archiving operations", "yliopisto", yliopisto.name, "caseType", caseType.value).increment()
     }
 }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/PdfGenerationMetricsService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/PdfGenerationMetricsService.kt
@@ -1,0 +1,108 @@
+package fi.elsapalvelu.elsa.service.metrics
+
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.context.annotation.Lazy
+import org.springframework.stereotype.Service
+
+/**
+ * Tracks PDF-generation workload in real time.
+ *
+ * Gauges
+ * ──────
+ * pdf.generation.active          – number of PDF operations currently executing
+ *                                  (luoPdf + yhdistaAsiakirjat + yhdistaPdf combined).
+ *                                  A sustained non-zero value during off-peak hours is
+ *                                  evidence that PDF rendering ties up JVM threads and
+ *                                  motivates moving generation to an external service.
+ *
+ * Counters
+ * ────────
+ * pdf.generation.requests.total  – lifetime count of completed operations (tag: operation).
+ *                                  Use the rate over a rolling window in Grafana to derive
+ *                                  daily/hourly volume per operation type.
+ * pdf.generation.errors.total    – lifetime count of failed operations (tag: operation).
+ */
+@Service
+@Lazy(false)
+class PdfGenerationMetricsService(registry: MeterRegistry) : ElsaMetricsService(registry) {
+
+    companion object {
+        const val OP_LUO_PDF = "luoPdf"
+        const val OP_YHDISTA_ASIAKIRJAT = "yhdistaAsiakirjat"
+        const val OP_YHDISTA_PDF = "yhdistaPdf"
+    }
+
+    /** Number of PDF operations currently executing across all threads. */
+    val activePdfOperations = atomicGauge(
+        name = "pdf.generation.active",
+        description = "Number of PDF generation / merge operations currently executing in the JVM"
+    )
+
+    private val requestsLuoPdf = counter(
+        "pdf.generation.requests.total",
+        "Total completed PDF generation calls",
+        "operation", OP_LUO_PDF
+    )
+
+    private val requestsYhdistaAsiakirjat = counter(
+        "pdf.generation.requests.total",
+        "Total completed PDF generation calls",
+        "operation", OP_YHDISTA_ASIAKIRJAT
+    )
+
+    private val requestsYhdistaPdf = counter(
+        "pdf.generation.requests.total",
+        "Total completed PDF generation calls",
+        "operation", OP_YHDISTA_PDF
+    )
+
+    private val errorsLuoPdf = counter(
+        "pdf.generation.errors.total",
+        "Total failed PDF generation calls",
+        "operation", OP_LUO_PDF
+    )
+
+    private val errorsYhdistaAsiakirjat = counter(
+        "pdf.generation.errors.total",
+        "Total failed PDF generation calls",
+        "operation", OP_YHDISTA_ASIAKIRJAT
+    )
+
+    private val errorsYhdistaPdf = counter(
+        "pdf.generation.errors.total",
+        "Total failed PDF generation calls",
+        "operation", OP_YHDISTA_PDF
+    )
+
+    /**
+     * Executes [block] while keeping the active-gauge incremented.
+     * Decrements the gauge and increments the appropriate counter when [block] finishes
+     * (whether normally or via exception).
+     */
+    fun <T> trackOperation(operation: String, block: () -> T): T {
+        activePdfOperations.incrementAndGet()
+        return try {
+            val result = block()
+            requestsCounter(operation).increment()
+            result
+        } catch (ex: Exception) {
+            errorsCounter(operation).increment()
+            throw ex
+        } finally {
+            activePdfOperations.updateAndGet { maxOf(0, it - 1) }
+        }
+    }
+
+    private fun requestsCounter(operation: String) = when (operation) {
+        OP_LUO_PDF -> requestsLuoPdf
+        OP_YHDISTA_ASIAKIRJAT -> requestsYhdistaAsiakirjat
+        else -> requestsYhdistaPdf
+    }
+
+    private fun errorsCounter(operation: String) = when (operation) {
+        OP_LUO_PDF -> errorsLuoPdf
+        OP_YHDISTA_ASIAKIRJAT -> errorsYhdistaAsiakirjat
+        else -> errorsYhdistaPdf
+    }
+}
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/PdfGenerationMetricsService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/PdfGenerationMetricsService.kt
@@ -4,24 +4,6 @@ import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 
-/**
- * Tracks PDF-generation workload in real time.
- *
- * Gauges
- * ──────
- * pdf.generation.active          – number of PDF operations currently executing
- *                                  (luoPdf + yhdistaAsiakirjat + yhdistaPdf combined).
- *                                  A sustained non-zero value during off-peak hours is
- *                                  evidence that PDF rendering ties up JVM threads and
- *                                  motivates moving generation to an external service.
- *
- * Counters
- * ────────
- * pdf.generation.requests.total  – lifetime count of completed operations (tag: operation).
- *                                  Use the rate over a rolling window in Grafana to derive
- *                                  daily/hourly volume per operation type.
- * pdf.generation.errors.total    – lifetime count of failed operations (tag: operation).
- */
 @Service
 @Lazy(false)
 class PdfGenerationMetricsService(registry: MeterRegistry) : ElsaMetricsService(registry) {
@@ -32,53 +14,16 @@ class PdfGenerationMetricsService(registry: MeterRegistry) : ElsaMetricsService(
         const val OP_YHDISTA_PDF = "yhdistaPdf"
     }
 
-    /** Number of PDF operations currently executing across all threads. */
-    val activePdfOperations = atomicGauge(
-        name = "pdf.generation.active",
-        description = "Number of PDF generation / merge operations currently executing in the JVM"
-    )
+    private val activePdfOperations = atomicGauge(name = "pdf.generation.active", description = "Number of PDF generation / merge operations currently executing")
 
-    private val requestsLuoPdf = counter(
-        "pdf.generation.requests.total",
-        "Total completed PDF generation calls",
-        "operation", OP_LUO_PDF
-    )
+    private val requestsLuoPdf = counter("pdf.generation.requests.total", "Total completed PDF generation calls", "operation", OP_LUO_PDF)
+    private val requestsYhdistaAsiakirjat = counter("pdf.generation.requests.total", "Total completed PDF generation calls", "operation", OP_YHDISTA_ASIAKIRJAT)
+    private val requestsYhdistaPdf = counter("pdf.generation.requests.total", "Total completed PDF generation calls", "operation", OP_YHDISTA_PDF)
 
-    private val requestsYhdistaAsiakirjat = counter(
-        "pdf.generation.requests.total",
-        "Total completed PDF generation calls",
-        "operation", OP_YHDISTA_ASIAKIRJAT
-    )
+    private val errorsLuoPdf = counter("pdf.generation.errors.total", "Total failed PDF generation calls", "operation", OP_LUO_PDF)
+    private val errorsYhdistaAsiakirjat = counter("pdf.generation.errors.total", "Total failed PDF generation calls", "operation", OP_YHDISTA_ASIAKIRJAT)
+    private val errorsYhdistaPdf = counter("pdf.generation.errors.total", "Total failed PDF generation calls", "operation", OP_YHDISTA_PDF)
 
-    private val requestsYhdistaPdf = counter(
-        "pdf.generation.requests.total",
-        "Total completed PDF generation calls",
-        "operation", OP_YHDISTA_PDF
-    )
-
-    private val errorsLuoPdf = counter(
-        "pdf.generation.errors.total",
-        "Total failed PDF generation calls",
-        "operation", OP_LUO_PDF
-    )
-
-    private val errorsYhdistaAsiakirjat = counter(
-        "pdf.generation.errors.total",
-        "Total failed PDF generation calls",
-        "operation", OP_YHDISTA_ASIAKIRJAT
-    )
-
-    private val errorsYhdistaPdf = counter(
-        "pdf.generation.errors.total",
-        "Total failed PDF generation calls",
-        "operation", OP_YHDISTA_PDF
-    )
-
-    /**
-     * Executes [block] while keeping the active-gauge incremented.
-     * Decrements the gauge and increments the appropriate counter when [block] finishes
-     * (whether normally or via exception).
-     */
     fun <T> trackOperation(operation: String, block: () -> T): T {
         activePdfOperations.incrementAndGet()
         return try {

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -117,5 +117,7 @@ management:
           system.cpu.usage,process.cpu.usage,
           executor.active,
           hikaricp.connections.active,hikaricp.connections.pending,hikaricp.connections.timeout,
-          http.sessions.active
+          http.sessions.active,http.sessions.total,
+          pdf.generation.active,pdf.generation.requests.total,pdf.generation.errors.total,
+          arkistointi.active,arkistointi.requests.total,arkistointi.errors.total
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/arkistointi/tampere/TampereArkistointiExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/arkistointi/tampere/TampereArkistointiExternalIntegrationTests.kt
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest
@@ -248,5 +250,8 @@ class TampereArkistointiExternalIntegrationTestApplication {
     @Bean
     fun helsinkiSiiloService(): HelsinkiSiiloService =
         Mockito.mock(HelsinkiSiiloService::class.java)
+
+    @Bean
+    fun meterRegistry(): MeterRegistry = SimpleMeterRegistry()
 }
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/arkistointi/tampere/TampereArkistointiExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/arkistointi/tampere/TampereArkistointiExternalIntegrationTests.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest
@@ -234,6 +235,7 @@ class TampereArkistointiExternalIntegrationTests : ExternalIntegrationTestSuppor
 @Import(
     TampereLouhiService::class,
     ArkistointiServiceImpl::class,
+    ArkistointiMetricsService::class,
     AlertPublisherServiceImpl::class  // single always-registered impl; no-ops when SNS not configured
 )
 class TampereArkistointiExternalIntegrationTestApplication {

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiAlertTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiAlertTest.kt
@@ -9,6 +9,8 @@ import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.service.AlertPublisherService
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
+import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
@@ -47,7 +49,8 @@ class ArkistointiAlertTest {
             applicationProperties = applicationProperties,
             tampereLouhiService = tampereLouhiService,
             helsinkiSiiloService = helsinkiSiiloService,
-            alertPublisherService = alertPublisherService
+            alertPublisherService = alertPublisherService,
+            arkistointiMetrics = ArkistointiMetricsService(SimpleMeterRegistry())
         )
     }
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
@@ -1,5 +1,9 @@
 package fi.elsapalvelu.elsa.service.impl
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.Asiakirja
 import fi.elsapalvelu.elsa.domain.AsiakirjaData
@@ -10,24 +14,58 @@ import fi.elsapalvelu.elsa.domain.Opintooikeus
 import fi.elsapalvelu.elsa.domain.User
 import fi.elsapalvelu.elsa.domain.Yliopisto
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
+import fi.elsapalvelu.elsa.service.AlertPublisherService
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
 import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.apache.commons.codec.digest.DigestUtils
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.time.LocalDate
 import java.util.zip.ZipInputStream
 
+@ExtendWith(MockitoExtension::class)
 class ArkistointiServiceImplTest {
+
+    @Mock
+    private lateinit var tampereLouhiService: TampereLouhiService
+
+    @Mock
+    private lateinit var helsinkiSiiloService: HelsinkiSiiloService
+
+    @Mock
+    private lateinit var alertPublisherService: AlertPublisherService
+
+    private lateinit var metricsRegistry: SimpleMeterRegistry
+    private lateinit var arkistointiMetrics: ArkistointiMetricsService
+    private lateinit var lahetaService: ArkistointiServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        metricsRegistry = SimpleMeterRegistry()
+        arkistointiMetrics = ArkistointiMetricsService(metricsRegistry)
+        lahetaService = ArkistointiServiceImpl(
+            applicationProperties = ApplicationProperties(),
+            tampereLouhiService = tampereLouhiService,
+            helsinkiSiiloService = helsinkiSiiloService,
+            alertPublisherService = alertPublisherService,
+            arkistointiMetrics = arkistointiMetrics
+        )
+    }
 
     @Test
     fun `muodostaSahke writes xml into zip when zipMetadata is enabled`() {
@@ -91,18 +129,88 @@ class ArkistointiServiceImplTest {
         }
     }
 
-    private fun assertXmlContent(xml: String) {
-        assertTrue(xml.startsWith("<?xml"))
-        assertTrue(xml.contains("<CaseFile"))
-        assertTrue(xml.contains("<Title>Valmistumisen asiakirjat</Title>"))
-        assertTrue(xml.contains("<NativeId>CASE-123</NativeId>"))
-        assertTrue(xml.contains("<Elsa_Syntymaaika>1990-12-31</Elsa_Syntymaaika>"))
-        assertTrue(xml.contains("<Elsa_Tarkastuspaiva>2024-01-02</Elsa_Tarkastuspaiva>"))
-        assertTrue(xml.contains("<Elsa_Hyvaksymispaiva>2024-01-03</Elsa_Hyvaksymispaiva>"))
-        assertTrue(xml.contains("<Path>pdf/testi.pdf</Path>"))
-        assertTrue(xml.contains("<HashValue>${DigestUtils.sha256Hex("pdf-data".toByteArray())}</HashValue>"))
-        assertTrue(xml.contains("<Elsa_Yliopisto>Tampereen yliopisto</Elsa_Yliopisto>"))
+    @Test
+    fun `laheta success increments success counter, does not publish alert, and resets active gauge`() {
+        lahetaService.laheta(
+            yliopisto = YliopistoEnum.HELSINGIN_YLIOPISTO,
+            filePath = "/tmp/ok.zip",
+            caseType = CaseType.VALMISTUMINEN,
+            yek = false
+        )
+
+        verify(alertPublisherService, never()).publishAlert(any(), any())
+
+        assertThat(successCount(YliopistoEnum.HELSINGIN_YLIOPISTO, CaseType.VALMISTUMINEN)).isEqualTo(1.0)
+        assertThat(errorCount(YliopistoEnum.HELSINGIN_YLIOPISTO, CaseType.VALMISTUMINEN)).isEqualTo(0.0)
+        assertThat(arkistointiMetrics.activeArkistointiOperations.get()).isEqualTo(0)
     }
+
+    @Test
+    fun `laheta Helsinki error publishes alert, increments error counter, and resets active gauge`() {
+        whenever(helsinkiSiiloService.laheta(any(), any()))
+            .thenThrow(RuntimeException("HY Siilo epäonnistui"))
+
+        assertThrows(RuntimeException::class.java) {
+            lahetaService.laheta(
+                yliopisto = YliopistoEnum.HELSINGIN_YLIOPISTO,
+                filePath = "/tmp/fail.zip",
+                caseType = CaseType.VALMISTUMINEN,
+                yek = false
+            )
+        }
+
+        verify(alertPublisherService).publishAlert(any(), any())
+
+        assertThat(errorCount(YliopistoEnum.HELSINGIN_YLIOPISTO, CaseType.VALMISTUMINEN)).isEqualTo(1.0)
+        assertThat(successCount(YliopistoEnum.HELSINGIN_YLIOPISTO, CaseType.VALMISTUMINEN)).isEqualTo(0.0)
+        assertThat(arkistointiMetrics.activeArkistointiOperations.get()).isEqualTo(0)
+    }
+
+    @Test
+    fun `laheta Tampere error publishes alert, increments error counter, and resets active gauge`() {
+        whenever(tampereLouhiService.laheta(any(), any()))
+            .thenThrow(RuntimeException("SFTP timeout"))
+
+        assertThrows(RuntimeException::class.java) {
+            lahetaService.laheta(
+                yliopisto = YliopistoEnum.TAMPEREEN_YLIOPISTO,
+                filePath = "/tmp/tre.zip",
+                caseType = CaseType.KOEJAKSO,
+                yek = false
+            )
+        }
+
+        verify(alertPublisherService).publishAlert(any(), any())
+
+        assertThat(errorCount(YliopistoEnum.TAMPEREEN_YLIOPISTO, CaseType.KOEJAKSO)).isEqualTo(1.0)
+        assertThat(successCount(YliopistoEnum.TAMPEREEN_YLIOPISTO, CaseType.KOEJAKSO)).isEqualTo(0.0)
+        assertThat(arkistointiMetrics.activeArkistointiOperations.get()).isEqualTo(0)
+    }
+
+    @Test
+    fun `laheta universities without integration do not update error counter and do not publish alert`() {
+        lahetaService.laheta(
+            yliopisto = YliopistoEnum.OULUN_YLIOPISTO,
+            filePath = "/tmp/oulu.zip",
+            caseType = CaseType.VALMISTUMINEN,
+            yek = false
+        )
+
+        verify(alertPublisherService, never()).publishAlert(any(), any())
+        assertThat(successCount(YliopistoEnum.OULUN_YLIOPISTO, CaseType.VALMISTUMINEN)).isEqualTo(1.0)
+        assertThat(errorCount(YliopistoEnum.OULUN_YLIOPISTO, CaseType.VALMISTUMINEN)).isEqualTo(0.0)
+    }
+
+
+    private fun successCount(yliopisto: YliopistoEnum, caseType: CaseType): Double =
+        metricsRegistry.find("arkistointi.requests.total")
+            .tags("yliopisto", yliopisto.name, "caseType", caseType.value)
+            .counter()?.count() ?: 0.0
+
+    private fun errorCount(yliopisto: YliopistoEnum, caseType: CaseType): Double =
+        metricsRegistry.find("arkistointi.errors.total")
+            .tags("yliopisto", yliopisto.name, "caseType", caseType.value)
+            .counter()?.count() ?: 0.0
 
     private fun createService(zipMetadata: Boolean): ArkistointiServiceImpl {
         val applicationProperties = ApplicationProperties()
@@ -116,7 +224,7 @@ class ArkistointiServiceImplTest {
             applicationProperties = applicationProperties,
             tampereLouhiService = TampereLouhiService(org.springframework.core.io.DefaultResourceLoader(), applicationProperties),
             helsinkiSiiloService = HelsinkiSiiloService(applicationProperties),
-            alertPublisherService = object : fi.elsapalvelu.elsa.service.AlertPublisherService {
+            alertPublisherService = object : AlertPublisherService {
                 override fun publishAlert(subject: String, message: String) = Unit
             },
             arkistointiMetrics = ArkistointiMetricsService(SimpleMeterRegistry())
@@ -183,6 +291,19 @@ class ArkistointiServiceImplTest {
             asiakirja = asiakirja,
             type = RecordType.YHTEENVETO
         )
+    }
+
+    private fun assertXmlContent(xml: String) {
+        assertTrue(xml.startsWith("<?xml"))
+        assertTrue(xml.contains("<CaseFile"))
+        assertTrue(xml.contains("<Title>Valmistumisen asiakirjat</Title>"))
+        assertTrue(xml.contains("<NativeId>CASE-123</NativeId>"))
+        assertTrue(xml.contains("<Elsa_Syntymaaika>1990-12-31</Elsa_Syntymaaika>"))
+        assertTrue(xml.contains("<Elsa_Tarkastuspaiva>2024-01-02</Elsa_Tarkastuspaiva>"))
+        assertTrue(xml.contains("<Elsa_Hyvaksymispaiva>2024-01-03</Elsa_Hyvaksymispaiva>"))
+        assertTrue(xml.contains("<Path>pdf/testi.pdf</Path>"))
+        assertTrue(xml.contains("<HashValue>${DigestUtils.sha256Hex("pdf-data".toByteArray())}</HashValue>"))
+        assertTrue(xml.contains("<Elsa_Yliopisto>Tampereen yliopisto</Elsa_Yliopisto>"))
     }
 
     private fun readZipEntries(zipFilePath: String): Map<String, ByteArray> {

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
@@ -13,6 +13,8 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
+import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.apache.commons.codec.digest.DigestUtils
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -116,7 +118,8 @@ class ArkistointiServiceImplTest {
             helsinkiSiiloService = HelsinkiSiiloService(applicationProperties),
             alertPublisherService = object : fi.elsapalvelu.elsa.service.AlertPublisherService {
                 override fun publishAlert(subject: String, message: String) = Unit
-            }
+            },
+            arkistointiMetrics = ArkistointiMetricsService(SimpleMeterRegistry())
         )
     }
 


### PR DESCRIPTION
# Lisätyt metriikat

## PDF-generointi (`PdfGenerationMetricsService`)

* `pdf.generation.active

  * Montako PDF-operaatiota on käynnissä juuri nyt

* `pdf.generation.requests.total`
  * Valmistuneiden PDF-operaatioiden kokonaismäärä (`operation` tagi)

* `pdf.generation.errors.total`

  * Epäonnistuneiden PDF-operaatioiden määrä (`operation` tagi)

## Arkistointi (`ArkistointiMetricsService`)

* `arkistointi.active`

  * Montako arkistointioperaatiota on käynnissä juuri nyt

* `arkistointi.requests.total`

  * Onnistuneiden arkistointien määrä (`yliopisto`, `caseType` tagit)

* `arkistointi.errors.total`

  * Epäonnistuneiden arkistointien määrä (`yliopisto`, `caseType` tagit)

## Käyttäjäistunnot (`ActiveSessionsMetricsService`)

* `http.sessions.total`

  * Kirjautumisten kokonaismäärä (lisäys olemassa olevaan `http.sessions.active` gaugeen)

# Miten metriikat auttavat tuotannossa

## `pdf.generation.active` - PDF generoinnin kuormitus

Näyttää reaaliaikaisesti kuinka monta PDF:ää on työn alla samanaikaisesti. Jos gauge pysyy jatkuvasti korkealla, se on konkreettinen todiste siitä, että PDF generointi kuormittaa JVM-säikeitä ja hidastaa sovellusta.

Tätä dataa voidaan käyttää perusteena sille, että PDF generointi siirretään erilliseen ulkoiseen palveluun.

## `arkistointi.requests.total` - Päivittäinen arkistointivolyymi CloudWatchissa

Sum-statistiikalla 24 tunnin ikkunassa saadaan suoraan vastaus kysymykseen:

> Kuinka monta asiakirjaa arkistoidaan päivässä?

Tämä auttaa:

* kapasiteettisuunnittelussa
* integraatioiden seurannassa
* käyttömäärien analysoinnissa

yliopisto- ja tapaustyyppikohtaisesti.

## `arkistointi.errors.total` – Arkistointivirheet yliopistoittain

`yliopisto` tagi kertoo heti, mikä integraatio on rikki.

## `pdf.generation.errors.total` – PDF-virheet

## `http.sessions.total` – Kirjautumisvolyymi

Päivittäinen kirjautumismäärä auttaa ymmärtämään sovelluksen todellista käyttöastetta ja tunnistamaan epänormaalia liikennettä.
