### PR TITLE
Add management port and job triggering endpoint

### DIFF
--- a/infra/docker-compose-cicd.yml
+++ b/infra/docker-compose-cicd.yml
@@ -58,7 +58,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/management/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8081/management/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 12

--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
@@ -195,6 +195,7 @@ class SecurityConfiguration(
                 .requestMatchers("/").permitAll() // ohjaus etusivulle
                 .requestMatchers("/kirjaudu").permitAll()
                 .requestMatchers("/api/").permitAll()
+                .requestMatchers("/api/ping").permitAll()
                 .requestMatchers("/api/haka-yliopistot").permitAll()
                 .requestMatchers("/api/julkinen/**").permitAll()
                 .requestMatchers("/api/auth-info").denyAll()

--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/management/ManagementSecurityConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/management/ManagementSecurityConfiguration.kt
@@ -1,0 +1,32 @@
+package fi.elsapalvelu.elsa.config.management
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+/**
+ * Permits all requests arriving on the dedicated management port (8081).
+ * Network-level access is restricted by the EC2 SSM security group → ECS task
+ * security group rule, so no application-level auth is needed here.
+ *
+ * Must be @Order(0) to take priority over the main SecurityConfiguration filter chain.
+ */
+@Configuration
+class ManagementSecurityConfiguration {
+
+    @Bean
+    @Order(0)
+    fun managementPortSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http.securityMatcher { request -> request.localPort == MANAGEMENT_PORT }
+        http.authorizeHttpRequests { auth -> auth.anyRequest().permitAll() }
+        http.csrf { csrf -> csrf.disable() }
+        return http.build()
+    }
+
+    companion object {
+        const val MANAGEMENT_PORT = 8081
+    }
+}
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/AbstractTriggerableJob.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/AbstractTriggerableJob.kt
@@ -1,0 +1,9 @@
+package fi.elsapalvelu.elsa.scheduler
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+abstract class AbstractTriggerableJob : TriggerableJob {
+    protected val log: Logger = LoggerFactory.getLogger(javaClass)
+}
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/JobTriggerEndpoint.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/JobTriggerEndpoint.kt
@@ -1,0 +1,77 @@
+package fi.elsapalvelu.elsa.scheduler
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint
+import org.springframework.boot.actuate.endpoint.annotation.Selector
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+import java.sql.Timestamp
+import java.time.Instant
+
+/**
+ * Actuator endpoint for manually triggering scheduled jobs from the bastion host.
+ *
+ * Available at: POST /management/jobtrigger/{jobName}  (port 8081, VPC-internal only)
+ *
+ * Jobs are auto-discovered via Spring injection of all [TriggerableJob] beans.
+ * To make a new scheduler manually triggerable, simply implement [TriggerableJob]
+ * (or extend [AbstractTriggerableJob]) — no changes needed here.
+ */
+@Component
+@Endpoint(id = "jobtrigger")
+class JobTriggerEndpoint(
+    jobs: List<TriggerableJob>,
+    private val jdbcTemplate: JdbcTemplate
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val jobRegistry: Map<String, TriggerableJob> = jobs.associateBy { it.jobName }
+
+    @WriteOperation
+    fun trigger(@Selector jobName: String): WebEndpointResponse<Map<String, String>> {
+        val job = jobRegistry[jobName]
+            ?: return WebEndpointResponse(
+                mapOf(
+                    "status" to "error",
+                    "message" to "Unknown job: '$jobName'. Valid jobs: ${jobRegistry.keys.sorted().joinToString()}"
+                ),
+                400
+            )
+
+        val isLocked = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM shedlock WHERE name = ? AND lock_until > ?",
+            Int::class.java,
+            jobName,
+            Timestamp.from(Instant.now())
+        )?.let { it > 0 } ?: false
+
+        if (isLocked) {
+            return WebEndpointResponse(
+                mapOf(
+                    "status" to "conflict",
+                    "message" to "Job '$jobName' is currently running or locked. Try again later."
+                ),
+                409
+            )
+        }
+
+        return try {
+            log.info("Manually triggering job: $jobName")
+            job.runJob()
+            log.info("Manual job trigger completed: $jobName")
+            WebEndpointResponse(
+                mapOf("status" to "ok", "message" to "Job '$jobName' triggered successfully."),
+                200
+            )
+        } catch (e: Exception) {
+            log.error("Manual job trigger failed for '$jobName': ${e.message}", e)
+            WebEndpointResponse(
+                mapOf("status" to "error", "message" to "Job '$jobName' failed: ${e.message}"),
+                500
+            )
+        }
+    }
+}
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/TriggerableJob.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/TriggerableJob.kt
@@ -1,0 +1,7 @@
+package fi.elsapalvelu.elsa.scheduler
+
+interface TriggerableJob {
+    val jobName: String
+    fun runJob()
+}
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledOpintotietoImport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledOpintotietoImport.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.scheduler
+package fi.elsapalvelu.elsa.scheduler.jobs
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.User
@@ -16,6 +16,7 @@ import javax.crypto.Cipher
 import javax.crypto.SecretKey
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
+import fi.elsapalvelu.elsa.scheduler.AbstractTriggerableJob
 
 @Component
 class ScheduledOpintotietoImport(
@@ -36,6 +37,7 @@ class ScheduledOpintotietoImport(
     }
 
     override fun runJob() {
+        log.info("OpintotietoImport käynnistetty")
         val timestamp = LocalDateTime.now()
         val cipher = Cipher.getInstance(applicationProperties.getSecurity().cipherAlgorithm)
         val decodedKey = Base64.getDecoder().decode(applicationProperties.getSecurity().encodedKey)
@@ -48,36 +50,47 @@ class ScheduledOpintotietoImport(
         val opintosuoritusServices =
             opintosuorituksetFetchingService.filter { it.shouldFetchOpintosuoritukset() }
                 .associateBy { it.getYliopisto() }
-        opintooikeusRepository.findAllValid()
-            .distinctBy { Pair(it.erikoistuvaLaakari?.id, it.yliopisto?.id) }.forEach {
-                val user = it.erikoistuvaLaakari?.kayttaja?.user!!
-                getHetu(user, cipher, originalKey)?.let { hetu ->
-                    runBlocking {
-                        try {
-                            opintotietoServices[it.yliopisto?.nimi]?.fetchOpintotietodata(hetu)
-                                ?.let { data ->
-                                    opintotietodataPersistenceService.createOrUpdateOpintotieto(
-                                        user.id!!,
-                                        data
-                                    )
-                                }
-                            opintosuoritusServices[it.yliopisto?.nimi]?.fetchOpintosuoritukset(hetu)
-                                ?.let { data ->
-                                    opintosuorituksetPersistenceService.createOrUpdateIfChanged(
-                                        user.id!!,
-                                        data
-                                    )
-                                }
-                        } catch (e: Exception) {
-                            log.error("OpintotietoImport virhe: ${e.message}")
-                        }
+        val opintooikeudet = opintooikeusRepository.findAllValid()
+            .distinctBy { Pair(it.erikoistuvaLaakari?.id, it.yliopisto?.id) }
+        log.info("OpintotietoImport: löydetty ${opintooikeudet.size} käyttäjää")
+        opintooikeudet.forEachIndexed { index, opintooikeus ->
+            val user = opintooikeus.erikoistuvaLaakari?.kayttaja?.user!!
+            val yliopistoNimi = opintooikeus.yliopisto?.nimi
+            log.info(
+                "OpintotietoImport: käyttäjä ${index + 1}/${opintooikeudet.size}: " +
+                    "userId=${user.id}, yliopisto=$yliopistoNimi"
+            )
+            getHetu(user, cipher, originalKey)?.let { hetu ->
+                runBlocking {
+                    try {
+                        opintotietoServices[yliopistoNimi]?.fetchOpintotietodata(hetu)
+                            ?.let { data ->
+                                opintotietodataPersistenceService.createOrUpdateOpintotieto(
+                                    user.id!!,
+                                    data
+                                )
+                            }
+                        opintosuoritusServices[yliopistoNimi]?.fetchOpintosuoritukset(hetu)
+                            ?.let { data ->
+                                opintosuorituksetPersistenceService.createOrUpdateIfChanged(
+                                    user.id!!,
+                                    data
+                                )
+                            }
+                    } catch (e: Exception) {
+                        log.error(
+                            "OpintotietoImport virhe käyttäjälle ${user.id} " +
+                                "(yliopisto=$yliopistoNimi): ${e.message}",
+                            e
+                        )
                     }
                 }
             }
+        }
         log.info(
-            "OpintotietoImport completed in ${
+            "OpintotietoImport valmis ${
                 Duration.between(timestamp, LocalDateTime.now()).toSeconds()
-            } seconds."
+            } sekunnissa"
         )
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledOpintotietoImport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledOpintotietoImport.kt
@@ -6,7 +6,6 @@ import fi.elsapalvelu.elsa.repository.OpintooikeusRepository
 import fi.elsapalvelu.elsa.service.*
 import kotlinx.coroutines.*
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
-import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.nio.charset.StandardCharsets
@@ -26,12 +25,17 @@ class ScheduledOpintotietoImport(
     private val opintosuorituksetPersistenceService: OpintosuorituksetPersistenceService,
     private val opintooikeusRepository: OpintooikeusRepository,
     private val applicationProperties: ApplicationProperties
-) {
-    private val log = LoggerFactory.getLogger(javaClass)
+) : AbstractTriggerableJob() {
+
+    override val jobName = "opintotietoImport"
 
     @Scheduled(cron = "0 0 4 ? * *", zone = "Europe/Helsinki")
     @SchedulerLock(name = "opintotietoImport", lockAtLeastFor = "5S", lockAtMostFor = "10M")
     fun import() {
+        runJob()
+    }
+
+    override fun runJob() {
         val timestamp = LocalDateTime.now()
         val cipher = Cipher.getInstance(applicationProperties.getSecurity().cipherAlgorithm)
         val decodedKey = Base64.getDecoder().decode(applicationProperties.getSecurity().encodedKey)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledPaattyvaOpintooikeusHerate.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledPaattyvaOpintooikeusHerate.kt
@@ -8,7 +8,6 @@ import fi.elsapalvelu.elsa.repository.OpintooikeusRepository
 import fi.elsapalvelu.elsa.service.MailProperty
 import fi.elsapalvelu.elsa.service.MailService
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
-import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.time.DayOfWeek
@@ -22,16 +21,21 @@ data class PaattyvaOikeus (
 )
 
 @Component
-class ScheduledPaattyvaOpintooikeusHerate (
+class ScheduledPaattyvaOpintooikeusHerate(
     private val opintooikeusRepository: OpintooikeusRepository,
     private val mailService: MailService,
     private val opintooikeusHerateRepository: OpintooikeusHerateRepository
-) {
-    private val log = LoggerFactory.getLogger(javaClass)
+) : AbstractTriggerableJob() {
+
+    override val jobName = "paattyvaOpintooikeusHerate"
 
     @Scheduled(cron = "0 0 6 * * 1", zone = "Europe/Helsinki")
     @SchedulerLock(name = "paattyvaOpintooikeusHerate", lockAtLeastFor = "5S", lockAtMostFor = "10M")
     fun fetchPaattyvatOpintooikeudet() {
+        runJob()
+    }
+
+    override fun runJob() {
         val today = LocalDate.now()
         val monday = today.with(DayOfWeek.MONDAY)
         val sunday = today.with(DayOfWeek.SUNDAY)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledPaattyvaOpintooikeusHerate.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledPaattyvaOpintooikeusHerate.kt
@@ -1,20 +1,23 @@
-package fi.elsapalvelu.elsa.scheduler
+package fi.elsapalvelu.elsa.scheduler.jobs
 
 import fi.elsapalvelu.elsa.domain.ErikoistuvaLaakari
 import fi.elsapalvelu.elsa.domain.Opintooikeus
 import fi.elsapalvelu.elsa.domain.OpintooikeusHerate
 import fi.elsapalvelu.elsa.repository.OpintooikeusHerateRepository
 import fi.elsapalvelu.elsa.repository.OpintooikeusRepository
+import fi.elsapalvelu.elsa.scheduler.AbstractTriggerableJob
 import fi.elsapalvelu.elsa.service.MailProperty
 import fi.elsapalvelu.elsa.service.MailService
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.time.DayOfWeek
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 
-data class PaattyvaOikeus (
+data class PaattyvaOikeus(
     var maaraaikainen: Boolean,
     var paattymispaiva: LocalDate?,
     var erikoistuvaLaakari: ErikoistuvaLaakari?
@@ -36,6 +39,8 @@ class ScheduledPaattyvaOpintooikeusHerate(
     }
 
     override fun runJob() {
+        log.info("PaattyvaOpintooikeusHerate käynnistetty")
+        val timestamp = LocalDateTime.now()
         val today = LocalDate.now()
         val monday = today.with(DayOfWeek.MONDAY)
         val sunday = today.with(DayOfWeek.SUNDAY)
@@ -51,11 +56,18 @@ class ScheduledPaattyvaOpintooikeusHerate(
             opintooikeusRepository.findAllPaattyvatByTimeFrame(monday.plusYears(1), sunday.plusYears(1))
                 .mapNotNull { mapPaattyvaOikeus(it).takeIf { o -> !o.maaraaikainen } }
         )
+        val totalCount = paattyvatOikeudet.sumOf { it.size }
+        log.info("PaattyvaOpintooikeusHerate: löydetty $totalCount päättyvää opinto-oikeutta")
         paattyvatOikeudet.forEach {
             if (it.isNotEmpty()) it.forEach { oikeus ->
                 lahetaHerate(oikeus)
             }
         }
+        log.info(
+            "PaattyvaOpintooikeusHerate valmis ${
+                Duration.between(timestamp, LocalDateTime.now()).toSeconds()
+            } sekunnissa"
+        )
     }
 
     fun mapPaattyvaOikeus(opintoOikeus: Opintooikeus): PaattyvaOikeus {
@@ -69,6 +81,10 @@ class ScheduledPaattyvaOpintooikeusHerate(
     fun lahetaHerate(paattyvaOikeus: PaattyvaOikeus) {
         try {
             val user = paattyvaOikeus.erikoistuvaLaakari?.kayttaja?.user ?: return
+            log.info(
+                "PaattyvaOpintooikeusHerate: lähetetään herätesähköposti käyttäjälle userId=${user.id}, " +
+                    "paattymispaiva=${paattyvaOikeus.paattymispaiva}, maaraaikainen=${paattyvaOikeus.maaraaikainen}"
+            )
             val properties =
                 if (paattyvaOikeus.maaraaikainen) {
                     mapOf(
@@ -107,7 +123,11 @@ class ScheduledPaattyvaOpintooikeusHerate(
             } else opintooikeusHerate.paattymassaHerateLahetetty = Instant.now()
             opintooikeusHerateRepository.save(opintooikeusHerate)
         } catch (e: Exception) {
-            log.error("Herätteen lähetys päättyvästä opinto-oikeudesta ei onnistunut.", e)
+            log.error(
+                "PaattyvaOpintooikeusHerate: herätteen lähetys epäonnistui käyttäjälle " +
+                    "userId=${paattyvaOikeus.erikoistuvaLaakari?.kayttaja?.user?.id}: ${e.message}",
+                e
+            )
         }
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledSisuTutkintoohjelmaImport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledSisuTutkintoohjelmaImport.kt
@@ -1,11 +1,14 @@
-package fi.elsapalvelu.elsa.scheduler
+package fi.elsapalvelu.elsa.scheduler.jobs
 
+import fi.elsapalvelu.elsa.scheduler.AbstractTriggerableJob
 import fi.elsapalvelu.elsa.service.SisuTutkintoohjelmaFetchingService
 import fi.elsapalvelu.elsa.service.SisuTutkintoohjelmaImportService
 import kotlinx.coroutines.runBlocking
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.LocalDateTime
 
 @Component
 class ScheduledSisuTutkintoohjelmaImport(
@@ -22,14 +25,21 @@ class ScheduledSisuTutkintoohjelmaImport(
     }
 
     override fun runJob() {
+        log.info("SisuTutkintoohjelmaImport käynnistetty")
+        val timestamp = LocalDateTime.now()
         runBlocking {
             try {
                 sisuTutkintoohjelmaFetchingService.fetch()?.let {
                     sisuTutkintoohjelmaImportService.import(it)
                 }
             } catch (e: Exception) {
-                log.error("SisuTutkintoohjelmaExportJob virhe: ${e.message}")
+                log.error("SisuTutkintoohjelmaImport virhe: ${e.message}", e)
             }
         }
+        log.info(
+            "SisuTutkintoohjelmaImport valmis ${
+                Duration.between(timestamp, LocalDateTime.now()).toSeconds()
+            } sekunnissa"
+        )
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledSisuTutkintoohjelmaImport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledSisuTutkintoohjelmaImport.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.service.SisuTutkintoohjelmaFetchingService
 import fi.elsapalvelu.elsa.service.SisuTutkintoohjelmaImportService
 import kotlinx.coroutines.runBlocking
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
-import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
@@ -12,12 +11,17 @@ import org.springframework.stereotype.Component
 class ScheduledSisuTutkintoohjelmaImport(
     private val sisuTutkintoohjelmaFetchingService: SisuTutkintoohjelmaFetchingService,
     private val sisuTutkintoohjelmaImportService: SisuTutkintoohjelmaImportService
-) {
-    private val log = LoggerFactory.getLogger(javaClass)
+) : AbstractTriggerableJob() {
+
+    override val jobName = "sisuTutkintoohjelmaImport"
 
     @Scheduled(cron = "0 0 3 ? * *", zone = "Europe/Helsinki")
     @SchedulerLock(name = "sisuTutkintoohjelmaImport", lockAtLeastFor = "5S", lockAtMostFor = "10M")
     fun import() {
+        runJob()
+    }
+
+    override fun runJob() {
         runBlocking {
             try {
                 sisuTutkintoohjelmaFetchingService.fetch()?.let {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledTerveyskeskuskoulutusjaksoSuoritusmerkinta.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledTerveyskeskuskoulutusjaksoSuoritusmerkinta.kt
@@ -1,12 +1,15 @@
-package fi.elsapalvelu.elsa.scheduler
+package fi.elsapalvelu.elsa.scheduler.jobs
 
 import fi.elsapalvelu.elsa.repository.KayttajaRepository
 import fi.elsapalvelu.elsa.repository.OpintooikeusRepository
+import fi.elsapalvelu.elsa.scheduler.AbstractTriggerableJob
 import fi.elsapalvelu.elsa.service.*
 import kotlinx.coroutines.runBlocking
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.LocalDateTime
 
 @Component
 class ScheduledTerveyskeskuskoulutusjaksoSuoritusmerkinta(
@@ -31,22 +34,32 @@ class ScheduledTerveyskeskuskoulutusjaksoSuoritusmerkinta(
     }
 
     override fun runJob() {
+        log.info("TerveyskeskuskoulutusjaksoSuoritusmerkinta käynnistetty")
+        val timestamp = LocalDateTime.now()
         runBlocking {
             try {
-                opintooikeusService.findAllByTerveyskoulutusjaksoSuorittamatta().forEach {
-                    if (opintosuoritusService.getTerveyskoulutusjaksoSuoritettu(it.id!!, it.erikoistuvaLaakari?.id!!)) {
-                        it.terveyskoulutusjaksoSuoritettu = true
-                        opintooikeusRepository.save(it)
-                    }
-                    else if (terveyskeskuskoulutusjaksonHyvaksyntaService.getTerveyskoulutusjaksoSuoritettu(
-                            it.id!!
+                val opintooikeudet = opintooikeusService.findAllByTerveyskoulutusjaksoSuorittamatta()
+                log.info(
+                    "TerveyskeskuskoulutusjaksoSuoritusmerkinta: löydetty ${opintooikeudet.size} " +
+                        "käsittelemätöntä opinto-oikeutta"
+                )
+                opintooikeudet.forEachIndexed { index, opintooikeus ->
+                    log.info(
+                        "TerveyskeskuskoulutusjaksoSuoritusmerkinta: käsitellään " +
+                            "${index + 1}/${opintooikeudet.size}: opintooikeusId=${opintooikeus.id}"
+                    )
+                    if (opintosuoritusService.getTerveyskoulutusjaksoSuoritettu(opintooikeus.id!!, opintooikeus.erikoistuvaLaakari?.id!!)) {
+                        opintooikeus.terveyskoulutusjaksoSuoritettu = true
+                        opintooikeusRepository.save(opintooikeus)
+                    } else if (terveyskeskuskoulutusjaksonHyvaksyntaService.getTerveyskoulutusjaksoSuoritettu(
+                            opintooikeus.id!!
                         )
                     ) {
-                        it.terveyskoulutusjaksoSuoritettu = true
-                        opintooikeusRepository.save(it)
+                        opintooikeus.terveyskoulutusjaksoSuoritettu = true
+                        opintooikeusRepository.save(opintooikeus)
 
                         mailService.sendEmailFromTemplate(
-                            kayttajaRepository.findById(it.erikoistuvaLaakari?.kayttaja?.id!!)
+                            kayttajaRepository.findById(opintooikeus.erikoistuvaLaakari?.kayttaja?.id!!)
                                 .get().user!!,
                             templateName = "tkkjaksonSuoritusmerkintaHaettavissa.html",
                             titleKey = "email.tkkjaksonsuoritusmerkintahaettavissa.title",
@@ -55,8 +68,13 @@ class ScheduledTerveyskeskuskoulutusjaksoSuoritusmerkinta(
                     }
                 }
             } catch (e: Exception) {
-                log.error("TerveyskeskuskoulutusjaksoSuoritusmerkinta virhe: ${e.message}")
+                log.error("TerveyskeskuskoulutusjaksoSuoritusmerkinta virhe: ${e.message}", e)
             }
         }
+        log.info(
+            "TerveyskeskuskoulutusjaksoSuoritusmerkinta valmis ${
+                Duration.between(timestamp, LocalDateTime.now()).toSeconds()
+            } sekunnissa"
+        )
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledTerveyskeskuskoulutusjaksoSuoritusmerkinta.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledTerveyskeskuskoulutusjaksoSuoritusmerkinta.kt
@@ -5,7 +5,6 @@ import fi.elsapalvelu.elsa.repository.OpintooikeusRepository
 import fi.elsapalvelu.elsa.service.*
 import kotlinx.coroutines.runBlocking
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
-import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
@@ -17,8 +16,9 @@ class ScheduledTerveyskeskuskoulutusjaksoSuoritusmerkinta(
     private val kayttajaRepository: KayttajaRepository,
     private val opintooikeusRepository: OpintooikeusRepository,
     private val opintosuoritusService: OpintosuoritusService
-) {
-    private val log = LoggerFactory.getLogger(javaClass)
+) : AbstractTriggerableJob() {
+
+    override val jobName = "terveyskeskuskoulutusjaksoSuoritusmerkinta"
 
     @Scheduled(cron = "0 0 10 * * *", zone = "Europe/Helsinki")
     @SchedulerLock(
@@ -27,6 +27,10 @@ class ScheduledTerveyskeskuskoulutusjaksoSuoritusmerkinta(
         lockAtMostFor = "10M"
     )
     fun check() {
+        runJob()
+    }
+
+    override fun runJob() {
         runBlocking {
             try {
                 opintooikeusService.findAllByTerveyskoulutusjaksoSuorittamatta().forEach {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/PingResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/PingResource.kt
@@ -1,0 +1,15 @@
+package fi.elsapalvelu.elsa.web.rest
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api")
+class PingResource {
+
+    @GetMapping("/ping")
+    fun ping(): ResponseEntity<String> = ResponseEntity.ok("OK")
+}
+

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -15,6 +15,8 @@
 # ===================================================================
 
 management:
+  server:
+    port: 8081
   endpoints:
     web:
       base-path: /management
@@ -32,6 +34,7 @@ management:
             "threaddump",
             "caches",
             "liquibase",
+            "jobtrigger",
           ]
   endpoint:
     health:


### PR DESCRIPTION
This pull request introduces a new framework for manually triggering scheduled jobs via a secure Actuator endpoint, refactors existing scheduled jobs to support this mechanism, and improves logging and maintainability. It also updates security settings to allow unauthenticated access to management endpoints on a dedicated port and makes minor configuration changes.

**Manual Job Triggering & Scheduler Refactor:**

- Introduced a `TriggerableJob` interface and an `AbstractTriggerableJob` base class, allowing scheduled jobs to be triggered both on schedule and manually. Existing jobs (`ScheduledOpintotietoImport`, `ScheduledPaattyvaOpintooikeusHerate`, `ScheduledSisuTutkintoohjelmaImport`) are refactored to implement this interface and moved to a dedicated `jobs` package. This enables new jobs to be easily made triggerable by extending the base class. [[1]](diffhunk://#diff-752339d43896bc3fb5dfe594ae3ea0859258ae259ecb727bce419718963895adR1-R7) [[2]](diffhunk://#diff-10efaed4fc737b6b2c001fa46c25038fc750695ec8f77e5c3d2a5536fb5a0c96R1-R9) [[3]](diffhunk://#diff-0b71cd63d00b8b6347e0216b1e9bb8628694d3db8df5cdb448cf978b6ed378a0L1-L9) [[4]](diffhunk://#diff-8fde4c92234f7f48b69f7daca3ca5cd5ba04d3e8b2b369fad1a48018b85c4e5aL1-R18) [[5]](diffhunk://#diff-406cceee8f589f29af8dabefdb8cc9071a81dd9eda8ff56bbdd7536659ce6cb1L1-R43)
- Added a new Actuator endpoint `JobTriggerEndpoint` at `/management/jobtrigger/{jobName}` (on port 8081) for triggering jobs from the bastion host. The endpoint checks for job existence, lock status, and provides clear responses for success, conflict, or error.

**Security and Management Endpoint Changes:**

- Added `ManagementSecurityConfiguration` to allow unauthenticated access to management endpoints on port 8081, relying on network-level security. This ensures that the new manual job trigger endpoint is accessible only within the internal network.
- Updated the Docker Compose health check to use the management port (8081) instead of the application port (8080), aligning with the new management endpoint configuration.
- Allowed unauthenticated access to `/api/ping` in the main security configuration.

**Logging and Observability Improvements:**

- Enhanced logging in scheduled jobs to include job start/completion times, per-user progress, and detailed error messages. This provides better traceability for both scheduled and manually triggered runs. [[1]](diffhunk://#diff-0b71cd63d00b8b6347e0216b1e9bb8628694d3db8df5cdb448cf978b6ed378a0L47-R93) [[2]](diffhunk://#diff-8fde4c92234f7f48b69f7daca3ca5cd5ba04d3e8b2b369fad1a48018b85c4e5aR59-R70) [[3]](diffhunk://#diff-8fde4c92234f7f48b69f7daca3ca5cd5ba04d3e8b2b369fad1a48018b85c4e5aR84-R87) [[4]](diffhunk://#diff-8fde4c92234f7f48b69f7daca3ca5cd5ba04d3e8b2b369fad1a48018b85c4e5aL106-R130) [[5]](diffhunk://#diff-406cceee8f589f29af8dabefdb8cc9071a81dd9eda8ff56bbdd7536659ce6cb1L1-R43)

**Codebase Cleanup:**

- Renamed scheduled job files and reorganized them into a `jobs` subpackage for clarity and maintainability. [[1]](diffhunk://#diff-0b71cd63d00b8b6347e0216b1e9bb8628694d3db8df5cdb448cf978b6ed378a0L1-L9) [[2]](diffhunk://#diff-8fde4c92234f7f48b69f7daca3ca5cd5ba04d3e8b2b369fad1a48018b85c4e5aL1-R18) [[3]](diffhunk://#diff-406cceee8f589f29af8dabefdb8cc9071a81dd9eda8ff56bbdd7536659ce6cb1L1-R43)

**References:** [[1]](diffhunk://#diff-752339d43896bc3fb5dfe594ae3ea0859258ae259ecb727bce419718963895adR1-R7) [[2]](diffhunk://#diff-10efaed4fc737b6b2c001fa46c25038fc750695ec8f77e5c3d2a5536fb5a0c96R1-R9) [[3]](diffhunk://#diff-0b71cd63d00b8b6347e0216b1e9bb8628694d3db8df5cdb448cf978b6ed378a0L1-L9) [[4]](diffhunk://#diff-fad750949c9d0ef12731459cb796cde479b487d9bb15b42fe815198f17abd2beR1-R77) [[5]](diffhunk://#diff-6e2e634ba5f2929cc87bace12a58a55f4aee5e91915553712f06ac31c171471aR1-R32) [[6]](diffhunk://#diff-28df44e601540147c8462a79de983fa2fc26fbfffa056ab1e05027f7c50a717eL61-R61) [[7]](diffhunk://#diff-19835b16131875979bb6ff061c388d3dbf9aa80fc6c976d18ea02cd5388d7e08R198) [[8]](diffhunk://#diff-0b71cd63d00b8b6347e0216b1e9bb8628694d3db8df5cdb448cf978b6ed378a0L47-R93) [[9]](diffhunk://#diff-8fde4c92234f7f48b69f7daca3ca5cd5ba04d3e8b2b369fad1a48018b85c4e5aR59-R70) [[10]](diffhunk://#diff-8fde4c92234f7f48b69f7daca3ca5cd5ba04d3e8b2b369fad1a48018b85c4e5aR84-R87) [[11]](diffhunk://#diff-8fde4c92234f7f48b69f7daca3ca5cd5ba04d3e8b2b369fad1a48018b85c4e5aL106-R130) [[12]](diffhunk://#diff-406cceee8f589f29af8dabefdb8cc9071a81dd9eda8ff56bbdd7536659ce6cb1L1-R43) [[13]](diffhunk://#diff-d49d47f8c70ee60bd336aad755385a1f52c2ca57731775d9a72ac3c5da3eb8ecL1-L58)