### PR TITLE
Peppi and Sisu services: refactoring and reorganization

### DIFF
--- a/src/main/docker/sonar.yml
+++ b/src/main/docker/sonar.yml
@@ -1,7 +1,0 @@
-version: "2"
-services:
-  elsabackend-sonar:
-    image: sonarqube:8.3.1-community
-    ports:
-      - 9001:9000
-      - 9092:9092

--- a/src/main/kotlin/fi/elsapalvelu/elsa/ElsaBackendApp.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/ElsaBackendApp.kt
@@ -2,8 +2,8 @@ package fi.elsapalvelu.elsa
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.repository.ErikoisalaSisuTutkintoohjelmaRepository
-import fi.elsapalvelu.elsa.service.SisuTutkintoohjelmaFetchingService
-import fi.elsapalvelu.elsa.service.SisuTutkintoohjelmaImportService
+import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaFetchingService
+import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaImportService
 import jakarta.annotation.PostConstruct
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
@@ -98,6 +98,8 @@ class ElsaBackendApp(
                 Application '${env.getProperty("spring.application.name")}' is running!
                 Local:      http://localhost:$serverPort$contextPath
                 Profile(s): ${env.activeProfiles.joinToString(",")}
+                Java: ${Runtime.version()}
+                Kotlin: ${KotlinVersion.CURRENT}
                 ----------------------------------------------------------
                 """.trimIndent()
             )

--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
@@ -9,6 +9,8 @@ import fi.elsapalvelu.elsa.security.*
 import fi.elsapalvelu.elsa.security.StaleXsrfCookieClearingFilter
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import jakarta.persistence.EntityNotFoundException
 import jakarta.servlet.http.HttpServletResponse
 import kotlinx.coroutines.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledOpintotietoImport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledOpintotietoImport.kt
@@ -17,6 +17,8 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
 import fi.elsapalvelu.elsa.scheduler.AbstractTriggerableJob
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 
 @Component
 class ScheduledOpintotietoImport(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledSisuTutkintoohjelmaImport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledSisuTutkintoohjelmaImport.kt
@@ -1,8 +1,8 @@
 package fi.elsapalvelu.elsa.scheduler.jobs
 
 import fi.elsapalvelu.elsa.scheduler.AbstractTriggerableJob
-import fi.elsapalvelu.elsa.service.SisuTutkintoohjelmaFetchingService
-import fi.elsapalvelu.elsa.service.SisuTutkintoohjelmaImportService
+import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaFetchingService
+import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaImportService
 import kotlinx.coroutines.runBlocking
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.springframework.scheduling.annotation.Scheduled

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/SisuTutkintoohjelmaFetchingService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/SisuTutkintoohjelmaFetchingService.kt
@@ -1,7 +1,0 @@
-package fi.elsapalvelu.elsa.service
-
-import fi.elsapalvelu.elsa.service.impl.Qualifications
-
-interface SisuTutkintoohjelmaFetchingService {
-    suspend fun fetch(): Qualifications?
-}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/SisuTutkintoohjelmaImportService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/SisuTutkintoohjelmaImportService.kt
@@ -1,7 +1,0 @@
-package fi.elsapalvelu.elsa.service
-
-import fi.elsapalvelu.elsa.service.impl.Qualifications
-
-interface SisuTutkintoohjelmaImportService {
-    fun import(qualifications: Qualifications)
-}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiService.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service
+package fi.elsapalvelu.elsa.service.arkistointi
 
 import fi.elsapalvelu.elsa.domain.Opintooikeus
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.arkistointi
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator
@@ -7,8 +7,16 @@ import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.Opintooikeus
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.service.AlertPublisherService
-import fi.elsapalvelu.elsa.service.ArkistointiService
-import fi.elsapalvelu.elsa.service.dto.arkistointi.*
+import fi.elsapalvelu.elsa.service.dto.arkistointi.ArkistointiMetadata
+import fi.elsapalvelu.elsa.service.dto.arkistointi.ArkistointiResult
+import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseFile
+import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
+import fi.elsapalvelu.elsa.service.dto.arkistointi.ContactInformation
+import fi.elsapalvelu.elsa.service.dto.arkistointi.PublicityClass
+import fi.elsapalvelu.elsa.service.dto.arkistointi.Record
+import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
+import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
+import fi.elsapalvelu.elsa.service.dto.arkistointi.TransferInformation
 import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
 import org.apache.commons.codec.digest.DigestUtils
 import org.slf4j.LoggerFactory
@@ -16,7 +24,7 @@ import org.springframework.stereotype.Service
 import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.time.LocalDate
-import java.util.*
+import java.util.ResourceBundle
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/HelsinkiSiiloService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/HelsinkiSiiloService.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.arkistointi
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/TampereLouhiService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/TampereLouhiService.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.arkistointi
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import org.apache.sshd.client.SshClient

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/AuthenticationTokenClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/AuthenticationTokenClientBuilderImpl.kt
@@ -1,6 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl
 
-import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonKoulutussopimusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonKoulutussopimusServiceImpl.kt
@@ -8,6 +8,7 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.*
 import fi.elsapalvelu.elsa.security.VASTUUHENKILO
 import fi.elsapalvelu.elsa.service.*
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiService
 import fi.elsapalvelu.elsa.service.dto.KoejaksonKoulutussopimusDTO
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonVaiheetServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonVaiheetServiceImpl.kt
@@ -4,10 +4,9 @@ import fi.elsapalvelu.elsa.domain.Kayttaja
 import fi.elsapalvelu.elsa.domain.Opintooikeus
 import fi.elsapalvelu.elsa.domain.enumeration.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.repository.*
-import fi.elsapalvelu.elsa.service.ArkistointiService
 import fi.elsapalvelu.elsa.service.KoejaksonVaiheetService
 import fi.elsapalvelu.elsa.service.KoejaksonVastuuhenkilonArvioQueryService
-import fi.elsapalvelu.elsa.service.KoejaksonVastuuhenkilonArvioService
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiService
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.*
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonVastuuhenkilonArvioServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonVastuuhenkilonArvioServiceImpl.kt
@@ -8,6 +8,7 @@ import fi.elsapalvelu.elsa.repository.*
 import fi.elsapalvelu.elsa.security.OPINTOHALLINNON_VIRKAILIJA
 import fi.elsapalvelu.elsa.security.VASTUUHENKILO
 import fi.elsapalvelu.elsa.service.*
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiService
 import fi.elsapalvelu.elsa.service.dto.AsiakirjaDTO
 import fi.elsapalvelu.elsa.service.dto.KoejaksonVastuuhenkilonArvioDTO
 import fi.elsapalvelu.elsa.service.dto.TyoskentelyjaksotTableDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
@@ -19,6 +19,7 @@ import fi.elsapalvelu.elsa.extensions.toYears
 import fi.elsapalvelu.elsa.repository.*
 import fi.elsapalvelu.elsa.security.VASTUUHENKILO
 import fi.elsapalvelu.elsa.service.*
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiService
 import fi.elsapalvelu.elsa.service.constants.*
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/AbstractOpintosuorituksetFetchingService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/AbstractOpintosuorituksetFetchingService.kt
@@ -1,0 +1,16 @@
+package fi.elsapalvelu.elsa.service.integration
+
+import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
+import fi.elsapalvelu.elsa.repository.YliopistoRepository
+
+abstract class AbstractOpintosuorituksetFetchingService(
+    private val yliopistoRepository: YliopistoRepository,
+    private val yliopisto: YliopistoEnum
+) : OpintosuorituksetFetchingService {
+
+    override fun shouldFetchOpintosuoritukset(): Boolean =
+        yliopistoRepository.findOneByNimi(yliopisto)?.haeOpintotietodata == true
+
+    override fun getYliopisto(): YliopistoEnum = yliopisto
+}
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/AbstractOpintotietodataFetchingService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/AbstractOpintotietodataFetchingService.kt
@@ -1,0 +1,16 @@
+package fi.elsapalvelu.elsa.service.integration
+
+import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
+import fi.elsapalvelu.elsa.repository.YliopistoRepository
+
+abstract class AbstractOpintotietodataFetchingService(
+    private val yliopistoRepository: YliopistoRepository,
+    private val yliopisto: YliopistoEnum
+) : OpintotietodataFetchingService {
+
+    override fun shouldFetchOpintotietodata(): Boolean =
+        yliopistoRepository.findOneByNimi(yliopisto)?.haeOpintotietodata == true
+
+    override fun getYliopisto(): YliopistoEnum = yliopisto
+}
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/GraphQLClientBuilder.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/GraphQLClientBuilder.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service
+package fi.elsapalvelu.elsa.service.integration
 
 import com.apollographql.apollo.ApolloClient
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/LocalizedString.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/LocalizedString.kt
@@ -1,0 +1,7 @@
+package fi.elsapalvelu.elsa.service.integration
+
+data class LocalizedString(
+    val fi: String?,
+    val sv: String?
+)
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/OkHttpClientBuilder.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/OkHttpClientBuilder.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service
+package fi.elsapalvelu.elsa.service.integration
 
 import okhttp3.OkHttpClient
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/OpintosuorituksetFetchingService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/OpintosuorituksetFetchingService.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service
+package fi.elsapalvelu.elsa.service.integration
 
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/OpintotietodataFetchingService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/OpintotietodataFetchingService.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service
+package fi.elsapalvelu.elsa.service.integration
 
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintosuorituksetFetchingService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintosuorituksetFetchingService.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service
+package fi.elsapalvelu.elsa.service.integration.peppi
 
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintosuorituksetFetchingServiceImpl.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
+import fi.elsapalvelu.elsa.service.integration.LocalizedString
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
@@ -88,7 +89,3 @@ data class StudyAccomplishment(
     val arvio: LocalizedString?
 )
 
-data class LocalizedString(
-    val fi: String?,
-    val sv: String?
-)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintosuorituksetFetchingServiceImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.peppi
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.core.type.TypeReference
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
-import fi.elsapalvelu.elsa.service.PeppiCommonOpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintotietodataFetchingService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintotietodataFetchingService.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service
+package fi.elsapalvelu.elsa.service.integration.peppi
 
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintotietodataFetchingServiceImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.peppi
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonProcessingException
@@ -11,7 +11,7 @@ import fi.elsapalvelu.elsa.domain.enumeration.OpintooikeudenTila
 import fi.elsapalvelu.elsa.domain.enumeration.OpintooikeudenTila.Companion.fromPeppiOpintooikeudenTila
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
-import fi.elsapalvelu.elsa.service.PeppiCommonOpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluClientBuilder.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluClientBuilder.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service
+package fi.elsapalvelu.elsa.service.integration.peppi.oulu
 
 import com.apollographql.apollo.ApolloClient
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluClientBuilderImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.peppi.oulu
 
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.network.okHttpClient

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluClientBuilderImpl.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.network.okHttpClient
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.interceptor.OkHttp3RequestInterceptor
-import fi.elsapalvelu.elsa.service.GraphQLClientBuilder
+import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.io.ResourceLoader

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintosuorituksetFetchingServiceImpl.kt
@@ -5,8 +5,8 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.checkErrors
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.GraphQLClientBuilder
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import fi.elsapalvelu.elsa.service.dto.OpintosuoritusDTO
 import fi.elsapalvelu.elsa.service.dto.OpintosuoritusOsakokonaisuusDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintosuorituksetFetchingServiceImpl.kt
@@ -5,8 +5,8 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.checkErrors
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
+import fi.elsapalvelu.elsa.service.integration.AbstractOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
-import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import fi.elsapalvelu.elsa.service.dto.OpintosuoritusDTO
 import fi.elsapalvelu.elsa.service.dto.OpintosuoritusOsakokonaisuusDTO
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Service
 @Service
 class PeppiOuluOpintosuorituksetFetchingServiceImpl(
     @Qualifier("PeppiOulu") private val peppiOuluClientBuilder: GraphQLClientBuilder,
-    private val yliopistoRepository: YliopistoRepository
-) : OpintosuorituksetFetchingService {
+    yliopistoRepository: YliopistoRepository
+) : AbstractOpintosuorituksetFetchingService(yliopistoRepository, YliopistoEnum.OULUN_YLIOPISTO) {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -62,13 +62,5 @@ class PeppiOuluOpintosuorituksetFetchingServiceImpl(
             arvio_sv = osakokonaisuus.grade?.name?.sv,
             vanhenemispaiva = osakokonaisuus.expiryDate?.tryParseToLocalDate(),
         )
-    }
-
-    override fun shouldFetchOpintosuoritukset(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.OULUN_YLIOPISTO)?.haeOpintotietodata == true
-    }
-
-    override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.OULUN_YLIOPISTO
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintosuorituksetFetchingServiceImpl.kt
@@ -1,6 +1,6 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.peppi.oulu
 
-import fi.elsapalvelu.elsa.OpintosuorituksetSisuHyQuery
+import fi.elsapalvelu.elsa.OpintosuorituksetPeppiOuluQuery
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.checkErrors
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
@@ -14,66 +14,61 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 
-private val validStates = listOf("ATTAINED", "SUBSTITUTED")
-
 @Service
-class SisuHyOpintosuorituksetFetchingServiceImpl(
-    @Qualifier("SisuHy") private val sisuHyClientBuilder: GraphQLClientBuilder,
+class PeppiOuluOpintosuorituksetFetchingServiceImpl(
+    @Qualifier("PeppiOulu") private val peppiOuluClientBuilder: GraphQLClientBuilder,
     private val yliopistoRepository: YliopistoRepository
 ) : OpintosuorituksetFetchingService {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
     override suspend fun fetchOpintosuoritukset(hetu: String): OpintosuorituksetPersistenceDTO? {
-        val response = sisuHyClientBuilder.apolloClient()
-            .query(OpintosuorituksetSisuHyQuery(id = hetu))
+        val response = peppiOuluClientBuilder.apolloClient()
+            .query(OpintosuorituksetPeppiOuluQuery(id = hetu))
             .execute()
-            .checkErrors("Opintosuoritustietoja ei saatu haettua HY:n Sisusta", log)
+            .checkErrors("Opintosuoritustietoja ei saatu haettua Oulun Pepistä", log)
 
-        return response.data?.private_person_by_personal_identity_code?.attainments?.filter {
-            it.state in validStates
-        }?.let {
+        return response.data?.private_person_by_personal_identity_code?.attainments?.let {
             OpintosuorituksetPersistenceDTO(
-                yliopisto = YliopistoEnum.HELSINGIN_YLIOPISTO,
+                yliopisto = YliopistoEnum.OULUN_YLIOPISTO,
                 items = it.map { a ->
                     OpintosuoritusDTO(
                         suorituspaiva = a.attainmentDate?.tryParseToLocalDate(),
                         opintopisteet = a.credits,
-                        nimi_fi = a.name?.fi ?: a.courseUnit?.name?.fi ?: a.module?.name?.fi,
-                        nimi_sv = a.name?.sv ?: a.courseUnit?.name?.sv ?: a.module?.name?.fi,
-                        kurssikoodi = a.code ?: a.courseUnit?.code ?: a.module?.code,
+                        nimi_fi = a.courseUnit?.name?.fi,
+                        nimi_sv = a.courseUnit?.name?.sv,
+                        kurssikoodi = a.courseUnit?.code,
                         hyvaksytty = a.grade?.passed,
                         arvio_fi = a.grade?.name?.fi,
                         arvio_sv = a.grade?.name?.sv,
                         vanhenemispaiva = a.expiryDate?.tryParseToLocalDate(),
                         yliopistoOpintooikeusId = a.studyRightId,
-                        osakokonaisuudet = a.childAttainments?.filter { c -> c.state in validStates }
-                            ?.map { c -> mapOsakokonaisuus(c) }
+                        osakokonaisuudet = a.childAttainments?.map { c -> mapOsakokonaisuus(c) }
                     )
                 }
             )
         }
     }
 
-    private fun mapOsakokonaisuus(osakokonaisuus: OpintosuorituksetSisuHyQuery.ChildAttainment): OpintosuoritusOsakokonaisuusDTO {
+    private fun mapOsakokonaisuus(osakokonaisuus: OpintosuorituksetPeppiOuluQuery.ChildAttainment): OpintosuoritusOsakokonaisuusDTO {
         return OpintosuoritusOsakokonaisuusDTO(
             suorituspaiva = osakokonaisuus.attainmentDate?.tryParseToLocalDate(),
             opintopisteet = osakokonaisuus.credits,
-            nimi_fi = osakokonaisuus.name?.fi ?: osakokonaisuus.courseUnit?.name?.fi,
-            nimi_sv = osakokonaisuus.name?.sv ?: osakokonaisuus.courseUnit?.name?.sv,
-            kurssikoodi = osakokonaisuus.code ?: osakokonaisuus.courseUnit?.code,
+            nimi_fi = osakokonaisuus.courseUnit?.name?.fi,
+            nimi_sv = osakokonaisuus.courseUnit?.name?.sv,
+            kurssikoodi = osakokonaisuus.courseUnit?.code,
             hyvaksytty = osakokonaisuus.grade?.passed,
             arvio_fi = osakokonaisuus.grade?.name?.fi,
             arvio_sv = osakokonaisuus.grade?.name?.sv,
-            vanhenemispaiva = osakokonaisuus.expiryDate?.tryParseToLocalDate()
+            vanhenemispaiva = osakokonaisuus.expiryDate?.tryParseToLocalDate(),
         )
     }
 
     override fun shouldFetchOpintosuoritukset(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.HELSINGIN_YLIOPISTO)?.haeOpintotietodata == true
+        return yliopistoRepository.findOneByNimi(YliopistoEnum.OULUN_YLIOPISTO)?.haeOpintotietodata == true
     }
 
     override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.HELSINGIN_YLIOPISTO
+        return YliopistoEnum.OULUN_YLIOPISTO
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintotietodataFetchingServiceImpl.kt
@@ -9,8 +9,8 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.checkErrors
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.GraphQLClientBuilder
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintotietoOpintooikeusDataDTO
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
 import fi.elsapalvelu.elsa.service.dto.enumeration.PeppiOpintooikeudenTila

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintotietodataFetchingServiceImpl.kt
@@ -9,8 +9,8 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.checkErrors
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
+import fi.elsapalvelu.elsa.service.integration.AbstractOpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
-import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintotietoOpintooikeusDataDTO
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
 import fi.elsapalvelu.elsa.service.dto.enumeration.PeppiOpintooikeudenTila
@@ -21,8 +21,8 @@ import org.springframework.stereotype.Service
 @Service
 class PeppiOuluOpintotietodataFetchingServiceImpl(
     @Qualifier("PeppiOulu") private val peppiOuluClientBuilder: GraphQLClientBuilder,
-    private val yliopistoRepository: YliopistoRepository
-) : OpintotietodataFetchingService {
+    yliopistoRepository: YliopistoRepository
+) : AbstractOpintotietodataFetchingService(yliopistoRepository, YliopistoEnum.OULUN_YLIOPISTO) {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -53,14 +53,6 @@ class PeppiOuluOpintotietodataFetchingServiceImpl(
                     )
                 })
         }
-    }
-
-    override fun shouldFetchOpintotietodata(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.OULUN_YLIOPISTO)?.haeOpintotietodata == true
-    }
-
-    override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.OULUN_YLIOPISTO
     }
 
     private fun mapOpintooikeudenTila(tila: String?): OpintooikeudenTila? {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintotietodataFetchingServiceImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.peppi.oulu
 
 import fi.elsapalvelu.elsa.OpintotietodataPeppiOuluQuery
 import fi.elsapalvelu.elsa.config.ERIKOISTUVA_HAMMASLAAKARI_PEPPI_KOULUTUS

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuClientBuilderImpl.kt
@@ -1,44 +1,42 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.peppi.turku
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.interceptor.OkHttp3RequestInterceptor
-import fi.elsapalvelu.elsa.security.AccessTokenAuthenticator
-import fi.elsapalvelu.elsa.service.AuthenticationTokenService
 import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import java.util.concurrent.TimeUnit
 
-@Qualifier("SisuTre")
+@Qualifier("PeppiTurku")
 @Service
-class SisuTreClientBuilderImpl(
-    sisuTreAuthenticationTokenService: AuthenticationTokenService,
+class PeppiTurkuClientBuilderImpl(
     applicationProperties: ApplicationProperties
 ) : OkHttpClientBuilder {
 
     init {
         Companion.applicationProperties = applicationProperties
-        Companion.sisuTreAuthenticationTokenService = sisuTreAuthenticationTokenService
     }
 
     companion object {
 
         private lateinit var applicationProperties: ApplicationProperties
-        private lateinit var sisuTreAuthenticationTokenService: AuthenticationTokenService
 
         val okHttpClient: OkHttpClient by lazy {
             OkHttpClient.Builder()
                 .addInterceptor(
                     OkHttp3RequestInterceptor(
                         mapOf(
-                            "Ocp-Apim-Subscription-Key" to applicationProperties.getSecurity()
-                                .getSisuTre().subscriptionKey!!,
-                            "Content-Type" to "application/json"
+                            "Accept" to "application/json",
+                            "ESP-ScreenName" to "peppi_elsa",
+                            "username" to "peppi_elsa",
+                            "X-Api-Key" to applicationProperties.getSecurity().getPeppiTurku().apiKey!!,
+                            "Authorization" to "Basic ${
+                                applicationProperties.getSecurity().getPeppiTurku().basicAuthEncodedKey!!
+                            }"
                         )
                     )
                 )
-                .authenticator(AccessTokenAuthenticator(sisuTreAuthenticationTokenService))
                 .connectTimeout(5, TimeUnit.SECONDS)
                 .readTimeout(5, TimeUnit.SECONDS)
                 .writeTimeout(5, TimeUnit.SECONDS)
@@ -47,10 +45,6 @@ class SisuTreClientBuilderImpl(
     }
 
     override fun okHttpClient(): OkHttpClient {
-        return okHttpClient.newBuilder().addInterceptor(
-            OkHttp3RequestInterceptor(
-                mapOf("Authorization" to "Bearer ${sisuTreAuthenticationTokenService.getCachedTokenOrRequestNew()}")
-            )
-        ).build()
+        return okHttpClient
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuClientBuilderImpl.kt
@@ -2,7 +2,7 @@ package fi.elsapalvelu.elsa.service.integration.peppi.turku
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.interceptor.OkHttp3RequestInterceptor
-import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintosuorituksetFetchingServiceImpl.kt
@@ -3,8 +3,8 @@ package fi.elsapalvelu.elsa.service.integration.peppi.turku
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
+import fi.elsapalvelu.elsa.service.integration.AbstractOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import org.springframework.beans.factory.annotation.Qualifier
@@ -15,8 +15,8 @@ class PeppiTurkuOpintosuorituksetFetchingServiceImpl(
     @Qualifier("PeppiTurku") private val peppiTurkuClientBuilder: OkHttpClientBuilder,
     private val commonOpintosuorituksetFetchingService: PeppiCommonOpintosuorituksetFetchingService,
     private val applicationProperties: ApplicationProperties,
-    private val yliopistoRepository: YliopistoRepository
-) : OpintosuorituksetFetchingService {
+    yliopistoRepository: YliopistoRepository
+) : AbstractOpintosuorituksetFetchingService(yliopistoRepository, YliopistoEnum.TURUN_YLIOPISTO) {
 
     override suspend fun fetchOpintosuoritukset(hetu: String): OpintosuorituksetPersistenceDTO? {
         val endpointBaseUrl =
@@ -27,13 +27,5 @@ class PeppiTurkuOpintosuorituksetFetchingServiceImpl(
             hetu,
             YliopistoEnum.TURUN_YLIOPISTO
         )
-    }
-
-    override fun shouldFetchOpintosuoritukset(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.TURUN_YLIOPISTO)?.haeOpintotietodata == true
-    }
-
-    override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.TURUN_YLIOPISTO
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintosuorituksetFetchingServiceImpl.kt
@@ -1,25 +1,27 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.peppi.turku
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
 import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
-import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
+import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 
 @Service
-class PeppiTurkuOpintotietodataFetchingServiceImpl(
+class PeppiTurkuOpintosuorituksetFetchingServiceImpl(
     @Qualifier("PeppiTurku") private val peppiTurkuClientBuilder: OkHttpClientBuilder,
-    private val commonOpintotietodataFetchingServiceImpl: PeppiCommonOpintotietodataFetchingServiceImpl,
+    private val commonOpintosuorituksetFetchingService: PeppiCommonOpintosuorituksetFetchingService,
     private val applicationProperties: ApplicationProperties,
     private val yliopistoRepository: YliopistoRepository
-) : OpintotietodataFetchingService {
+) : OpintosuorituksetFetchingService {
 
-    override suspend fun fetchOpintotietodata(hetu: String): OpintotietodataDTO? {
-        val endpointBaseUrl = "${applicationProperties.getSecurity().getPeppiTurku().endpointUrl!!}/student"
-        return commonOpintotietodataFetchingServiceImpl.fetchOpintotietodata(
+    override suspend fun fetchOpintosuoritukset(hetu: String): OpintosuorituksetPersistenceDTO? {
+        val endpointBaseUrl =
+            "${applicationProperties.getSecurity().getPeppiTurku().endpointUrl!!}/study_accomplishments"
+        return commonOpintosuorituksetFetchingService.fetchOpintosuoritukset(
             endpointBaseUrl,
             peppiTurkuClientBuilder.okHttpClient(),
             hetu,
@@ -27,7 +29,7 @@ class PeppiTurkuOpintotietodataFetchingServiceImpl(
         )
     }
 
-    override fun shouldFetchOpintotietodata(): Boolean {
+    override fun shouldFetchOpintosuoritukset(): Boolean {
         return yliopistoRepository.findOneByNimi(YliopistoEnum.TURUN_YLIOPISTO)?.haeOpintotietodata == true
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintosuorituksetFetchingServiceImpl.kt
@@ -3,8 +3,8 @@ package fi.elsapalvelu.elsa.service.integration.peppi.turku
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintotietodataFetchingServiceImpl.kt
@@ -3,8 +3,8 @@ package fi.elsapalvelu.elsa.service.integration.peppi.turku
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
+import fi.elsapalvelu.elsa.service.integration.AbstractOpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingServiceImpl
 import org.springframework.beans.factory.annotation.Qualifier
@@ -15,8 +15,8 @@ class PeppiTurkuOpintotietodataFetchingServiceImpl(
     @Qualifier("PeppiTurku") private val peppiTurkuClientBuilder: OkHttpClientBuilder,
     private val commonOpintotietodataFetchingServiceImpl: PeppiCommonOpintotietodataFetchingServiceImpl,
     private val applicationProperties: ApplicationProperties,
-    private val yliopistoRepository: YliopistoRepository
-) : OpintotietodataFetchingService {
+    yliopistoRepository: YliopistoRepository
+) : AbstractOpintotietodataFetchingService(yliopistoRepository, YliopistoEnum.TURUN_YLIOPISTO) {
 
     override suspend fun fetchOpintotietodata(hetu: String): OpintotietodataDTO? {
         val endpointBaseUrl = "${applicationProperties.getSecurity().getPeppiTurku().endpointUrl!!}/student"
@@ -26,13 +26,5 @@ class PeppiTurkuOpintotietodataFetchingServiceImpl(
             hetu,
             YliopistoEnum.TURUN_YLIOPISTO
         )
-    }
-
-    override fun shouldFetchOpintotietodata(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.TURUN_YLIOPISTO)?.haeOpintotietodata == true
-    }
-
-    override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.TURUN_YLIOPISTO
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintotietodataFetchingServiceImpl.kt
@@ -1,27 +1,26 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.peppi.turku
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
 import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
-import fi.elsapalvelu.elsa.service.PeppiCommonOpintosuorituksetFetchingService
-import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
+import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingServiceImpl
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 
 @Service
-class PeppiTurkuOpintosuorituksetFetchingServiceImpl(
+class PeppiTurkuOpintotietodataFetchingServiceImpl(
     @Qualifier("PeppiTurku") private val peppiTurkuClientBuilder: OkHttpClientBuilder,
-    private val commonOpintosuorituksetFetchingService: PeppiCommonOpintosuorituksetFetchingService,
+    private val commonOpintotietodataFetchingServiceImpl: PeppiCommonOpintotietodataFetchingServiceImpl,
     private val applicationProperties: ApplicationProperties,
     private val yliopistoRepository: YliopistoRepository
-) : OpintosuorituksetFetchingService {
+) : OpintotietodataFetchingService {
 
-    override suspend fun fetchOpintosuoritukset(hetu: String): OpintosuorituksetPersistenceDTO? {
-        val endpointBaseUrl =
-            "${applicationProperties.getSecurity().getPeppiTurku().endpointUrl!!}/study_accomplishments"
-        return commonOpintosuorituksetFetchingService.fetchOpintosuoritukset(
+    override suspend fun fetchOpintotietodata(hetu: String): OpintotietodataDTO? {
+        val endpointBaseUrl = "${applicationProperties.getSecurity().getPeppiTurku().endpointUrl!!}/student"
+        return commonOpintotietodataFetchingServiceImpl.fetchOpintotietodata(
             endpointBaseUrl,
             peppiTurkuClientBuilder.okHttpClient(),
             hetu,
@@ -29,7 +28,7 @@ class PeppiTurkuOpintosuorituksetFetchingServiceImpl(
         )
     }
 
-    override fun shouldFetchOpintosuoritukset(): Boolean {
+    override fun shouldFetchOpintotietodata(): Boolean {
         return yliopistoRepository.findOneByNimi(YliopistoEnum.TURUN_YLIOPISTO)?.haeOpintotietodata == true
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintotietodataFetchingServiceImpl.kt
@@ -3,8 +3,8 @@ package fi.elsapalvelu.elsa.service.integration.peppi.turku
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingServiceImpl
 import org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefClientBuilderImpl.kt
@@ -2,7 +2,7 @@ package fi.elsapalvelu.elsa.service.integration.peppi.uef
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.interceptor.OkHttp3RequestInterceptor
-import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefClientBuilderImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.peppi.uef
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.interceptor.OkHttp3RequestInterceptor

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintosuorituksetFetchingServiceImpl.kt
@@ -1,11 +1,11 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.peppi.uef
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
 import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
 import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
-import fi.elsapalvelu.elsa.service.PeppiCommonOpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintosuorituksetFetchingServiceImpl.kt
@@ -3,8 +3,8 @@ package fi.elsapalvelu.elsa.service.integration.peppi.uef
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
+import fi.elsapalvelu.elsa.service.integration.AbstractOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import org.springframework.beans.factory.annotation.Qualifier
@@ -15,8 +15,8 @@ class PeppiUefOpintosuorituksetFetchingServiceImpl(
     @Qualifier("PeppiUef") private val peppiUefClientBuilder: OkHttpClientBuilder,
     private val commonOpintosuorituksetFetchingService: PeppiCommonOpintosuorituksetFetchingService,
     private val applicationProperties: ApplicationProperties,
-    private val yliopistoRepository: YliopistoRepository
-) : OpintosuorituksetFetchingService {
+    yliopistoRepository: YliopistoRepository
+) : AbstractOpintosuorituksetFetchingService(yliopistoRepository, YliopistoEnum.ITA_SUOMEN_YLIOPISTO) {
 
     override suspend fun fetchOpintosuoritukset(hetu: String): OpintosuorituksetPersistenceDTO? {
         val endpointBaseUrl =
@@ -27,13 +27,5 @@ class PeppiUefOpintosuorituksetFetchingServiceImpl(
             hetu,
             YliopistoEnum.ITA_SUOMEN_YLIOPISTO
         )
-    }
-
-    override fun shouldFetchOpintosuoritukset(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.ITA_SUOMEN_YLIOPISTO)?.haeOpintotietodata == true
-    }
-
-    override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.ITA_SUOMEN_YLIOPISTO
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintosuorituksetFetchingServiceImpl.kt
@@ -3,8 +3,8 @@ package fi.elsapalvelu.elsa.service.integration.peppi.uef
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintotietodataFetchingServiceImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.peppi.uef
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
@@ -6,6 +6,7 @@ import fi.elsapalvelu.elsa.repository.YliopistoRepository
 import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
 import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingServiceImpl
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintotietodataFetchingServiceImpl.kt
@@ -3,8 +3,8 @@ package fi.elsapalvelu.elsa.service.integration.peppi.uef
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingServiceImpl
 import org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintotietodataFetchingServiceImpl.kt
@@ -3,8 +3,8 @@ package fi.elsapalvelu.elsa.service.integration.peppi.uef
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
+import fi.elsapalvelu.elsa.service.integration.AbstractOpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingServiceImpl
 import org.springframework.beans.factory.annotation.Qualifier
@@ -15,8 +15,8 @@ class PeppiUefOpintotietodataFetchingServiceImpl(
     @Qualifier("PeppiUef") private val peppiUefClientBuilder: OkHttpClientBuilder,
     private val commonOpintotietodataFetchingServiceImpl: PeppiCommonOpintotietodataFetchingServiceImpl,
     private val applicationProperties: ApplicationProperties,
-    private val yliopistoRepository: YliopistoRepository
-) : OpintotietodataFetchingService {
+    yliopistoRepository: YliopistoRepository
+) : AbstractOpintotietodataFetchingService(yliopistoRepository, YliopistoEnum.ITA_SUOMEN_YLIOPISTO) {
 
     override suspend fun fetchOpintotietodata(hetu: String): OpintotietodataDTO? {
         val endpointBaseUrl = "${applicationProperties.getSecurity().getPeppiUef().endpointUrl!!}/elsa-1"
@@ -26,13 +26,5 @@ class PeppiUefOpintotietodataFetchingServiceImpl(
             hetu,
             YliopistoEnum.ITA_SUOMEN_YLIOPISTO
         )
-    }
-
-    override fun shouldFetchOpintotietodata(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.ITA_SUOMEN_YLIOPISTO)?.haeOpintotietodata == true
-    }
-
-    override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.ITA_SUOMEN_YLIOPISTO
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaFetchingService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaFetchingService.kt
@@ -1,0 +1,7 @@
+package fi.elsapalvelu.elsa.service.integration.sisu
+
+import fi.elsapalvelu.elsa.service.integration.sisu.Qualifications
+
+interface SisuTutkintoohjelmaFetchingService {
+    suspend fun fetch(): Qualifications?
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaFetchingServiceImpl.kt
@@ -1,11 +1,11 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.sisu
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.service.GraphQLClientBuilder
-import fi.elsapalvelu.elsa.service.SisuTutkintoohjelmaFetchingService
+import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaFetchingService
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaFetchingServiceImpl.kt
@@ -4,8 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.ApplicationProperties
-import fi.elsapalvelu.elsa.service.GraphQLClientBuilder
-import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaFetchingService
+import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaImportService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaImportService.kt
@@ -1,0 +1,7 @@
+package fi.elsapalvelu.elsa.service.integration.sisu
+
+import fi.elsapalvelu.elsa.service.integration.sisu.Qualifications
+
+interface SisuTutkintoohjelmaImportService {
+    fun import(qualifications: Qualifications)
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaImportServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaImportServiceImpl.kt
@@ -1,8 +1,8 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.sisu
 
 import fi.elsapalvelu.elsa.domain.ErikoisalaSisuTutkintoohjelma
 import fi.elsapalvelu.elsa.repository.ErikoisalaRepository
-import fi.elsapalvelu.elsa.service.SisuTutkintoohjelmaImportService
+import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaImportService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyClientBuilderImpl.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.network.okHttpClient
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.interceptor.OkHttp3RequestInterceptor
-import fi.elsapalvelu.elsa.service.GraphQLClientBuilder
+import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
 import okhttp3.OkHttpClient
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyClientBuilderImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.sisu.helsinki
 
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.network.okHttpClient

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintosuorituksetFetchingServiceImpl.kt
@@ -5,8 +5,8 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.checkErrors
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
+import fi.elsapalvelu.elsa.service.integration.AbstractOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
-import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import fi.elsapalvelu.elsa.service.dto.OpintosuoritusDTO
 import fi.elsapalvelu.elsa.service.dto.OpintosuoritusOsakokonaisuusDTO
@@ -19,8 +19,8 @@ private val validStates = listOf("ATTAINED", "SUBSTITUTED")
 @Service
 class SisuHyOpintosuorituksetFetchingServiceImpl(
     @Qualifier("SisuHy") private val sisuHyClientBuilder: GraphQLClientBuilder,
-    private val yliopistoRepository: YliopistoRepository
-) : OpintosuorituksetFetchingService {
+    yliopistoRepository: YliopistoRepository
+) : AbstractOpintosuorituksetFetchingService(yliopistoRepository, YliopistoEnum.HELSINGIN_YLIOPISTO) {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -67,13 +67,5 @@ class SisuHyOpintosuorituksetFetchingServiceImpl(
             arvio_sv = osakokonaisuus.grade?.name?.sv,
             vanhenemispaiva = osakokonaisuus.expiryDate?.tryParseToLocalDate()
         )
-    }
-
-    override fun shouldFetchOpintosuoritukset(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.HELSINGIN_YLIOPISTO)?.haeOpintotietodata == true
-    }
-
-    override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.HELSINGIN_YLIOPISTO
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintosuorituksetFetchingServiceImpl.kt
@@ -5,8 +5,8 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.checkErrors
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.GraphQLClientBuilder
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import fi.elsapalvelu.elsa.service.dto.OpintosuoritusDTO
 import fi.elsapalvelu.elsa.service.dto.OpintosuoritusOsakokonaisuusDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintosuorituksetFetchingServiceImpl.kt
@@ -1,6 +1,6 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.sisu.helsinki
 
-import fi.elsapalvelu.elsa.OpintosuorituksetPeppiOuluQuery
+import fi.elsapalvelu.elsa.OpintosuorituksetSisuHyQuery
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.checkErrors
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
@@ -14,61 +14,66 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 
+private val validStates = listOf("ATTAINED", "SUBSTITUTED")
+
 @Service
-class PeppiOuluOpintosuorituksetFetchingServiceImpl(
-    @Qualifier("PeppiOulu") private val peppiOuluClientBuilder: GraphQLClientBuilder,
+class SisuHyOpintosuorituksetFetchingServiceImpl(
+    @Qualifier("SisuHy") private val sisuHyClientBuilder: GraphQLClientBuilder,
     private val yliopistoRepository: YliopistoRepository
 ) : OpintosuorituksetFetchingService {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
     override suspend fun fetchOpintosuoritukset(hetu: String): OpintosuorituksetPersistenceDTO? {
-        val response = peppiOuluClientBuilder.apolloClient()
-            .query(OpintosuorituksetPeppiOuluQuery(id = hetu))
+        val response = sisuHyClientBuilder.apolloClient()
+            .query(OpintosuorituksetSisuHyQuery(id = hetu))
             .execute()
-            .checkErrors("Opintosuoritustietoja ei saatu haettua Oulun Pepistä", log)
+            .checkErrors("Opintosuoritustietoja ei saatu haettua HY:n Sisusta", log)
 
-        return response.data?.private_person_by_personal_identity_code?.attainments?.let {
+        return response.data?.private_person_by_personal_identity_code?.attainments?.filter {
+            it.state in validStates
+        }?.let {
             OpintosuorituksetPersistenceDTO(
-                yliopisto = YliopistoEnum.OULUN_YLIOPISTO,
+                yliopisto = YliopistoEnum.HELSINGIN_YLIOPISTO,
                 items = it.map { a ->
                     OpintosuoritusDTO(
                         suorituspaiva = a.attainmentDate?.tryParseToLocalDate(),
                         opintopisteet = a.credits,
-                        nimi_fi = a.courseUnit?.name?.fi,
-                        nimi_sv = a.courseUnit?.name?.sv,
-                        kurssikoodi = a.courseUnit?.code,
+                        nimi_fi = a.name?.fi ?: a.courseUnit?.name?.fi ?: a.module?.name?.fi,
+                        nimi_sv = a.name?.sv ?: a.courseUnit?.name?.sv ?: a.module?.name?.fi,
+                        kurssikoodi = a.code ?: a.courseUnit?.code ?: a.module?.code,
                         hyvaksytty = a.grade?.passed,
                         arvio_fi = a.grade?.name?.fi,
                         arvio_sv = a.grade?.name?.sv,
                         vanhenemispaiva = a.expiryDate?.tryParseToLocalDate(),
                         yliopistoOpintooikeusId = a.studyRightId,
-                        osakokonaisuudet = a.childAttainments?.map { c -> mapOsakokonaisuus(c) }
+                        osakokonaisuudet = a.childAttainments?.filter { c -> c.state in validStates }
+                            ?.map { c -> mapOsakokonaisuus(c) }
                     )
                 }
             )
         }
     }
 
-    private fun mapOsakokonaisuus(osakokonaisuus: OpintosuorituksetPeppiOuluQuery.ChildAttainment): OpintosuoritusOsakokonaisuusDTO {
+    private fun mapOsakokonaisuus(osakokonaisuus: OpintosuorituksetSisuHyQuery.ChildAttainment): OpintosuoritusOsakokonaisuusDTO {
         return OpintosuoritusOsakokonaisuusDTO(
             suorituspaiva = osakokonaisuus.attainmentDate?.tryParseToLocalDate(),
             opintopisteet = osakokonaisuus.credits,
-            nimi_fi = osakokonaisuus.courseUnit?.name?.fi,
-            nimi_sv = osakokonaisuus.courseUnit?.name?.sv,
-            kurssikoodi = osakokonaisuus.courseUnit?.code,
+            nimi_fi = osakokonaisuus.name?.fi ?: osakokonaisuus.courseUnit?.name?.fi,
+            nimi_sv = osakokonaisuus.name?.sv ?: osakokonaisuus.courseUnit?.name?.sv,
+            kurssikoodi = osakokonaisuus.code ?: osakokonaisuus.courseUnit?.code,
             hyvaksytty = osakokonaisuus.grade?.passed,
             arvio_fi = osakokonaisuus.grade?.name?.fi,
             arvio_sv = osakokonaisuus.grade?.name?.sv,
-            vanhenemispaiva = osakokonaisuus.expiryDate?.tryParseToLocalDate(),
+            vanhenemispaiva = osakokonaisuus.expiryDate?.tryParseToLocalDate()
         )
     }
 
     override fun shouldFetchOpintosuoritukset(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.OULUN_YLIOPISTO)?.haeOpintotietodata == true
+        return yliopistoRepository.findOneByNimi(YliopistoEnum.HELSINGIN_YLIOPISTO)?.haeOpintotietodata == true
     }
 
     override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.OULUN_YLIOPISTO
+        return YliopistoEnum.HELSINGIN_YLIOPISTO
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintotietodataFetchingServiceImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.sisu.helsinki
 
 import fi.elsapalvelu.elsa.OpintotietodataSisuHyQuery
 import fi.elsapalvelu.elsa.config.ERIKOISTUVA_HAMMASLAAKARI_SISU_KOULUTUS

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintotietodataFetchingServiceImpl.kt
@@ -9,8 +9,8 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.checkErrors
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
+import fi.elsapalvelu.elsa.service.integration.AbstractOpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
-import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintotietoOpintooikeusDataDTO
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
 import org.slf4j.LoggerFactory
@@ -20,8 +20,8 @@ import org.springframework.stereotype.Service
 @Service
 class SisuHyOpintotietodataFetchingServiceImpl(
     @Qualifier("SisuHy") private val sisuHyClientBuilder: GraphQLClientBuilder,
-    private val yliopistoRepository: YliopistoRepository
-) : OpintotietodataFetchingService {
+    yliopistoRepository: YliopistoRepository
+) : AbstractOpintotietodataFetchingService(yliopistoRepository, YliopistoEnum.HELSINGIN_YLIOPISTO) {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -53,13 +53,5 @@ class SisuHyOpintotietodataFetchingServiceImpl(
                     )
                 })
         }
-    }
-
-    override fun shouldFetchOpintotietodata(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.HELSINGIN_YLIOPISTO)?.haeOpintotietodata == true
-    }
-
-    override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.HELSINGIN_YLIOPISTO
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/helsinki/SisuHyOpintotietodataFetchingServiceImpl.kt
@@ -9,8 +9,8 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.checkErrors
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.GraphQLClientBuilder
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintotietoOpintooikeusDataDTO
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreAuthenticationTokenServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreAuthenticationTokenServiceImpl.kt
@@ -8,7 +8,7 @@ import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.security.AuthenticationToken
 import fi.elsapalvelu.elsa.security.AuthenticationTokenCache
 import fi.elsapalvelu.elsa.service.AuthenticationTokenService
-import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreAuthenticationTokenServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreAuthenticationTokenServiceImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.sisu.tampere
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonProcessingException

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreClientBuilderImpl.kt
@@ -1,42 +1,44 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.sisu.tampere
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.interceptor.OkHttp3RequestInterceptor
+import fi.elsapalvelu.elsa.security.AccessTokenAuthenticator
+import fi.elsapalvelu.elsa.service.AuthenticationTokenService
 import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import java.util.concurrent.TimeUnit
 
-@Qualifier("PeppiTurku")
+@Qualifier("SisuTre")
 @Service
-class PeppiTurkuClientBuilderImpl(
+class SisuTreClientBuilderImpl(
+    sisuTreAuthenticationTokenService: AuthenticationTokenService,
     applicationProperties: ApplicationProperties
 ) : OkHttpClientBuilder {
 
     init {
         Companion.applicationProperties = applicationProperties
+        Companion.sisuTreAuthenticationTokenService = sisuTreAuthenticationTokenService
     }
 
     companion object {
 
         private lateinit var applicationProperties: ApplicationProperties
+        private lateinit var sisuTreAuthenticationTokenService: AuthenticationTokenService
 
         val okHttpClient: OkHttpClient by lazy {
             OkHttpClient.Builder()
                 .addInterceptor(
                     OkHttp3RequestInterceptor(
                         mapOf(
-                            "Accept" to "application/json",
-                            "ESP-ScreenName" to "peppi_elsa",
-                            "username" to "peppi_elsa",
-                            "X-Api-Key" to applicationProperties.getSecurity().getPeppiTurku().apiKey!!,
-                            "Authorization" to "Basic ${
-                                applicationProperties.getSecurity().getPeppiTurku().basicAuthEncodedKey!!
-                            }"
+                            "Ocp-Apim-Subscription-Key" to applicationProperties.getSecurity()
+                                .getSisuTre().subscriptionKey!!,
+                            "Content-Type" to "application/json"
                         )
                     )
                 )
+                .authenticator(AccessTokenAuthenticator(sisuTreAuthenticationTokenService))
                 .connectTimeout(5, TimeUnit.SECONDS)
                 .readTimeout(5, TimeUnit.SECONDS)
                 .writeTimeout(5, TimeUnit.SECONDS)
@@ -45,6 +47,10 @@ class PeppiTurkuClientBuilderImpl(
     }
 
     override fun okHttpClient(): OkHttpClient {
-        return okHttpClient
+        return okHttpClient.newBuilder().addInterceptor(
+            OkHttp3RequestInterceptor(
+                mapOf("Authorization" to "Bearer ${sisuTreAuthenticationTokenService.getCachedTokenOrRequestNew()}")
+            )
+        ).build()
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreClientBuilderImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreClientBuilderImpl.kt
@@ -4,7 +4,7 @@ import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.interceptor.OkHttp3RequestInterceptor
 import fi.elsapalvelu.elsa.security.AccessTokenAuthenticator
 import fi.elsapalvelu.elsa.service.AuthenticationTokenService
-import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintosuorituksetFetchingServiceImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.sisu.tampere
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonMappingException
@@ -108,3 +108,9 @@ data class Grade(
     val name: LocalizedString?,
     val passed: Boolean
 )
+
+data class LocalizedString(
+    val fi: String?,
+    val sv: String?
+)
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintosuorituksetFetchingServiceImpl.kt
@@ -7,8 +7,9 @@ import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
+import fi.elsapalvelu.elsa.service.integration.AbstractOpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.LocalizedString
 import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR
@@ -26,8 +27,8 @@ class SisuTreOpintosuorituksetFetchingServiceImpl(
     @Qualifier("SisuTre") private val sisuTreClientBuilder: OkHttpClientBuilder,
     private val applicationProperties: ApplicationProperties,
     private val objectMapper: ObjectMapper,
-    private val yliopistoRepository: YliopistoRepository
-) : OpintosuorituksetFetchingService {
+    yliopistoRepository: YliopistoRepository
+) : AbstractOpintosuorituksetFetchingService(yliopistoRepository, YliopistoEnum.TAMPEREEN_YLIOPISTO) {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -77,13 +78,6 @@ class SisuTreOpintosuorituksetFetchingServiceImpl(
         }
     }
 
-    override fun shouldFetchOpintosuoritukset(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.TAMPEREEN_YLIOPISTO)?.haeOpintotietodata == true
-    }
-
-    override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.TAMPEREEN_YLIOPISTO
-    }
 }
 
 data class AttainmentsResponse(val attainments: List<Attainment>)
@@ -107,10 +101,5 @@ data class CourseUnit(
 data class Grade(
     val name: LocalizedString?,
     val passed: Boolean
-)
-
-data class LocalizedString(
-    val fi: String?,
-    val sv: String?
 )
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintosuorituksetFetchingServiceImpl.kt
@@ -7,8 +7,8 @@ import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintotietodataFetchingServiceImpl.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.impl
+package fi.elsapalvelu.elsa.service.integration.sisu.tampere
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonMappingException

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintotietodataFetchingServiceImpl.kt
@@ -8,8 +8,8 @@ import fi.elsapalvelu.elsa.domain.enumeration.OpintooikeudenTila.Companion.fromS
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintotietodataFetchingServiceImpl.kt
@@ -8,8 +8,8 @@ import fi.elsapalvelu.elsa.domain.enumeration.OpintooikeudenTila.Companion.fromS
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
+import fi.elsapalvelu.elsa.service.integration.AbstractOpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR
@@ -28,8 +28,8 @@ class SisuTreOpintotietodataFetchingServiceImpl(
     @Qualifier("SisuTre") private val sisuTreClientBuilder: OkHttpClientBuilder,
     private val applicationProperties: ApplicationProperties,
     private val objectMapper: ObjectMapper,
-    private val yliopistoRepository: YliopistoRepository
-) : OpintotietodataFetchingService {
+    yliopistoRepository: YliopistoRepository
+) : AbstractOpintotietodataFetchingService(yliopistoRepository, YliopistoEnum.TAMPEREEN_YLIOPISTO) {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -77,14 +77,6 @@ class SisuTreOpintotietodataFetchingServiceImpl(
             log.error("$JSON_FETCHING_ERROR: $endpointUrl ${e.message}", e)
             throw e
         }
-    }
-
-    override fun shouldFetchOpintotietodata(): Boolean {
-        return yliopistoRepository.findOneByNimi(YliopistoEnum.TAMPEREEN_YLIOPISTO)?.haeOpintotietodata == true
-    }
-
-    override fun getYliopisto(): YliopistoEnum {
-        return YliopistoEnum.TAMPEREEN_YLIOPISTO
     }
 }
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/config/SecurityConfigurationTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/config/SecurityConfigurationTest.kt
@@ -10,9 +10,9 @@ import fi.elsapalvelu.elsa.repository.OpintooikeusRepository
 import fi.elsapalvelu.elsa.repository.UserRepository
 import fi.elsapalvelu.elsa.repository.VerificationTokenRepository
 import fi.elsapalvelu.elsa.service.OpintooikeusService
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.OpintosuorituksetPersistenceService
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.OpintotietodataPersistenceService
 import fi.elsapalvelu.elsa.service.UserService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/FetchingServiceExternalIntegrationBase.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/FetchingServiceExternalIntegrationBase.kt
@@ -1,8 +1,8 @@
 package fi.elsapalvelu.elsa.externalintegration
 
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import fi.elsapalvelu.elsa.service.dto.OpintosuoritusDTO
 import fi.elsapalvelu.elsa.service.dto.OpintosuoritusOsakokonaisuusDTO
@@ -11,7 +11,6 @@ import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.slf4j.LoggerFactory
 
 abstract class FetchingServiceExternalIntegrationBase : ExternalIntegrationTestSupport() {
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/arkistointi/tampere/TampereArkistointiExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/arkistointi/tampere/TampereArkistointiExternalIntegrationTests.kt
@@ -4,13 +4,13 @@ import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.externalintegration.ExternalIntegrationTestSupport
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiServiceImpl
+import fi.elsapalvelu.elsa.service.arkistointi.HelsinkiSiiloService
+import fi.elsapalvelu.elsa.service.arkistointi.TampereLouhiService
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
-import fi.elsapalvelu.elsa.service.impl.ArkistointiServiceImpl
 import fi.elsapalvelu.elsa.service.impl.AlertPublisherServiceImpl
-import fi.elsapalvelu.elsa.service.impl.HelsinkiSiiloService
-import fi.elsapalvelu.elsa.service.impl.TampereLouhiService
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Disabled

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/oulu/PeppiOuluExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/oulu/PeppiOuluExternalIntegrationTests.kt
@@ -5,9 +5,9 @@ import com.apollographql.apollo.exception.ApolloException
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.externalintegration.FetchingServiceExternalIntegrationBase
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.GraphQLClientBuilder
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.peppi.oulu.PeppiOuluClientBuilderImpl
 import fi.elsapalvelu.elsa.service.integration.peppi.oulu.PeppiOuluOpintosuorituksetFetchingServiceImpl
 import fi.elsapalvelu.elsa.service.integration.peppi.oulu.PeppiOuluOpintotietodataFetchingServiceImpl

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/oulu/PeppiOuluExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/oulu/PeppiOuluExternalIntegrationTests.kt
@@ -8,9 +8,9 @@ import fi.elsapalvelu.elsa.repository.YliopistoRepository
 import fi.elsapalvelu.elsa.service.GraphQLClientBuilder
 import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
-import fi.elsapalvelu.elsa.service.impl.PeppiOuluClientBuilderImpl
-import fi.elsapalvelu.elsa.service.impl.PeppiOuluOpintosuorituksetFetchingServiceImpl
-import fi.elsapalvelu.elsa.service.impl.PeppiOuluOpintotietodataFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.oulu.PeppiOuluClientBuilderImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.oulu.PeppiOuluOpintosuorituksetFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.oulu.PeppiOuluOpintotietodataFetchingServiceImpl
 import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThatCode

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/turku/PeppiTurkuExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/turku/PeppiTurkuExternalIntegrationTests.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.externalintegration.FetchingServiceExternalIntegrationBase
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingServiceImpl
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingServiceImpl
 import fi.elsapalvelu.elsa.service.integration.peppi.turku.PeppiTurkuClientBuilderImpl

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/turku/PeppiTurkuExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/turku/PeppiTurkuExternalIntegrationTests.kt
@@ -6,11 +6,11 @@ import fi.elsapalvelu.elsa.externalintegration.FetchingServiceExternalIntegratio
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
 import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
-import fi.elsapalvelu.elsa.service.impl.PeppiCommonOpintosuorituksetFetchingServiceImpl
-import fi.elsapalvelu.elsa.service.impl.PeppiCommonOpintotietodataFetchingServiceImpl
-import fi.elsapalvelu.elsa.service.impl.PeppiTurkuClientBuilderImpl
-import fi.elsapalvelu.elsa.service.impl.PeppiTurkuOpintosuorituksetFetchingServiceImpl
-import fi.elsapalvelu.elsa.service.impl.PeppiTurkuOpintotietodataFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.turku.PeppiTurkuClientBuilderImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.turku.PeppiTurkuOpintosuorituksetFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.turku.PeppiTurkuOpintotietodataFetchingServiceImpl
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.SpringBootConfiguration

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/uef/PeppiUefExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/uef/PeppiUefExternalIntegrationTests.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.externalintegration.FetchingServiceExternalIntegrationBase
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingServiceImpl
 import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingServiceImpl
 import fi.elsapalvelu.elsa.service.integration.peppi.uef.PeppiUefClientBuilderImpl

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/uef/PeppiUefExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/uef/PeppiUefExternalIntegrationTests.kt
@@ -6,11 +6,11 @@ import fi.elsapalvelu.elsa.externalintegration.FetchingServiceExternalIntegratio
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
 import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
-import fi.elsapalvelu.elsa.service.impl.PeppiCommonOpintosuorituksetFetchingServiceImpl
-import fi.elsapalvelu.elsa.service.impl.PeppiCommonOpintotietodataFetchingServiceImpl
-import fi.elsapalvelu.elsa.service.impl.PeppiUefClientBuilderImpl
-import fi.elsapalvelu.elsa.service.impl.PeppiUefOpintosuorituksetFetchingServiceImpl
-import fi.elsapalvelu.elsa.service.impl.PeppiUefOpintotietodataFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.uef.PeppiUefClientBuilderImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.uef.PeppiUefOpintosuorituksetFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.peppi.uef.PeppiUefOpintotietodataFetchingServiceImpl
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.SpringBootConfiguration

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/sisu/hy/SisuHyExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/sisu/hy/SisuHyExternalIntegrationTests.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.externalintegration.FetchingServiceExternalIntegrationBase
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaFetchingService
 import fi.elsapalvelu.elsa.service.integration.sisu.helsinki.SisuHyClientBuilderImpl
 import fi.elsapalvelu.elsa.service.integration.sisu.helsinki.SisuHyOpintosuorituksetFetchingServiceImpl

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/sisu/hy/SisuHyExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/sisu/hy/SisuHyExternalIntegrationTests.kt
@@ -6,11 +6,11 @@ import fi.elsapalvelu.elsa.externalintegration.FetchingServiceExternalIntegratio
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
 import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
-import fi.elsapalvelu.elsa.service.SisuTutkintoohjelmaFetchingService
-import fi.elsapalvelu.elsa.service.impl.SisuHyClientBuilderImpl
-import fi.elsapalvelu.elsa.service.impl.SisuHyOpintosuorituksetFetchingServiceImpl
-import fi.elsapalvelu.elsa.service.impl.SisuHyOpintotietodataFetchingServiceImpl
-import fi.elsapalvelu.elsa.service.impl.SisuTutkintoohjelmaFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaFetchingService
+import fi.elsapalvelu.elsa.service.integration.sisu.helsinki.SisuHyClientBuilderImpl
+import fi.elsapalvelu.elsa.service.integration.sisu.helsinki.SisuHyOpintosuorituksetFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.sisu.helsinki.SisuHyOpintotietodataFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaFetchingServiceImpl
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/sisu/tre/SisuTreExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/sisu/tre/SisuTreExternalIntegrationTests.kt
@@ -5,15 +5,14 @@ import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.externalintegration.FetchingServiceExternalIntegrationBase
 import fi.elsapalvelu.elsa.repository.YliopistoRepository
 import fi.elsapalvelu.elsa.service.AuthenticationTokenService
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.impl.AuthenticationTokenClientBuilderImpl
 import fi.elsapalvelu.elsa.service.integration.sisu.tampere.SisuTreAuthenticationTokenServiceImpl
 import fi.elsapalvelu.elsa.service.integration.sisu.tampere.SisuTreClientBuilderImpl
 import fi.elsapalvelu.elsa.service.integration.sisu.tampere.SisuTreOpintosuorituksetFetchingServiceImpl
 import fi.elsapalvelu.elsa.service.integration.sisu.tampere.SisuTreOpintotietodataFetchingServiceImpl
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/sisu/tre/SisuTreExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/sisu/tre/SisuTreExternalIntegrationTests.kt
@@ -8,10 +8,10 @@ import fi.elsapalvelu.elsa.service.AuthenticationTokenService
 import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.impl.AuthenticationTokenClientBuilderImpl
-import fi.elsapalvelu.elsa.service.impl.SisuTreAuthenticationTokenServiceImpl
-import fi.elsapalvelu.elsa.service.impl.SisuTreClientBuilderImpl
-import fi.elsapalvelu.elsa.service.impl.SisuTreOpintosuorituksetFetchingServiceImpl
-import fi.elsapalvelu.elsa.service.impl.SisuTreOpintotietodataFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.sisu.tampere.SisuTreAuthenticationTokenServiceImpl
+import fi.elsapalvelu.elsa.service.integration.sisu.tampere.SisuTreClientBuilderImpl
+import fi.elsapalvelu.elsa.service.integration.sisu.tampere.SisuTreOpintosuorituksetFetchingServiceImpl
+import fi.elsapalvelu.elsa.service.integration.sisu.tampere.SisuTreOpintotietodataFetchingServiceImpl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/fi/elsapalvelu/elsa/scheduler/ScheduledOpintotietoImportTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/scheduler/ScheduledOpintotietoImportTest.kt
@@ -15,9 +15,9 @@ import fi.elsapalvelu.elsa.domain.Yliopisto
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.OpintooikeusRepository
 import fi.elsapalvelu.elsa.scheduler.jobs.ScheduledOpintotietoImport
-import fi.elsapalvelu.elsa.service.OpintosuorituksetFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.OpintosuorituksetPersistenceService
-import fi.elsapalvelu.elsa.service.OpintotietodataFetchingService
+import fi.elsapalvelu.elsa.service.integration.OpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.OpintotietodataPersistenceService
 import fi.elsapalvelu.elsa.service.dto.OpintosuorituksetPersistenceDTO
 import fi.elsapalvelu.elsa.service.dto.OpintotietodataDTO

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/SisuTutkintoohjelmaImportServiceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/SisuTutkintoohjelmaImportServiceIT.kt
@@ -4,9 +4,10 @@ import fi.elsapalvelu.elsa.ElsaBackendApp
 import fi.elsapalvelu.elsa.domain.Erikoisala
 import fi.elsapalvelu.elsa.domain.ErikoisalaSisuTutkintoohjelma
 import fi.elsapalvelu.elsa.repository.ErikoisalaRepository
-import fi.elsapalvelu.elsa.service.impl.Entity
-import fi.elsapalvelu.elsa.service.impl.Qualifications
-import fi.elsapalvelu.elsa.service.impl.Requirement
+import fi.elsapalvelu.elsa.service.integration.sisu.Entity
+import fi.elsapalvelu.elsa.service.integration.sisu.Qualifications
+import fi.elsapalvelu.elsa.service.integration.sisu.Requirement
+import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaImportService
 import fi.elsapalvelu.elsa.web.rest.helpers.ErikoisalaHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiAlertTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiAlertTest.kt
@@ -8,6 +8,9 @@ import com.nhaarman.mockitokotlin2.whenever
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.service.AlertPublisherService
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiServiceImpl
+import fi.elsapalvelu.elsa.service.arkistointi.HelsinkiSiiloService
+import fi.elsapalvelu.elsa.service.arkistointi.TampereLouhiService
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
 import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
@@ -15,6 +15,9 @@ import fi.elsapalvelu.elsa.domain.User
 import fi.elsapalvelu.elsa.domain.Yliopisto
 import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.service.AlertPublisherService
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiServiceImpl
+import fi.elsapalvelu.elsa.service.arkistointi.HelsinkiSiiloService
+import fi.elsapalvelu.elsa.service.arkistointi.TampereLouhiService
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/ValmistumispyyntoHyvaksyntaArkistointiIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/ValmistumispyyntoHyvaksyntaArkistointiIT.kt
@@ -17,9 +17,9 @@ import fi.elsapalvelu.elsa.repository.ValmistumispyyntoRepository
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI
 import fi.elsapalvelu.elsa.security.OPINTOHALLINNON_VIRKAILIJA
 import fi.elsapalvelu.elsa.security.VASTUUHENKILO
-import fi.elsapalvelu.elsa.service.ArkistointiService
 import fi.elsapalvelu.elsa.service.MailService
 import fi.elsapalvelu.elsa.service.PdfService
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiService
 import fi.elsapalvelu.elsa.service.dto.ValmistumispyyntoHyvaksyntaFormDTO
 import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
 import fi.elsapalvelu.elsa.web.rest.convertObjectToJsonBytes


### PR DESCRIPTION
This pull request introduces significant refactoring and reorganization of the service layer, especially around integration and archiving services. It moves several service interfaces and implementations into more appropriate packages, introduces new abstract integration service classes, and cleans up related imports. Additionally, it removes legacy files and updates configuration and logging for improved maintainability.

**Service Layer Refactoring and Reorganization:**

* Moved `SisuTutkintoohjelmaFetchingService` and `SisuTutkintoohjelmaImportService` interfaces and their usages from the generic `service` package to `service.integration.sisu`, and removed the old interface files. This clarifies their role as integration services. [[1]](diffhunk://#diff-14313797492d8d7e9342d6570c1130486a354cef2d30dbd276cbdab81e688994L5-R6) [[2]](diffhunk://#diff-406cceee8f589f29af8dabefdb8cc9071a81dd9eda8ff56bbdd7536659ce6cb1L4-R5) [[3]](diffhunk://#diff-9fb1674a57b933de430dba74ea523416704eaef68c0366c0bc69e6afc4b2ead4L1-L7) [[4]](diffhunk://#diff-6ab93174f5d46f6b4baf4e4a9b3d1cb85d701bb7bc43162440abbb0fcd4ed3c5L1-L7)
* Introduced new abstract classes `AbstractOpintosuorituksetFetchingService` and `AbstractOpintotietodataFetchingService` in `service.integration` to provide shared logic for fetching operations based on university configuration. [[1]](diffhunk://#diff-d78262b04f2d113badcbe8007e1b8e5482e3f0d9405bb988a0c5477fe9983fbdR1-R16) [[2]](diffhunk://#diff-296ccbafb3dff7edc9d524c347405041e932bb0545fb24d6b3bb122c45173461R1-R16)
* Moved `GraphQLClientBuilder` and `OkHttpClientBuilder` to the `service.integration` package, updating all relevant imports. [[1]](diffhunk://#diff-262854b7d926944aa3ec7d0790d1fe8892348e1b594c77681e9001fb89963852L1-R1) [[2]](diffhunk://#diff-49b45a3d18d0b04a9fe603052701535c17616b6e562ff887cfa01b4b5e5784b1L3-R3) [[3]](diffhunk://#diff-19835b16131875979bb6ff061c388d3dbf9aa80fc6c976d18ea02cd5388d7e08R12-R13) [[4]](diffhunk://#diff-0b71cd63d00b8b6347e0216b1e9bb8628694d3db8df5cdb448cf978b6ed378a0R20-R21)
* Added a new `LocalizedString` data class to `service.integration` for handling localized text.

**Archiving Service Renaming and Organization:**

* Renamed and moved `ArkistointiService`, `ArkistointiServiceImpl`, `HelsinkiSiiloService`, and `TampereLouhiService` from generic or `impl` packages to the new `service.arkistointi` package, and updated all usages and imports accordingly. [[1]](diffhunk://#diff-ea0fe84766478ef4ab7ce927c07ef361fab392b17c74c41e5efe33cc7c3da56dL1-R1) [[2]](diffhunk://#diff-0e7858052fd90ca86550c4768e8048b19db3979706dea4c1f1e6181a31243302L1-R1) [[3]](diffhunk://#diff-0e7858052fd90ca86550c4768e8048b19db3979706dea4c1f1e6181a31243302L10-R27) [[4]](diffhunk://#diff-99f3106d5ff4cb9f6bbcc4c42348c4e1eeb6a6bfe9cbb7cecbd2904b084784acL1-R1) [[5]](diffhunk://#diff-3a1ffb65c7538417de33b82121baa7ded1077fbce1b6c4874b0a8eb655ca13abL1-R1) [[6]](diffhunk://#diff-2eb96137f294ad87cd55505a520fe5940f972d0d34a70e5ae9d2b76332ae1afeR11) [[7]](diffhunk://#diff-26999f2b0721f741c8458eeb01f04d19f9f288104e38fa252007ac0ae5f33350L7-R9) [[8]](diffhunk://#diff-823cf0f6dd904633d1a1f64767a6319b44e8fae4eab669b4e701ceb9392569f5R11) [[9]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86R22)

**Configuration and Logging Improvements:**

* Enhanced application startup logging to include Java and Kotlin versions for better traceability.

**Cleanup and Removal:**

* Removed the obsolete SonarQube docker configuration file.

These changes help clarify the project structure, improve maintainability, and set the foundation for future integration work.