### PR TITLE
Add alert publishing for failed user login due to incorrect name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: ./gradlew test
       - name: Integration test
         run: ./gradlew integrationTest
+      - name: Detekt (test sources with type resolution)
+        run: ./gradlew detektTest
       - name: Generate SBOM
         run: ./gradlew cyclonedxBom -x test -x integrationTest
       - name: Upload SBOM artifact

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -1,6 +1,8 @@
 style:
   MaxLineLength:
     maxLineLength: 180
+  UnusedVariable:
+    active: true
   WildcardImport:
     active: false
   MagicNumber:

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -3,6 +3,8 @@ style:
     maxLineLength: 180
   UnusedVariable:
     active: true
+  VarCouldBeVal:
+    ignoreLateinitVar: true
   WildcardImport:
     active: false
   MagicNumber:

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/UserServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/UserServiceImpl.kt
@@ -5,6 +5,7 @@ import fi.elsapalvelu.elsa.config.LoginException
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.enumeration.KayttajatilinTila
 import fi.elsapalvelu.elsa.repository.*
+import fi.elsapalvelu.elsa.service.AlertPublisherService
 import fi.elsapalvelu.elsa.service.UserService
 import fi.elsapalvelu.elsa.service.constants.KAYTTAJA_NOT_FOUND_ERROR
 import fi.elsapalvelu.elsa.service.dto.OmatTiedotDTO
@@ -46,7 +47,8 @@ class UserServiceImpl(
     private val koejaksonKehittamistoimenpiteetRepository: KoejaksonKehittamistoimenpiteetRepository,
     private val koejaksonLoppukeskusteluRepository: KoejaksonLoppukeskusteluRepository,
     private val seurantajaksoRepository: SeurantajaksoRepository,
-    private val entityManager: EntityManager
+    private val entityManager: EntityManager,
+    private val alertPublisherService: AlertPublisherService
 ) : UserService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -315,7 +317,13 @@ class UserServiceImpl(
         ) {
             log.error(
                 "Kirjautuminen epäonnistui käyttäjälle $firstName $lastName (eppn $eppn). " +
-                    "Kutsussa annettu nimi ${tokenUser.firstName} ${tokenUser.lastName} ei ole" +
+                    "Kutsussa annettu nimi ${tokenUser.firstName} ${tokenUser.lastName} ei ole " +
+                    "tarpeeksi lähellä käyttäjän nimeä."
+            )
+            alertPublisherService.publishAlert(
+                subject = "Kirjautuminen epäonnistui: virheellinen nimi",
+                message = "Kirjautuminen epäonnistui käyttäjälle $firstName $lastName (eppn $eppn). " +
+                    "Kutsussa annettu nimi ${tokenUser.firstName} ${tokenUser.lastName} ei ole " +
                     "tarpeeksi lähellä käyttäjän nimeä."
             )
             throw Exception(LoginException.VIRHEELLINEN_NIMI.name)

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/ExternalIntegrationTestSupport.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/ExternalIntegrationTestSupport.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Tag
 import org.slf4j.LoggerFactory
 
 @Tag("external-integration")
-abstract class ExternalIntegrationTestSupport {
+open class ExternalIntegrationTestSupport {
 
     protected val log = LoggerFactory.getLogger(javaClass)
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/FetchingServiceExternalIntegrationBase.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/FetchingServiceExternalIntegrationBase.kt
@@ -48,8 +48,8 @@ abstract class FetchingServiceExternalIntegrationBase : ExternalIntegrationTestS
             .isNotNull
             .isNotEmpty
 
-        result.opintooikeudet?.forEach {
-            log(it)
+        result.opintooikeudet?.forEach { oikeus ->
+            log(oikeus)
 
             assertThat(result.opintooikeudet)
                 .describedAs("opintooikeudet must not be empty")

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/OpintooikeusServiceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/OpintooikeusServiceIT.kt
@@ -101,7 +101,7 @@ class OpintooikeusServiceIT {
 
         assertFalse(elOikeus.kaytossa)
         assertFalse(yekOikeus.kaytossa)
-        assertEquals(1, erikoistuvaLaakari.opintooikeudet.filter { it.kaytossa == true }.size)
+        assertEquals(1, erikoistuvaLaakari.opintooikeudet.count { it.kaytossa == true })
     }
 
     @Test
@@ -128,7 +128,7 @@ class OpintooikeusServiceIT {
 
         assertFalse(expiredOikeus.kaytossa)
         assertFalse(yekOikeus.kaytossa)
-        assertEquals(1, erikoistuvaLaakari.opintooikeudet.filter { it.kaytossa == true }.size)
+        assertEquals(1, erikoistuvaLaakari.opintooikeudet.count { it.kaytossa == true })
     }
 
     @Test
@@ -182,7 +182,7 @@ class OpintooikeusServiceIT {
         assertFalse(user.authorities.contains(Authority(YEK_KOULUTETTAVA)))
         assertTrue(user.authorities.contains(Authority(ERIKOISTUVA_LAAKARI)))
         assertFalse(yekOikeus.kaytossa)
-        assertEquals(1, erikoistuvaLaakari.opintooikeudet.filter { it.kaytossa == true }.size)
+        assertEquals(1, erikoistuvaLaakari.opintooikeudet.count { it.kaytossa == true })
 
         val oikeusKaytossa = erikoistuvaLaakari.opintooikeudet.firstOrNull { it.kaytossa == true }
         assertEquals(erikoistuvaLaakari.aktiivinenOpintooikeus, oikeusKaytossa?.id)
@@ -222,7 +222,7 @@ class OpintooikeusServiceIT {
         assertTrue(user.authorities.contains(Authority(YEK_KOULUTETTAVA)))
         assertTrue(user.authorities.contains(Authority(ERIKOISTUVA_LAAKARI)))
 
-        assertEquals(1, erikoistuvaLaakari.opintooikeudet.filter { it.kaytossa == true }.size)
+        assertEquals(1, erikoistuvaLaakari.opintooikeudet.count { it.kaytossa == true })
         assertEquals(erikoistuvaLaakari.aktiivinenOpintooikeus, oikeusKaytossa?.id)
     }
 
@@ -256,7 +256,7 @@ class OpintooikeusServiceIT {
         assertTrue(user.authorities.contains(Authority(YEK_KOULUTETTAVA)))
         assertFalse(user.authorities.contains(Authority(ERIKOISTUVA_LAAKARI)))
 
-        assertEquals(1, erikoistuvaLaakari.opintooikeudet.filter { it.kaytossa == true }.size)
+        assertEquals(1, erikoistuvaLaakari.opintooikeudet.count { it.kaytossa == true })
     }
 
     @Test
@@ -289,7 +289,7 @@ class OpintooikeusServiceIT {
         assertFalse(user.authorities.contains(Authority(ERIKOISTUVA_LAAKARI)))
 
         assertTrue(expiredOikeus.kaytossa)
-        assertEquals(1, erikoistuvaLaakari.opintooikeudet.filter { it.kaytossa == true }.size)
+        assertEquals(1, erikoistuvaLaakari.opintooikeudet.count { it.kaytossa == true })
     }
 
     @Test
@@ -335,6 +335,6 @@ class OpintooikeusServiceIT {
         assertFalse(user.authorities.contains(Authority(ERIKOISTUVA_LAAKARI)))
 
         assertTrue(expiredOikeus.kaytossa)
-        assertEquals(1, erikoistuvaLaakari.opintooikeudet.filter { it.kaytossa == true }.size)
+        assertEquals(1, erikoistuvaLaakari.opintooikeudet.count { it.kaytossa == true })
     }
 }

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/UserServiceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/UserServiceIT.kt
@@ -36,7 +36,7 @@ class UserServiceIT {
 
     private lateinit var user: User
 
-    private lateinit var userDetails: MutableMap<String, List<Any>>
+    private val userDetails: MutableMap<String, List<Any>> = mutableMapOf()
 
     @BeforeEach
     fun init() {
@@ -48,10 +48,9 @@ class UserServiceIT {
             lastName = DEFAULT_LASTNAME,
             langKey = DEFAULT_LANGKEY
         )
-        userDetails = mutableMapOf(
-            "urn:oid:2.5.4.42" to listOf(DEFAULT_FIRSTNAME),
-            "urn:oid:2.5.4.4" to listOf(DEFAULT_LASTNAME)
-        )
+        userDetails.clear()
+        userDetails["urn:oid:2.5.4.42"] = listOf(DEFAULT_FIRSTNAME)
+        userDetails["urn:oid:2.5.4.4"] = listOf(DEFAULT_LASTNAME)
     }
 
     @Test

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ValidateNameAlertTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ValidateNameAlertTest.kt
@@ -1,0 +1,183 @@
+package fi.elsapalvelu.elsa.service.impl
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import fi.elsapalvelu.elsa.domain.User
+import fi.elsapalvelu.elsa.domain.VerificationToken
+import fi.elsapalvelu.elsa.repository.*
+import fi.elsapalvelu.elsa.service.AlertPublisherService
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+
+@ExtendWith(MockitoExtension::class)
+class ValidateNameAlertTest {
+
+    @Mock private lateinit var userRepository: UserRepository
+    @Mock private lateinit var verificationTokenRepository: VerificationTokenRepository
+    @Mock private lateinit var kayttajaRepository: KayttajaRepository
+    @Mock private lateinit var kouluttajavaltuutusRepository: KouluttajavaltuutusRepository
+    @Mock private lateinit var kayttajaYliopistoErikoisalaRepository: KayttajaYliopistoErikoisalaRepository
+    @Mock private lateinit var suoritusarviointiRepository: SuoritusarviointiRepository
+    @Mock private lateinit var koejaksonKoulutussopimusRepository: KoejaksonKoulutussopimusRepository
+    @Mock private lateinit var koejaksonAloituskeskusteluRepository: KoejaksonAloituskeskusteluRepository
+    @Mock private lateinit var koejaksonValiarviointiRepository: KoejaksonValiarviointiRepository
+    @Mock private lateinit var koejaksonKehittamistoimenpiteetRepository: KoejaksonKehittamistoimenpiteetRepository
+    @Mock private lateinit var koejaksonLoppukeskusteluRepository: KoejaksonLoppukeskusteluRepository
+    @Mock private lateinit var seurantajaksoRepository: SeurantajaksoRepository
+    @Mock private lateinit var entityManager: EntityManager
+    @Mock private lateinit var alertPublisherService: AlertPublisherService
+
+    private lateinit var userService: UserServiceImpl
+    private lateinit var cipher: Cipher
+    private lateinit var token: VerificationToken
+
+    @BeforeEach
+    fun setUp() {
+        userService = UserServiceImpl(
+            userRepository = userRepository,
+            verificationTokenRepository = verificationTokenRepository,
+            kayttajaRepository = kayttajaRepository,
+            kouluttajavaltuutusRepository = kouluttajavaltuutusRepository,
+            kayttajaYliopistoErikoisalaRepository = kayttajaYliopistoErikoisalaRepository,
+            suoritusarviointiRepository = suoritusarviointiRepository,
+            koejaksonKoulutussopimusRepository = koejaksonKoulutussopimusRepository,
+            koejaksonAloituskeskusteluRepository = koejaksonAloituskeskusteluRepository,
+            koejaksonValiarviointiRepository = koejaksonValiarviointiRepository,
+            koejaksonKehittamistoimenpiteetRepository = koejaksonKehittamistoimenpiteetRepository,
+            koejaksonLoppukeskusteluRepository = koejaksonLoppukeskusteluRepository,
+            seurantajaksoRepository = seurantajaksoRepository,
+            entityManager = entityManager,
+            alertPublisherService = alertPublisherService
+        )
+
+        val keyGenerator = KeyGenerator.getInstance("AES")
+        keyGenerator.init(128)
+        val secretKey = keyGenerator.generateKey()
+        cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+
+        token = VerificationToken()
+    }
+
+    // -------------------------------------------------------------------------
+    // Name mismatch → alert expected
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `alert is published when token user name is too different from login name`() {
+        val tokenUser = User().apply {
+            id = "user-1"
+            firstName = "Matti"
+            lastName = "Virtanen"
+        }
+
+        // "Completely Different" is far from "Matti Virtanen" → validation should fail
+        assertThrows(Exception::class.java) {
+            userService.createOrUpdateUserWithToken(
+                tokenUser = tokenUser,
+                token = token,
+                cipher = cipher,
+                originalKey = cipher.parameters?.let { null } ?: run {
+                    val kg = KeyGenerator.getInstance("AES")
+                    kg.init(128)
+                    kg.generateKey()
+                }!!,
+                hetu = null,
+                eppn = "matti.virtanen@test.fi",
+                firstName = "Completely",
+                lastName = "Different"
+            )
+        }
+
+        val subjectCaptor = argumentCaptor<String>()
+        val messageCaptor = argumentCaptor<String>()
+        verify(alertPublisherService).publishAlert(subjectCaptor.capture(), messageCaptor.capture())
+
+        assertThat(subjectCaptor.firstValue).contains("virheellinen nimi")
+        assertThat(messageCaptor.firstValue).contains("Completely")
+        assertThat(messageCaptor.firstValue).contains("Different")
+        assertThat(messageCaptor.firstValue).contains("matti.virtanen@test.fi")
+    }
+
+    @Test
+    fun `alert message contains token user name`() {
+        val tokenUser = User().apply {
+            id = "user-2"
+            firstName = "Pekka"
+            lastName = "Korhonen"
+        }
+
+        assertThrows(Exception::class.java) {
+            userService.createOrUpdateUserWithToken(
+                tokenUser = tokenUser,
+                token = token,
+                cipher = cipher,
+                originalKey = run {
+                    val kg = KeyGenerator.getInstance("AES")
+                    kg.init(128)
+                    kg.generateKey()
+                },
+                hetu = null,
+                eppn = "pekka.korhonen@test.fi",
+                firstName = "Xyz",
+                lastName = "Abc"
+            )
+        }
+
+        val messageCaptor = argumentCaptor<String>()
+        verify(alertPublisherService).publishAlert(any(), messageCaptor.capture())
+
+        assertThat(messageCaptor.firstValue).contains("Pekka")
+        assertThat(messageCaptor.firstValue).contains("Korhonen")
+    }
+
+    // -------------------------------------------------------------------------
+    // Name close enough → no alert expected
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `no alert is published when token user name is close enough to login name`() {
+        val secretKey = run {
+            val kg = KeyGenerator.getInstance("AES")
+            kg.init(128)
+            kg.generateKey()
+        }
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+
+        val tokenUser = User().apply {
+            id = "user-3"
+            firstName = "Matti"
+            lastName = "Virtanen"
+        }
+
+        // Names match closely (Levenshtein distance ≤ 2) – validation passes
+        // but further processing will throw because kayttajaRepository is a mock
+        // returning empty; we only care that no alert was published.
+        try {
+            userService.createOrUpdateUserWithToken(
+                tokenUser = tokenUser,
+                token = token,
+                cipher = cipher,
+                originalKey = secretKey,
+                hetu = null,
+                eppn = "matti.virtanen@test.fi",
+                firstName = "Matti",
+                lastName = "Virtanen"
+            )
+        } catch (_: Exception) {
+            // expected – repos are mocked with default no-op / empty behaviour
+        }
+
+        verify(alertPublisherService, never()).publishAlert(any(), any())
+    }
+}
+

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ValidateNameAlertTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ValidateNameAlertTest.kt
@@ -60,9 +60,6 @@ class ValidateNameAlertTest {
             alertPublisherService = alertPublisherService
         )
 
-        val keyGenerator = KeyGenerator.getInstance("AES")
-        keyGenerator.init(128)
-        val secretKey = keyGenerator.generateKey()
         cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
 
         token = VerificationToken()

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/common/KayttajahallintaResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/common/KayttajahallintaResourceIT.kt
@@ -480,7 +480,7 @@ class KayttajahallintaResourceIT : ResourceIntegrationTestBase() {
                 .content(convertObjectToJsonBytes(kayttajahallintaKayttajaDTO)).with(SecurityMockMvcRequestPostProcessors.csrf())).andExpect(status().isCreated)
 
         val originalVastuuhenkilonTehtavat = kayttajaRepository.findById(vastuuhenkilo.id!!).get().yliopistotAndErikoisalat.first().vastuuhenkilonTehtavat
-        assertThat(!originalVastuuhenkilonTehtavat.contains(vastuuhenkilonTehtava))
+        assertThat(originalVastuuhenkilonTehtavat).doesNotContain(vastuuhenkilonTehtava)
     }
 
     @ParameterizedTest
@@ -538,7 +538,7 @@ class KayttajahallintaResourceIT : ResourceIntegrationTestBase() {
         assertThat(updatedVastuuhenkilo.yliopistotAndErikoisalat.first().vastuuhenkilonTehtavat).size().isEqualTo(0)
 
         val updatedVastuuhenkiloWithReassignedTehtava = kayttajaRepository.findById(vastuuhenkiloForReassignedTehtava.id!!).get()
-        assertThat(updatedVastuuhenkiloWithReassignedTehtava.yliopistotAndErikoisalat.first().vastuuhenkilonTehtavat.contains(vastuuhenkilonTehtava))
+        assertThat(updatedVastuuhenkiloWithReassignedTehtava.yliopistotAndErikoisalat.first().vastuuhenkilonTehtavat).contains(vastuuhenkilonTehtava)
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariMuutToiminnotResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariMuutToiminnotResourceIT.kt
@@ -102,7 +102,7 @@ class ErikoistuvaLaakariMuutToiminnotResourceIT {
             testLahikouluttaja?.user?.authorities?.contains(
                 Authority(name = KOULUTTAJA)
             )
-        )
+        ).isTrue()
 
         assertThat(testLahikouluttaja?.yliopistotAndErikoisalat).hasSize(1)
         assertThat(testLahikouluttaja?.yliopistotAndErikoisalat?.firstOrNull()?.yliopisto).isEqualTo(opintooikeus.yliopisto)
@@ -137,7 +137,7 @@ class ErikoistuvaLaakariMuutToiminnotResourceIT {
             testLahikouluttaja?.user?.authorities?.contains(
                 Authority(name = KOULUTTAJA)
             )
-        )
+        ).isTrue()
 
         assertThat(testLahikouluttaja?.yliopistotAndErikoisalat).hasSize(1)
         assertThat(testLahikouluttaja?.yliopistotAndErikoisalat?.firstOrNull()?.yliopisto).isEqualTo(newOpintooikeus.yliopisto)

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResourceIT.kt
@@ -298,7 +298,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResourceIT: ResourceIntegrationTestBase(
         val tyoskentelyjaksoDTO = tyoskentelyjaksoMapper.toDto(tyoskentelyjaksoRepository.findById(tyoskentelyjakso.id!!).get())
 
         // Asetetaan päättymispäivä suoritusarvioinnin ulkopuolelle
-        tyoskentelyjaksoDTO.apply { paattymispaiva = LocalDate.of(2020, 1, 19) }
+        tyoskentelyjaksoDTO.paattymispaiva = LocalDate.of(2020, 1, 19)
 
         val tyoskentelyjaksoJson = objectMapper.writeValueAsString(tyoskentelyjaksoDTO)
 
@@ -321,7 +321,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResourceIT: ResourceIntegrationTestBase(
         val tyoskentelyjaksoDTO = tyoskentelyjaksoMapper.toDto(tyoskentelyjaksoRepository.findById(tyoskentelyjakso.id!!).get())
 
         // Asetetaan päättymispäivä suoritusarvioinnin päivälle
-        tyoskentelyjaksoDTO.apply { paattymispaiva = suoritusarviointiTapahtumanAjankohta }
+        tyoskentelyjaksoDTO.paattymispaiva = suoritusarviointiTapahtumanAjankohta
 
         val tyoskentelyjaksoJson = objectMapper.writeValueAsString(tyoskentelyjaksoDTO)
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/ErikoistuvaLaakariHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/ErikoistuvaLaakariHelper.kt
@@ -28,7 +28,7 @@ object ErikoistuvaLaakariHelper {
         laillistamistodistusNimi: String? = DEFAULT_LAILLISTAMISTODISTUS_NIMI, laillistamistodistusTyyppi: String? = DEFAULT_LAILLISTAMISTODISTUS_TYYPPI): ErikoistuvaLaakari {
         val erikoistuvaLaakari = ErikoistuvaLaakari()
 
-        var kayttaja = user?.let { em.findAll(Kayttaja::class).firstOrNull { it.user == user } }
+        var kayttaja = user?.let { u -> em.findAll(Kayttaja::class).firstOrNull { it.user == u } }
         if (kayttaja == null) {
             kayttaja = KayttajaHelper.createEntity(em, user)
             persistAndFlush(em, kayttaja)

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/KoejaksonVaiheetHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/KoejaksonVaiheetHelper.kt
@@ -55,7 +55,7 @@ object KoejaksonVaiheetHelper {
         ): KoejaksonAloituskeskustelu {
             val opintooikeus = erikoistuvaLaakari.getOpintooikeusKaytossa()
             return KoejaksonAloituskeskustelu(
-                opintooikeus = erikoistuvaLaakari.getOpintooikeusKaytossa(),
+                opintooikeus = opintooikeus,
                 koejaksonSuorituspaikka = DEFAULT_KOULUTUSPAIKKA,
                 koejaksonAlkamispaiva = DEFAULT_ALKAMISPAIVA,
                 koejaksonPaattymispaiva = DEFAULT_PAATTYMISPAIVA,

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/OpintosuoritusHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/OpintosuoritusHelper.kt
@@ -3,6 +3,7 @@ package fi.elsapalvelu.elsa.web.rest.helpers
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.enumeration.OpintosuoritusTyyppiEnum
 import fi.elsapalvelu.elsa.web.rest.findAll
+import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.persistence.EntityManager
@@ -14,10 +15,10 @@ object OpintosuoritusHelper {
     const val DEFAULT_KURSSIKOODI = "DDDDDDDDDD"
     const val DEFAULT_ARVIO_FI = "BBBBBBBBBB"
     const val DEFAULT_ARVIO_SV = "BBBBBBBBBC"
-    val DEFAULT_OPINTOSUORITUSTYYPPI = OpintosuoritusTyyppiEnum.JOHTAMISOPINTO
-    val DEFAULT_SUORITUSPAIVA = LocalDate.ofEpochDay(0L)
-    val DEFAULT_VANHENEMISPAIVA = LocalDate.ofEpochDay(5L)
-    val DEFAULT_MUOKKAUSAIKA = LocalDate.ofEpochDay(5L).atStartOfDay(ZoneId.systemDefault()).toInstant()
+    val DEFAULT_OPINTOSUORITUSTYYPPI: OpintosuoritusTyyppiEnum = OpintosuoritusTyyppiEnum.JOHTAMISOPINTO
+    val DEFAULT_SUORITUSPAIVA: LocalDate = LocalDate.ofEpochDay(0L)
+    val DEFAULT_VANHENEMISPAIVA: LocalDate = LocalDate.ofEpochDay(5L)
+    val DEFAULT_MUOKKAUSAIKA: Instant = LocalDate.ofEpochDay(5L).atStartOfDay(ZoneId.systemDefault()).toInstant()
 
     @JvmStatic
     fun createEntity(

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/OpintosuoritusOsakokonaisuusHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/OpintosuoritusOsakokonaisuusHelper.kt
@@ -2,6 +2,7 @@ package fi.elsapalvelu.elsa.web.rest.helpers
 
 import fi.elsapalvelu.elsa.domain.Opintosuoritus
 import fi.elsapalvelu.elsa.domain.OpintosuoritusOsakokonaisuus
+import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.persistence.EntityManager
@@ -14,9 +15,9 @@ object OpintosuoritusOsakokonaisuusHelper {
     const val DEFAULT_KURSSIKOODI = "DDDDDDDDDD"
     const val DEFAULT_ARVIO_FI = "DDDDDDDDDD"
     const val DEFAULT_ARVIO_SV = "DDDDDDDDDE"
-    val DEFAULT_SUORITUSPAIVA = LocalDate.ofEpochDay(0L)
-    val DEFAULT_VANHENEMISPAIVA = LocalDate.ofEpochDay(5L)
-    val DEFAULT_MUOKKAUSAIKA = LocalDate.ofEpochDay(5L).atStartOfDay(ZoneId.systemDefault()).toInstant()
+    val DEFAULT_SUORITUSPAIVA: LocalDate = LocalDate.ofEpochDay(0L)
+    val DEFAULT_VANHENEMISPAIVA: LocalDate = LocalDate.ofEpochDay(5L)
+    val DEFAULT_MUOKKAUSAIKA: Instant = LocalDate.ofEpochDay(5L).atStartOfDay(ZoneId.systemDefault()).toInstant()
 
     fun createEntity(
         em: EntityManager,

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaValmistumispyyntoResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaValmistumispyyntoResourceIT.kt
@@ -422,11 +422,6 @@ class VirkailijaValmistumispyyntoResourceIT : ResourceIntegrationTestBase() {
 
         val yekSuorituspaiva = LocalDate.ofEpochDay(15)
 
-        val valmistumispyynnonTarkistusDTO = ValmistumispyynnonTarkistusUpdateDTO(
-            yekSuoritettu = true,
-            yekSuorituspaiva = yekSuorituspaiva,
-            keskenerainen = true
-        )
 
         testMockMvc.perform(
             multipart(

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResourceIT.kt
@@ -327,7 +327,7 @@ class YekKoulutettavaTyoskentelyjaksoResourceIT {
         val tyoskentelyjaksoDTO = tyoskentelyjaksoMapper.toDto(existingTyoskentelyjakso)
 
         // Asetetaan päättymispäivä suoritusarvioinnin ulkopuolelle
-        tyoskentelyjaksoDTO.apply { paattymispaiva = LocalDate.of(2020, 1, 19) }
+        tyoskentelyjaksoDTO.paattymispaiva = LocalDate.of(2020, 1, 19)
 
         val tyoskentelyjaksoJson = objectMapper.writeValueAsString(tyoskentelyjaksoDTO)
 
@@ -352,7 +352,7 @@ class YekKoulutettavaTyoskentelyjaksoResourceIT {
         val tyoskentelyjaksoDTO = tyoskentelyjaksoMapper.toDto(existingTyoskentelyjakso)
 
         // Asetetaan päättymispäivä suoritusarvioinnin päivälle
-        tyoskentelyjaksoDTO.apply { paattymispaiva = suoritusarviointiTapahtumanAjankohta }
+        tyoskentelyjaksoDTO.paattymispaiva = suoritusarviointiTapahtumanAjankohta
 
         val tyoskentelyjaksoJson = objectMapper.writeValueAsString(tyoskentelyjaksoDTO)
 


### PR DESCRIPTION
This pull request adds alerting functionality to the `UserServiceImpl` class to notify when a login fails due to an invalid name. The main changes include injecting the `AlertPublisherService` and publishing an alert when this specific login error occurs.

**Alerting enhancements:**

* Injected the `AlertPublisherService` into the `UserServiceImpl` constructor to enable publishing alerts. [[1]](diffhunk://#diff-b64aea11f02bdee24e552cc314652804b9d1a481ea78f648d948d3862858aa09R8) [[2]](diffhunk://#diff-b64aea11f02bdee24e552cc314652804b9d1a481ea78f648d948d3862858aa09L49-R51)
* Added a call to `alertPublisherService.publishAlert` to send an alert when a login attempt fails due to the provided name not matching the user's name closely enough.