### PR TITLE
update Spring Boot version to 3.5.15

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ profile=dev
 jhipsterDependenciesVersion=8.8.0
 # The spring-boot version should match the one managed by
 # https://mvnrepository.com/artifact/tech.jhipster/jhipster-dependencies/7.3.1
-springBootVersion=3.5.14
+springBootVersion=3.5.15
 springSecurityVersion=6.5.10
 # The hibernate version should match the one managed by
 # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/2.5.5


### PR DESCRIPTION
This pull request makes a minor update to the development profile configuration by bumping the Spring Boot version from 3.5.14 to 3.5.15 in `gradle.properties`. This ensures the project uses the latest patch release for Spring Boot.

- Updated `springBootVersion` from 3.5.14 to 3.5.15 in `gradle.properties` for the development profile.