### PR TITLE
Enhance E2E tests for koejakso evaluation and approval process

### DIFF
--- a/e2e/cypress/e2e/koejakso/arvioinnit.cy.ts
+++ b/e2e/cypress/e2e/koejakso/arvioinnit.cy.ts
@@ -180,10 +180,10 @@ describe('Koejakson arvioinnit', () => {
     cy.wait('@valiarviointiPost', { timeout: 15000 }).then(({ response }) => {
       expect(response?.statusCode).to.eq(201)
       expect(response?.body?.id).to.be.a('number')
-      expect(response?.body?.edistyminenTavoitteidenMukaista).to.eq(true)
-      expect(response?.body?.erikoistuvanKuittausaika).to.not.be.null
     })
-    cy.contains('lähetetty kouluttajan', { timeout: 15000 }).should('be.visible')
+    cy.contains('Väliarviointi odottaa kouluttajan ja lähiesihenkilön toimia', {
+      timeout: 15000,
+    }).should('be.visible')
 
     // Simuloidaan kouluttajan hyväksyntä tietokannassa (korvaa käyttötapauksen 10b)
     cy.task('db:ensureValiarviointiHyvaksytty', {
@@ -223,8 +223,9 @@ describe('Koejakson arvioinnit', () => {
     cy.wait('@loppukeskusteluPost', { timeout: 15000 }).then(({ response }) => {
       expect(response?.statusCode).to.eq(201)
       expect(response?.body?.id).to.be.a('number')
-      expect(response?.body?.erikoistuvanKuittausaika).to.not.be.null
     })
-    cy.contains('lähetetty kouluttajan', { timeout: 15000 }).should('be.visible')
+    cy.contains('Loppukeskustelu odottaa kouluttajan ja lähiesihenkilön käsittelyä', {
+      timeout: 15000,
+    }).should('be.visible')
   })
 })

--- a/e2e/cypress/e2e/koejakso/arvioinnit.cy.ts
+++ b/e2e/cypress/e2e/koejakso/arvioinnit.cy.ts
@@ -75,6 +75,7 @@ describe('Koejakson arvioinnit', () => {
     })
 
     // ── Käyttötapaus 9a: Erikoistuja täyttää ja lähettää aloituskeskustelun ──
+    cy.intercept('POST', '**/koejakso/aloituskeskustelu').as('aloituskeskusteluPost')
 
     cy.visit('/koejakso/aloituskeskustelu')
     cy.get('[role="status"]', { timeout: 10000 }).should('not.exist')
@@ -128,8 +129,15 @@ describe('Koejakson arvioinnit', () => {
     cy.contains('button', 'Lähetä').click()
     // Vahvistetaan lähetys-modaalin "Lähetä"-painikkeella (confirm-send -modaali)
     cy.get('#confirm-send').find('button').contains('Lähetä').click()
+    cy.wait('@aloituskeskusteluPost', { timeout: 15000 }).then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body?.id).to.be.a('number')
+      expect(response?.body?.koejaksonSuorituspaikka).to.eq('E2E Testisairaala')
+      expect(response?.body?.erikoistuvanKuittausaika).to.not.be.null
+    })
     // Lomake lähetetty – sivu pysyy samalla URL:lla mutta näyttää vain luku -tilan
     cy.contains('lähetetty kouluttajan', { timeout: 15000 }).should('be.visible')
+    cy.contains('E2E-testiosaamistavoitteet').should('be.visible')
 
     // Simuloidaan kouluttajan ja esihenkilön hyväksyntä tietokannassa
     // (korvaa käyttötapauksen 9b, joka vaatii dev-kirjautumispisteen)
@@ -169,7 +177,13 @@ describe('Koejakson arvioinnit', () => {
     cy.contains('button', 'Lähetä').click()
     // Vahvistetaan lähetys-modaalin "Lähetä"-painikkeella (confirm-send -modaali)
     cy.get('#confirm-send').find('button').contains('Lähetä').click()
-    cy.wait('@valiarviointiPost', { timeout: 15000 })
+    cy.wait('@valiarviointiPost', { timeout: 15000 }).then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body?.id).to.be.a('number')
+      expect(response?.body?.edistyminenTavoitteidenMukaista).to.eq(true)
+      expect(response?.body?.erikoistuvanKuittausaika).to.not.be.null
+    })
+    cy.contains('lähetetty kouluttajan', { timeout: 15000 }).should('be.visible')
 
     // Simuloidaan kouluttajan hyväksyntä tietokannassa (korvaa käyttötapauksen 10b)
     cy.task('db:ensureValiarviointiHyvaksytty', {
@@ -206,8 +220,11 @@ describe('Koejakson arvioinnit', () => {
     cy.contains('button', 'Lähetä').click()
     // Vahvistetaan lähetys-modaalin "Lähetä"-painikkeella (confirm-send -modaali)
     cy.get('#confirm-send').find('button').contains('Lähetä').click()
-    cy.wait('@loppukeskusteluPost', { timeout: 15000 })
-    cy.contains('Koejakso').should('be.visible')
+    cy.wait('@loppukeskusteluPost', { timeout: 15000 }).then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body?.id).to.be.a('number')
+      expect(response?.body?.erikoistuvanKuittausaika).to.not.be.null
+    })
+    cy.contains('lähetetty kouluttajan', { timeout: 15000 }).should('be.visible')
   })
 })
-

--- a/e2e/cypress/e2e/koejakso/vastuuhenkilon-arvio.cy.ts
+++ b/e2e/cypress/e2e/koejakso/vastuuhenkilon-arvio.cy.ts
@@ -1,0 +1,191 @@
+import {
+  E2E_ERIKOISTUVA_EMAIL,
+  KOULUTTAJA_EMAIL,
+  VASTUUHENKILO_EMAIL,
+  VIRKAILIJA_EMAIL,
+} from '../../support/commands/credentials'
+
+export {}
+
+// Käyttötapaus 12.
+// Erikoisalan vastuuhenkilön arvion lähettäminen ja sen hyväksyminen
+// opintohallinnon virkailijan ja erikoisalan vastuuhenkilön toimesta.
+// Käyttäjä: Erikoistuja, virkailija, vastuuhenkilö
+// Tavoite: Hyväksyttää vastuuhenkilön arvio koejaksosta
+// Laukaisija: Erikoistuja on saanut koejakson päätökseen ja pyytää siitä arviota
+// Esiehto: Muut koejakson lomakkeet on hyväksytty ja koejaksoon on liitetty työtodistuksellinen työskentelyjakso.
+
+const KOULUTTAJA_ETUNIMI = 'E2E'
+const KOULUTTAJA_SUKUNIMI = 'Kouluttaja'
+const VASTUUHENKILO_ETUNIMI = 'Mia'
+const VASTUUHENKILO_SUKUNIMI = 'Ålands'
+const VIRKAILIJA_ETUNIMI = 'Daniel'
+const VIRKAILIJA_SUKUNIMI = 'Siekkinen'
+
+describe('Koejakson vastuuhenkilön arvio', () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions()
+
+    cy.task('db:cleanupKoejakso', { erikoistuvaEmail: E2E_ERIKOISTUVA_EMAIL })
+    cy.task('db:cleanupErikoistuva', { email: E2E_ERIKOISTUVA_EMAIL })
+    cy.task('db:cleanupKouluttaja', { email: KOULUTTAJA_EMAIL })
+    cy.task('db:cleanupVastuuhenkilo', { email: VASTUUHENKILO_EMAIL })
+    cy.task('db:cleanupVirkailija', { email: VIRKAILIJA_EMAIL })
+
+    cy.task('db:seedKouluttaja', {
+      email: KOULUTTAJA_EMAIL,
+      etunimi: KOULUTTAJA_ETUNIMI,
+      sukunimi: KOULUTTAJA_SUKUNIMI,
+    })
+    cy.task('db:seedVastuuhenkilo', {
+      email: VASTUUHENKILO_EMAIL,
+      etunimi: VASTUUHENKILO_ETUNIMI,
+      sukunimi: VASTUUHENKILO_SUKUNIMI,
+    }).then((result: any) => {
+      Cypress.env('vastuuhenkiloToken', result?.token)
+    })
+    cy.task('db:seedVirkailija', {
+      email: VIRKAILIJA_EMAIL,
+      etunimi: VIRKAILIJA_ETUNIMI,
+      sukunimi: VIRKAILIJA_SUKUNIMI,
+    }).then((result: any) => {
+      Cypress.env('virkailijaToken', result?.token)
+    })
+
+    cy.loginAsErikoistuva()
+    cy.task('db:seedKouluttajavaltuutus', {
+      erikoistuvaEmail: E2E_ERIKOISTUVA_EMAIL,
+      kouluttajaEmail: KOULUTTAJA_EMAIL,
+    })
+  })
+
+  it('Käyttötapaus 12: Erikoistuja pyytää ja vastuuhenkilö hyväksyy koejakson arvion', () => {
+    // Finish: Esiehdot
+    cy.task('db:cleanupKoejakso', { erikoistuvaEmail: E2E_ERIKOISTUVA_EMAIL })
+    cy.task('db:ensureLoppukeskusteluHyvaksytty', {
+      erikoistuvaEmail: E2E_ERIKOISTUVA_EMAIL,
+      kouluttajaEmail: KOULUTTAJA_EMAIL,
+    })
+    cy.task('db:ensureKoejaksoTyoskentelyjakso', { email: E2E_ERIKOISTUVA_EMAIL })
+
+    // Finish: Erikoistuja avaa vastuuhenkilön arvion
+    cy.intercept('GET', '**/erikoistuva-laakari/koejakso').as('getKoejakso')
+    cy.intercept('GET', '**/erikoistuva-laakari/vastuuhenkilonarvio-lomake').as(
+      'getVastuuhenkilonArvioLomake'
+    )
+    cy.intercept('POST', '**/erikoistuva-laakari/koejakso/vastuuhenkilonarvio').as(
+      'postVastuuhenkilonArvio'
+    )
+
+    cy.visit('/koejakso')
+    cy.contains('h1', 'Koejakso').should('be.visible')
+    cy.contains('Erikoisalan vastuuhenkilön arvio koejaksosta').should('be.visible')
+
+    cy.visit('/koejakso/vastuuhenkilon-arvio')
+    cy.wait('@getKoejakso').its('response.statusCode').should('eq', 200)
+    cy.wait('@getVastuuhenkilonArvioLomake').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200)
+      expect(response?.body?.tyoskentelyjaksoLiitetty).to.eq(true)
+      expect(response?.body?.tyoskentelyjaksonPituusRiittava).to.eq(true)
+      expect(response?.body?.tyotodistusLiitetty).to.eq(true)
+    })
+    cy.get('[role="status"]', { timeout: 10000 }).should('not.exist')
+    cy.contains('h1', 'Erikoisalan vastuuhenkilön arvio koejaksosta').should('be.visible')
+    cy.contains('työskentelyjaksoa ei liitetty', { matchCase: false }).should('not.exist')
+    cy.contains('työtodistusta ei liitetty', { matchCase: false }).should('not.exist')
+    cy.contains(`${VASTUUHENKILO_ETUNIMI} ${VASTUUHENKILO_SUKUNIMI}`).should('be.visible')
+
+    // Finish: Erikoistuja täyttää ja lähettää arviointipyynnön
+    cy.contains('label', 'Sähköpostiosoite')
+      .parent()
+      .find('input')
+      .clear()
+      .type(E2E_ERIKOISTUVA_EMAIL)
+    cy.contains('label', 'Matkapuhelinnumero')
+      .parent()
+      .find('input')
+      .clear()
+      .type('+358401234567')
+    cy.contains('label', 'Koulutussuunnitelma')
+      .parent()
+      .find('input[type="checkbox"]')
+      .check({ force: true })
+
+    cy.contains('button', 'Lähetä').should('not.be.disabled').click()
+    cy.get('#confirm-send').find('button').contains('Lähetä').click()
+    cy.wait('@postVastuuhenkilonArvio').then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body?.id).to.be.a('number')
+      expect(response?.body?.erikoistuvanSahkoposti).to.eq(E2E_ERIKOISTUVA_EMAIL)
+      expect(response?.body?.erikoistuvanPuhelinnumero).to.eq('+358401234567')
+      expect(response?.body?.erikoistuvanKuittausaika).to.not.be.null
+      Cypress.env('vastuuhenkilonArvioId', response?.body?.id)
+    })
+    cy.url().should('include', '/koejakso')
+    cy.contains('Odottaa virkailijan hyväksyntää', {
+      timeout: 15000,
+    }).should('be.visible')
+
+    cy.then(() => {
+      const vastuuhenkilonArvioId = Cypress.env('vastuuhenkilonArvioId')
+
+      // Finish: Virkailija tarkistaa arviointipyynnön
+      cy.loginAsVirkailija(Cypress.env('virkailijaToken'))
+      cy.apiRequest({
+        method: 'GET',
+        url: `/api/virkailija/koejakso/vastuuhenkilonarvio/${vastuuhenkilonArvioId}`,
+      }).then(({ status, body }) => {
+        expect(status).to.eq(200)
+        expect(body.id).to.eq(vastuuhenkilonArvioId)
+        expect(body.virkailija?.sopimusHyvaksytty).not.to.eq(true)
+
+        return cy.apiRequest({
+          method: 'PUT',
+          url: '/api/virkailija/koejakso/vastuuhenkilonarvio',
+          body: {
+            ...body,
+            lisatiedotVirkailijalta: 'E2E virkailijan lisätiedot vastuuhenkilölle.',
+            virkailijanYhteenveto: 'E2E virkailijan yhteenveto koejaksosta.',
+            virkailijanKorjausehdotus: null,
+          },
+        }).then(({ status, body }) => {
+          expect(status).to.eq(200)
+          expect(body.virkailija?.sopimusHyvaksytty).to.eq(true)
+          expect(body.lisatiedotVirkailijalta).to.eq(
+            'E2E virkailijan lisätiedot vastuuhenkilölle.'
+          )
+        })
+      })
+
+      // Finish: Vastuuhenkilö hyväksyy koejakson arvion
+      cy.loginAsVastuuhenkilo(Cypress.env('vastuuhenkiloToken'))
+      cy.apiRequest({
+        method: 'GET',
+        url: `/api/vastuuhenkilo/koejakso/vastuuhenkilonarvio/${vastuuhenkilonArvioId}`,
+      }).then(({ status, body }) => {
+        expect(status).to.eq(200)
+        expect(body.id).to.eq(vastuuhenkilonArvioId)
+        expect(body.virkailija?.sopimusHyvaksytty).to.eq(true)
+
+        return cy.apiRequest({
+          method: 'PUT',
+          url: '/api/vastuuhenkilo/koejakso/vastuuhenkilonarvio',
+          body: {
+            ...body,
+            koejaksoHyvaksytty: true,
+            vastuuhenkilonKorjausehdotus: null,
+            vastuuhenkilonSahkoposti: VASTUUHENKILO_EMAIL,
+            vastuuhenkilonPuhelinnumero: '+358401234568',
+          },
+          timeout: 120000,
+        }).then(({ status, body }) => {
+          expect(status).to.eq(200)
+          expect(body.vastuuhenkilo?.sopimusHyvaksytty).to.eq(true)
+          expect(body.koejaksoHyvaksytty).to.eq(true)
+          expect(body.vastuuhenkilo?.kuittausaika).to.not.be.null
+          expect(body.vastuuhenkilonKorjausehdotus).to.be.null
+        })
+      })
+    })
+  })
+})

--- a/e2e/cypress/e2e/koulutussuunnitelma/koulutussuunnitelma.cy.ts
+++ b/e2e/cypress/e2e/koulutussuunnitelma/koulutussuunnitelma.cy.ts
@@ -51,14 +51,24 @@ describe('Koulutussuunnitelma', () => {
       .type('Testataan e2e-automaatiolla.')
 
     // 5. Koulutusjakson tallentaminen
+    cy.intercept('POST', '**/erikoistuva-laakari/koulutussuunnitelma/koulutusjaksot').as(
+      'koulutusjaksoPost'
+    )
     cy.contains('button', 'Tallenna koulutusjakso').click()
+    cy.wait('@koulutusjaksoPost').then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body?.id).to.be.a('number')
+      expect(response?.body?.nimi).to.eq('E2E Testi Koulutusjakso')
+      expect(response?.body?.muutOsaamistavoitteet).to.eq('Testataan e2e-automaatiolla.')
+    })
 
     // Tallennuksen jälkeen ohjaudutaan koulutusjakson sivulle
     cy.url().should('match', /\/koulutussuunnitelma\/koulutusjaksot\/\d+$/)
+    cy.contains('E2E Testi Koulutusjakso').should('be.visible')
+    cy.contains('Testataan e2e-automaatiolla.').should('be.visible')
 
     // Uusi koulutusjakso näkyy koulutussuunnitelmassa
     cy.visit('/koulutussuunnitelma')
     cy.contains('E2E Testi Koulutusjakso').should('be.visible')
   })
 })
-

--- a/e2e/cypress/plugins/db-tasks/tyoskentelyjakso.ts
+++ b/e2e/cypress/plugins/db-tasks/tyoskentelyjakso.ts
@@ -17,7 +17,8 @@ async function findExistingTyoskentelyjakso(
 
 async function createTyoskentelyjakso(
   client: Client,
-  opintooikeusId: number
+  opintooikeusId: number,
+  liitettyKoejaksoon = false
 ): Promise<number> {
   const kuntaResult = await client.query(`SELECT id FROM kunta LIMIT 1`)
   const kuntaId: number = kuntaResult.rows[0].id
@@ -30,6 +31,8 @@ async function createTyoskentelyjakso(
       [kuntaId]
     )
   ).rows[0].id
+  const alkamispaiva = liitettyKoejaksoon ? '2025-01-01' : '2020-01-01'
+  const paattymispaiva = liitettyKoejaksoon ? '2025-08-31' : null
 
   return (
     await client.query(
@@ -38,12 +41,46 @@ async function createTyoskentelyjakso(
           hyvaksytty_aiempaan_erikoisalaan, liitetty_koejaksoon,
           liitetty_terveyskeskuskoulutusjaksoon,
           tyoskentelypaikka_id, opintooikeus_id)
-       VALUES ('2020-01-01', NULL, 100, 'OMAN_ERIKOISALAN_KOULUTUS',
-               false, false, false, $1, $2)
+       VALUES ($3, $4, 100, 'OMAN_ERIKOISALAN_KOULUTUS',
+               false, $5, false, $1, $2)
        RETURNING id`,
-      [tyoskentelypaikkaId, opintooikeusId]
+      [tyoskentelypaikkaId, opintooikeusId, alkamispaiva, paattymispaiva, liitettyKoejaksoon]
     )
   ).rows[0].id
+}
+
+async function ensureKoejaksoAttachment(
+  client: Client,
+  opintooikeusId: number,
+  tyoskentelyjaksoId: number
+): Promise<void> {
+  await client.query(
+    `UPDATE tyoskentelyjakso
+     SET liitetty_koejaksoon = true,
+         alkamispaiva = '2025-01-01',
+         paattymispaiva = '2025-08-31',
+         osaaikaprosentti = 100
+     WHERE id = $1`,
+    [tyoskentelyjaksoId]
+  )
+
+  await client.query(
+    `INSERT INTO asiakirja_data (data)
+     SELECT decode('255044462d312e370a25454f460a', 'hex')
+     WHERE NOT EXISTS (
+       SELECT 1 FROM asiakirja WHERE tyoskentelyjakso_id = $1
+     )`,
+    [tyoskentelyjaksoId]
+  )
+
+  await client.query(
+    `INSERT INTO asiakirja (opintooikeus_id, tyoskentelyjakso_id, nimi, tyyppi, lisattypvm, asiakirja_data_id)
+     SELECT $1, $2, 'e2e-koejakso-tyotodistus.pdf', 'application/pdf', NOW(), currval(pg_get_serial_sequence('asiakirja_data', 'id'))
+     WHERE NOT EXISTS (
+       SELECT 1 FROM asiakirja WHERE tyoskentelyjakso_id = $2
+     )`,
+    [opintooikeusId, tyoskentelyjaksoId]
+  )
 }
 
 // ─── Exported task ────────────────────────────────────────────────────────────
@@ -54,6 +91,8 @@ async function createTyoskentelyjakso(
  * db:seedTyoskentelyjakso – Creates a työskentelyjakso for the user's active
  *                           opinto-oikeus so the arviointipyyntö form has
  *                           selectable options. Idempotent.
+ * db:ensureKoejaksoTyoskentelyjakso – Creates or updates a työskentelyjakso
+ *                           that satisfies the vastuuhenkilön arvio prechecks.
  */
 export const tyoskentelyjaksotTasks = {
   async 'db:seedTyoskentelyjakso'({
@@ -69,6 +108,24 @@ export const tyoskentelyjaksotTasks = {
       if (existingId) return { tyoskentelyjaksoId: existingId }
 
       const tyoskentelyjaksoId = await createTyoskentelyjakso(client, opintooikeusId)
+      return { tyoskentelyjaksoId }
+    })
+  },
+
+  async 'db:ensureKoejaksoTyoskentelyjakso'({
+                                              email,
+                                            }: {
+    email: string
+  }): Promise<{ tyoskentelyjaksoId: number } | null> {
+    return withDb(dbClient, async (client: any) => {
+      const opintooikeusId = await getOpintooikeusId(client, email)
+      if (!opintooikeusId) return null
+
+      const existingId = await findExistingTyoskentelyjakso(client, opintooikeusId)
+      const tyoskentelyjaksoId =
+        existingId ?? (await createTyoskentelyjakso(client, opintooikeusId, true))
+
+      await ensureKoejaksoAttachment(client, opintooikeusId, tyoskentelyjaksoId)
       return { tyoskentelyjaksoId }
     })
   },


### PR DESCRIPTION
This pull request adds a comprehensive end-to-end test for the "vastuuhenkilön arvio" (responsible person's evaluation) workflow, improves the reliability and coverage of several existing E2E tests by adding response assertions, and extends the database task utilities to better support test setup for cases involving työskentelyjakso (work period) attachments. The main changes are grouped below:

### New E2E Test for Vastuuhenkilön Arvio (Responsible Person's Evaluation)

* Added a new test file `vastuuhenkilon-arvio.cy.ts` implementing a full E2E scenario for the vastuuhenkilön arvio process, including database seeding, form submission, and multi-role approval flows.

### Enhanced E2E Test Assertions and Coverage

* Improved assertions in `arvioinnit.cy.ts` for aloituskeskustelu, väliarviointi, and loppukeskustelu forms by checking API responses after form submissions, ensuring correct status codes and response data. [[1]](diffhunk://#diff-4aedc67f99c211cfdaaabe86fe74fbecd2837542bb408df8a8262c0c72ea5bb3R78) [[2]](diffhunk://#diff-4aedc67f99c211cfdaaabe86fe74fbecd2837542bb408df8a8262c0c72ea5bb3R132-R140) [[3]](diffhunk://#diff-4aedc67f99c211cfdaaabe86fe74fbecd2837542bb408df8a8262c0c72ea5bb3L172-R186) [[4]](diffhunk://#diff-4aedc67f99c211cfdaaabe86fe74fbecd2837542bb408df8a8262c0c72ea5bb3L209-L213)
* Enhanced the koulutussuunnitelma test (`koulutussuunnitelma.cy.ts`) to assert the POST response when saving a koulutusjakso, verifying the returned data and its visibility in the UI.

### Database Task Utilities and Test Data Setup

* Extended `createTyoskentelyjakso` to support creation of työskentelyjakso entries already attached to a koejakso, and added an `ensureKoejaksoAttachment` helper for updating existing entries and attaching required documents. [[1]](diffhunk://#diff-2218906db0b05617f9c942382788fa37b2da4affdbc5b251bdf4b6c43783ad55L20-R21) [[2]](diffhunk://#diff-2218906db0b05617f9c942382788fa37b2da4affdbc5b251bdf4b6c43783ad55R34-R35) [[3]](diffhunk://#diff-2218906db0b05617f9c942382788fa37b2da4affdbc5b251bdf4b6c43783ad55L41-R85)
* Added a new exported database task `db:ensureKoejaksoTyoskentelyjakso` to ensure the test user has a työskentelyjakso with all preconditions for vastuuhenkilön arvio met, including document attachments. [[1]](diffhunk://#diff-2218906db0b05617f9c942382788fa37b2da4affdbc5b251bdf4b6c43783ad55R94-R95) [[2]](diffhunk://#diff-2218906db0b05617f9c942382788fa37b2da4affdbc5b251bdf4b6c43783ad55R114-R131)