### PR TITLE
More external integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Justfile-komennot 
 
-Projektissa on valmiita kehityskomentoja `Justfile`-tiedostossa.
+Projektissa on valmiita kehityskomentoja `Justfile`-tiedostossa
 
 - `just br` (build-run): ajaa ensin buildin ja käynnistää sen jälkeen backendin sekä frontendin
 - `just r` (run): käynnistää backendin ja frontendin ilman build-vaihetta.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Justfile-komennot 
 
-Projektissa on valmiita kehityskomentoja `Justfile`-tiedostossa
+Projektissa on valmiita kehityskomentoja `Justfile`-tiedostossa.
 
 - `just br` (build-run): ajaa ensin buildin ja käynnistää sen jälkeen backendin sekä frontendin
 - `just r` (run): käynnistää backendin ja frontendin ilman build-vaihetta.

--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,7 @@ tasks.register('externalIntegrationTests', Test) {
     classpath = sourceSets.test.runtimeClasspath
     reports.html.required = false
     testlogger {
+        theme = ThemeType.PLAIN
         showStandardStreams = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,6 @@ tasks.register('externalIntegrationTests', Test) {
     classpath = sourceSets.test.runtimeClasspath
     reports.html.required = false
     testlogger {
-        theme = ThemeType.PLAIN
         showStandardStreams = true
     }
 }

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -38,7 +38,7 @@ phases:
       - chmod 600 /tmp/hy-sisu.key
       - aws s3 cp "$APPLICATION_ARKISTOINTI_TRE_PRIVATE_KEY_LOCATION" /tmp/louhi_elsatest
       - chmod 600 /tmp/louhi_elsatest
-      - APPLICATION_SECURITY_SISU_HY_CERTIFICATE_LOCATION=file:/tmp/hy-sisu.crt APPLICATION_SECURITY_SISU_HY_PRIVATE_KEY_LOCATION=file:/tmp/hy-sisu.key APPLICATION_ARKISTOINTI_TRE_PRIVATE_KEY_LOCATION=file:/tmp/louhi_elsatest ./gradlew externalIntegrationTests
+      - APPLICATION_SECURITY_SISU_HY_CERTIFICATE_LOCATION=file:/tmp/hy-sisu.crt APPLICATION_SECURITY_SISU_HY_PRIVATE_KEY_LOCATION=file:/tmp/hy-sisu.key APPLICATION_ARKISTOINTI_TRE_PRIVATE_KEY_LOCATION=file:/tmp/louhi_elsatest ./gradlew externalIntegrationTests --console=rich
   post_build:
     commands:
       - echo "Build status $CODEBUILD_BUILD_SUCCEEDING"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,6 +30,7 @@ phases:
     commands:
       - echo "Starting external integration tests"
       - chmod +x gradlew
+      - chmod +x src/test/scripts/run-external-integration-tests.sh
   build:
     commands:
       - aws s3 cp "$APPLICATION_SECURITY_SISU_HY_CERTIFICATE_LOCATION" /tmp/hy-sisu.crt
@@ -38,7 +39,7 @@ phases:
       - chmod 600 /tmp/hy-sisu.key
       - aws s3 cp "$APPLICATION_ARKISTOINTI_TRE_PRIVATE_KEY_LOCATION" /tmp/louhi_elsatest
       - chmod 600 /tmp/louhi_elsatest
-      - APPLICATION_SECURITY_SISU_HY_CERTIFICATE_LOCATION=file:/tmp/hy-sisu.crt APPLICATION_SECURITY_SISU_HY_PRIVATE_KEY_LOCATION=file:/tmp/hy-sisu.key APPLICATION_ARKISTOINTI_TRE_PRIVATE_KEY_LOCATION=file:/tmp/louhi_elsatest ./gradlew externalIntegrationTests 2>&1 | sed 's/.*FAILED.*/\e[1;31m&\e[0m/'; exit ${PIPESTATUS[0]}
+      - APPLICATION_SECURITY_SISU_HY_CERTIFICATE_LOCATION=file:/tmp/hy-sisu.crt APPLICATION_SECURITY_SISU_HY_PRIVATE_KEY_LOCATION=file:/tmp/hy-sisu.key APPLICATION_ARKISTOINTI_TRE_PRIVATE_KEY_LOCATION=file:/tmp/louhi_elsatest bash src/test/scripts/run-external-integration-tests.sh
   post_build:
     commands:
       - echo "Build status $CODEBUILD_BUILD_SUCCEEDING"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -38,7 +38,7 @@ phases:
       - chmod 600 /tmp/hy-sisu.key
       - aws s3 cp "$APPLICATION_ARKISTOINTI_TRE_PRIVATE_KEY_LOCATION" /tmp/louhi_elsatest
       - chmod 600 /tmp/louhi_elsatest
-      - APPLICATION_SECURITY_SISU_HY_CERTIFICATE_LOCATION=file:/tmp/hy-sisu.crt APPLICATION_SECURITY_SISU_HY_PRIVATE_KEY_LOCATION=file:/tmp/hy-sisu.key APPLICATION_ARKISTOINTI_TRE_PRIVATE_KEY_LOCATION=file:/tmp/louhi_elsatest ./gradlew externalIntegrationTests --console=rich
+      - APPLICATION_SECURITY_SISU_HY_CERTIFICATE_LOCATION=file:/tmp/hy-sisu.crt APPLICATION_SECURITY_SISU_HY_PRIVATE_KEY_LOCATION=file:/tmp/hy-sisu.key APPLICATION_ARKISTOINTI_TRE_PRIVATE_KEY_LOCATION=file:/tmp/louhi_elsatest ./gradlew externalIntegrationTests 2>&1 | sed 's/.*FAILED.*/\e[1;31m&\e[0m/'; exit ${PIPESTATUS[0]}
   post_build:
     commands:
       - echo "Build status $CODEBUILD_BUILD_SUCCEEDING"

--- a/src/main/kotlin/fi/elsapalvelu/elsa/extensions/ApolloResponseExtensions.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/extensions/ApolloResponseExtensions.kt
@@ -2,12 +2,20 @@ package fi.elsapalvelu.elsa.extensions
 
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.exception.ApolloHttpException
 import org.slf4j.Logger
+
+private const val GRAPHQL_NO_VALUE_PRESENT_ERROR = "Unexpected Internal Error: No value present"
 
 fun <D : Operation.Data> ApolloResponse<D>.checkErrors(context: String, log: Logger): ApolloResponse<D> {
     // Network / parsing error
     exception?.let { ex ->
-        log.error("$context. Virhe: ${ex.message}", ex)
+        if (ex is ApolloHttpException) {
+            val responseBody = try { ex.body?.readUtf8() } catch (_: Exception) { null }
+            log.error("$context. HTTP ${ex.statusCode} virhe. Response body: $responseBody", ex)
+        } else {
+            log.error("$context. Virhe: ${ex.message}", ex)
+        }
         throw ex
     }
 
@@ -26,4 +34,3 @@ fun <D : Operation.Data> ApolloResponse<D>.checkErrors(context: String, log: Log
 
     return this
 }
-

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/UserServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/UserServiceImpl.kt
@@ -131,7 +131,7 @@ class UserServiceImpl(
                     user.avatar = null
                 }
             }
-        } catch (ex: UnsupportedFormatException) {
+        } catch (_: UnsupportedFormatException) {
             log.debug("Päivitettävä profiilikuva ei ole tuettu")
         }
 
@@ -194,7 +194,7 @@ class UserServiceImpl(
                 val iv = params.getParameterSpec(IvParameterSpec::class.java).iv
                 val ciphertext = if (hetu != null)
                     cipher.doFinal(
-                        hetu.toString().toByteArray(StandardCharsets.UTF_8)
+                        hetu.toByteArray(StandardCharsets.UTF_8)
                     ) else null
 
                 tokenUser.hetu = ciphertext

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/FetchingServiceExternalIntegrationBase.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/FetchingServiceExternalIntegrationBase.kt
@@ -21,6 +21,8 @@ abstract class FetchingServiceExternalIntegrationBase : ExternalIntegrationTestS
 
     protected open fun getTestHetu() = "210281-9988"
 
+    protected open val assertErikoisalaTunnisteList: Boolean = true
+
     @Test
     fun shouldFetchOpintotietodataWithoutErrors() {
         val yliopisto = opintotietodataService.getYliopisto()
@@ -75,10 +77,12 @@ abstract class FetchingServiceExternalIntegrationBase : ExternalIntegrationTestS
                         .describedAs("asetus should be populated")
                         .isNotBlank
 
-                    assertThat(it.erikoisalaTunnisteList)
-                        .describedAs("erikoisalaTunnisteList should be populated")
-                        .isNotNull
-                        .isNotEmpty
+                    if (assertErikoisalaTunnisteList) {
+                        assertThat(it.erikoisalaTunnisteList)
+                            .describedAs("erikoisalaTunnisteList should be populated")
+                            .isNotNull
+                            .isNotEmpty
+                    }
 
                     assertThat(it.tila)
                         .describedAs("tila should be populated")

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/FetchingServiceExternalIntegrationBase.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/FetchingServiceExternalIntegrationBase.kt
@@ -75,6 +75,11 @@ abstract class FetchingServiceExternalIntegrationBase : ExternalIntegrationTestS
                         .describedAs("asetus should be populated")
                         .isNotBlank
 
+                    assertThat(it.erikoisalaTunnisteList)
+                        .describedAs("erikoisalaTunnisteList should be populated")
+                        .isNotNull
+                        .isNotEmpty
+
                     assertThat(it.tila)
                         .describedAs("tila should be populated")
                         .isNotNull

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/turku/PeppiTurkuExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/turku/PeppiTurkuExternalIntegrationTests.kt
@@ -1,9 +1,6 @@
 package fi.elsapalvelu.elsa.externalintegration.peppi.turku
 
 import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.externalintegration.FetchingServiceExternalIntegrationBase
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
@@ -14,7 +11,6 @@ import fi.elsapalvelu.elsa.service.impl.PeppiCommonOpintotietodataFetchingServic
 import fi.elsapalvelu.elsa.service.impl.PeppiTurkuClientBuilderImpl
 import fi.elsapalvelu.elsa.service.impl.PeppiTurkuOpintosuorituksetFetchingServiceImpl
 import fi.elsapalvelu.elsa.service.impl.PeppiTurkuOpintotietodataFetchingServiceImpl
-import org.junit.jupiter.api.Disabled
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.SpringBootConfiguration
@@ -28,7 +24,6 @@ import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest(classes = [PeppiTurkuExternalIntegrationTestApplication::class])
 @ActiveProfiles("external-integration")
-@Disabled
 class PeppiTurkuExternalIntegrationTests : FetchingServiceExternalIntegrationBase() {
 
     @Autowired
@@ -43,7 +38,7 @@ class PeppiTurkuExternalIntegrationTests : FetchingServiceExternalIntegrationBas
     override val opintosuorituksetService: OpintosuorituksetFetchingService
         get() = peppiTurkuOpintosuorituksetFetchingServiceImpl
 
-    override fun getTestHetu() = "030884-227C"
+    override fun getTestHetu() = "010957-994N"
 }
 
 @SpringBootConfiguration

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/uef/PeppiUefExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/uef/PeppiUefExternalIntegrationTests.kt
@@ -38,6 +38,8 @@ class PeppiUefExternalIntegrationTests : FetchingServiceExternalIntegrationBase(
     override val opintosuorituksetService: OpintosuorituksetFetchingService
         get() = peppiUefOpintosuorituksetFetchingServiceImpl
 
+    override val assertErikoisalaTunnisteList: Boolean = false
+
     override fun getTestHetu() = "130560-9972"
 }
 

--- a/src/test/scripts/run-external-integration-tests.sh
+++ b/src/test/scripts/run-external-integration-tests.sh
@@ -8,11 +8,11 @@ GRADLE_EXIT=${PIPESTATUS[0]}
 
 FAILED_TESTS=$(grep -E "^\s+Test .* FAILED" "$OUTPUT_FILE")
 if [ -n "$FAILED_TESTS" ]; then
-    echo ""
-    echo "=================================================="
-    echo "FAILED TESTS:"
-    echo "$FAILED_TESTS"
-    echo "=================================================="
+    printf '\n' >&2
+    printf '\033[1;31m==================================================\n' >&2
+    printf 'FAILED TESTS:\n' >&2
+    printf '%s\n' "$FAILED_TESTS" >&2
+    printf '==================================================\033[0m\n' >&2
 fi
 
 exit $GRADLE_EXIT

--- a/src/test/scripts/run-external-integration-tests.sh
+++ b/src/test/scripts/run-external-integration-tests.sh
@@ -8,11 +8,13 @@ GRADLE_EXIT=${PIPESTATUS[0]}
 
 FAILED_TESTS=$(grep -E "^\s+Test .* FAILED" "$OUTPUT_FILE")
 if [ -n "$FAILED_TESTS" ]; then
-    printf '\n' >&2
-    printf '\033[1;31m==================================================\n' >&2
-    printf 'FAILED TESTS:\n' >&2
-    printf '%s\n' "$FAILED_TESTS" >&2
-    printf '==================================================\033[0m\n' >&2
+    echo "" >&2
+    echo "ERROR ==================================================" >&2
+    echo "ERROR FAILED TESTS:" >&2
+    while IFS= read -r line; do
+        echo "ERROR $line" >&2
+    done <<< "$FAILED_TESTS"
+    echo "ERROR ==================================================" >&2
 fi
 
 exit $GRADLE_EXIT

--- a/src/test/scripts/run-external-integration-tests.sh
+++ b/src/test/scripts/run-external-integration-tests.sh
@@ -6,7 +6,7 @@ OUTPUT_FILE="/tmp/gradle-test-output.txt"
 ./gradlew externalIntegrationTests 2>&1 | tee "$OUTPUT_FILE"
 GRADLE_EXIT=${PIPESTATUS[0]}
 
-FAILED_TESTS=$(grep -E "^\s+Test .* FAILED" "$OUTPUT_FILE")
+FAILED_TESTS=$(awk '/^[^ ]/ { class=$0 } /FAILED/ { print class " >" $0 }' "$OUTPUT_FILE")
 if [ -n "$FAILED_TESTS" ]; then
     echo "" >&2
     echo "ERROR ==================================================" >&2

--- a/src/test/scripts/run-external-integration-tests.sh
+++ b/src/test/scripts/run-external-integration-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -o pipefail
+
+OUTPUT_FILE="/tmp/gradle-test-output.txt"
+
+./gradlew externalIntegrationTests 2>&1 | tee "$OUTPUT_FILE"
+GRADLE_EXIT=${PIPESTATUS[0]}
+
+FAILED_TESTS=$(grep -E "^\s+Test .* FAILED" "$OUTPUT_FILE")
+if [ -n "$FAILED_TESTS" ]; then
+    echo ""
+    echo "=================================================="
+    echo "FAILED TESTS:"
+    echo "$FAILED_TESTS"
+    echo "=================================================="
+fi
+
+exit $GRADLE_EXIT
+


### PR DESCRIPTION
This pull request introduces several improvements to error handling, test execution, and test coverage for external integration tests. The most significant changes include enhanced error logging for HTTP exceptions, the addition of a wrapper script for running integration tests with improved output, and updates to test logic to increase flexibility and reliability.

**Error Handling Improvements:**
- Enhanced the `checkErrors` extension in `ApolloResponseExtensions.kt` to log HTTP response bodies when an `ApolloHttpException` occurs, providing more context for debugging network errors.

**Test Execution & Reporting:**
- Added a new script `run-external-integration-tests.sh` to wrap the execution of external integration tests, capturing output and clearly reporting failed tests for better visibility in CI logs. The buildspec was updated to use this script. [[1]](diffhunk://#diff-b825eed94cbf5a8c1dd967792166b2f2c2e56b841bf7b8e313e4761e1d78fdf4R1-R21) [[2]](diffhunk://#diff-69387ac97f1b775f19989fc28150f89e785406cbff04643a969f5e396573dd5cR33) [[3]](diffhunk://#diff-69387ac97f1b775f19989fc28150f89e785406cbff04643a969f5e396573dd5cL41-R42)

**Test Logic and Coverage Updates:**
- Introduced a configurable flag `assertErikoisalaTunnisteList` in `FetchingServiceExternalIntegrationBase` to allow derived test classes to skip or enforce checks on `erikoisalaTunnisteList`, improving test flexibility for different university integrations. [[1]](diffhunk://#diff-d5329845f44e58bc0df47e7b6c8d1f33e3d0b267b630eb6fa0d22a209cb4ab04R24-R25) [[2]](diffhunk://#diff-d5329845f44e58bc0df47e7b6c8d1f33e3d0b267b630eb6fa0d22a209cb4ab04R80-R86) [[3]](diffhunk://#diff-77ba8a059b0f6e0397e70aebfebb003effb1ea3db8ba026150f503e721cd2a49R41-R42)
- Enabled the Turku external integration tests by removing the `@Disabled` annotation and updating the test hetu value, ensuring these tests are now executed as part of the suite. [[1]](diffhunk://#diff-1a59caf958e9ca8c86874fab77f1618f2a25462f66305ccac7ac68b29b1a9f6aL31) [[2]](diffhunk://#diff-1a59caf958e9ca8c86874fab77f1618f2a25462f66305ccac7ac68b29b1a9f6aL46-R41)

**Minor Code Quality Improvements:**
- Used a catch-all in `UserServiceImpl.kt` for `UnsupportedFormatException` to avoid unused variable warnings.
- Simplified byte conversion in `UserServiceImpl.kt` for hetu encryption.
- Removed unused imports from `PeppiTurkuExternalIntegrationTests.kt`. [[1]](diffhunk://#diff-1a59caf958e9ca8c86874fab77f1618f2a25462f66305ccac7ac68b29b1a9f6aL4-L6) [[2]](diffhunk://#diff-1a59caf958e9ca8c86874fab77f1618f2a25462f66305ccac7ac68b29b1a9f6aL17)