### PR TITLE
enhance error handling for GraphQL responses (empty response error -> warn)

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/extensions/ApolloResponseExtensions.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/extensions/ApolloResponseExtensions.kt
@@ -4,6 +4,8 @@ import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Operation
 import org.slf4j.Logger
 
+private const val GRAPHQL_NO_VALUE_PRESENT_ERROR = "Unexpected Internal Error: No value present"
+
 fun <D : Operation.Data> ApolloResponse<D>.checkErrors(context: String, log: Logger): ApolloResponse<D> {
     // Network / parsing error
     exception?.let { ex ->
@@ -20,6 +22,11 @@ fun <D : Operation.Data> ApolloResponse<D>.checkErrors(context: String, log: Log
                 err.extensions?.let { append(", extensions: $it") }
             }
         }
+        if (hasOnlyNoValuePresentGraphQLErrors()) {
+            log.warn("$context. GraphQL-virheet: $errMsg")
+            return this
+        }
+
         log.error("$context. GraphQL-virheet: $errMsg")
         throw RuntimeException("$context. GraphQL-virheet: $errMsg")
     }
@@ -27,3 +34,5 @@ fun <D : Operation.Data> ApolloResponse<D>.checkErrors(context: String, log: Log
     return this
 }
 
+private fun <D : Operation.Data> ApolloResponse<D>.hasOnlyNoValuePresentGraphQLErrors(): Boolean =
+    errors?.all { it.message.contains(GRAPHQL_NO_VALUE_PRESENT_ERROR) } == true


### PR DESCRIPTION
This pull request updates error handling in the `ApolloResponseExtensions.kt` file to better manage a specific GraphQL error scenario. Now, if the only errors present in a GraphQL response are "No value present" errors, the code logs a warning instead of throwing a runtime exception. This helps prevent unnecessary exceptions for this known, less critical error case.

Error handling improvements:

* Added a constant `GRAPHQL_NO_VALUE_PRESENT_ERROR` to represent the "No value present" error message.
* Updated the `checkErrors` extension function to log a warning and return the response (instead of throwing an exception) if all GraphQL errors are "No value present" errors, using the new `hasOnlyNoValuePresentGraphQLErrors` helper function.
* Added the `hasOnlyNoValuePresentGraphQLErrors` private helper function to check if all errors match the "No value present" message.