### PR TITLE
Remove unnecessary AWS S3 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,6 @@ dependencies {
     testImplementation "com.h2database:h2:2.4.240"
     implementation "org.jetbrains.kotlin:kotlin-reflect"
     implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.2.1'
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.2.1'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sns:3.2.1'
     implementation 'io.micrometer:micrometer-registry-cloudwatch2'
     implementation "org.apache.commons:commons-text:1.10.0"

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -75,8 +75,6 @@ spring:
       enabled: true
   cloud:
     aws:
-      s3:
-        enabled: false
       sns:
         enabled: false
 


### PR DESCRIPTION
This pull request makes a small configuration change to the Spring application YAML file, specifically related to AWS service integration.

- Disabled the AWS S3 configuration block by removing the `s3.enabled: false` setting from `src/test/resources/config/application.yml`.