### PR TITLE
enhance error logging for archiving failures with detailed HTTP response information

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiService.kt
@@ -21,7 +21,14 @@ interface ArkistointiService {
         caseType: CaseType = CaseType.VALMISTUMINEN
     ): ArkistointiResult
 
-    fun laheta(yliopisto: YliopistoEnum, filePath: String, caseType: CaseType, yek: Boolean)
+    fun laheta(
+        yliopisto: YliopistoEnum,
+        filePath: String,
+        caseType: CaseType,
+        yek: Boolean,
+        caseId: String? = null,
+        erikoistujanNimi: String? = null
+    )
 
     fun onKaytossa(yliopisto: YliopistoEnum, caseType: CaseType): Boolean
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
@@ -244,9 +244,11 @@ class ArkistointiServiceImpl(
                     try {
                         tampereLouhiService.laheta(filePath, yek)
                     } catch (e: Exception) {
+                        val sftpHost = applicationProperties.getArkistointi().getTre().host ?: "tuntematon"
                         alertPublisherService.publishAlert(
                             subject = "Tampere arkistointi epäonnistui",
                             message = "Arkistointitiedoston lähetys Louhi SFTP-palvelimelle epäonnistui. " +
+                                "SFTP-palvelin: $sftpHost. " +
                                 "Tiedosto: $filePath, CaseType: ${caseType.value}. Virhe: ${e.message}"
                         )
                         arkistointiMetrics.recordError(yliopisto, caseType)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
@@ -235,7 +235,9 @@ class ArkistointiServiceImpl(
         yliopisto: YliopistoEnum,
         filePath: String,
         caseType: CaseType,
-        yek: Boolean
+        yek: Boolean,
+        caseId: String?,
+        erikoistujanNimi: String?
     ) {
         arkistointiMetrics.activeArkistointiOperations.incrementAndGet()
         try {
@@ -247,9 +249,15 @@ class ArkistointiServiceImpl(
                         val sftpHost = applicationProperties.getArkistointi().getTre().host ?: "tuntematon"
                         alertPublisherService.publishAlert(
                             subject = "Tampere arkistointi epäonnistui",
-                            message = "Arkistointitiedoston lähetys Louhi SFTP-palvelimelle epäonnistui. " +
-                                "SFTP-palvelin: $sftpHost. " +
-                                "Tiedosto: $filePath, CaseType: ${caseType.value}. Virhe: ${e.message}"
+                            message = buildAlertMessage(
+                                intro = "Arkistointitiedoston lähetys Louhi SFTP-palvelimelle epäonnistui.",
+                                extra = "SFTP-palvelin: $sftpHost.",
+                                filePath = filePath,
+                                caseType = caseType,
+                                caseId = caseId,
+                                erikoistujanNimi = erikoistujanNimi,
+                                error = e.message
+                            )
                         )
                         arkistointiMetrics.recordError(yliopisto, caseType)
                         throw e
@@ -262,8 +270,15 @@ class ArkistointiServiceImpl(
                     } catch (e: Exception) {
                         alertPublisherService.publishAlert(
                             subject = "Helsinki arkistointi epäonnistui",
-                            message = "Arkistointitiedoston lähetys HY Siilo-palveluun epäonnistui. " +
-                                "Tiedosto: $filePath, CaseType: ${caseType.value}. Virhe: ${e.message}"
+                            message = buildAlertMessage(
+                                intro = "Arkistointitiedoston lähetys HY Siilo-palveluun epäonnistui.",
+                                extra = null,
+                                filePath = filePath,
+                                caseType = caseType,
+                                caseId = caseId,
+                                erikoistujanNimi = erikoistujanNimi,
+                                error = e.message
+                            )
                         )
                         arkistointiMetrics.recordError(yliopisto, caseType)
                         throw e
@@ -307,5 +322,23 @@ class ArkistointiServiceImpl(
 
         val metadataProperties = getMetadataForYliopisto(yliopisto)
         return metadataProperties?.getCaseMetadata(caseType) != null
+    }
+
+    private fun buildAlertMessage(
+        intro: String,
+        extra: String?,
+        filePath: String,
+        caseType: CaseType,
+        caseId: String?,
+        erikoistujanNimi: String?,
+        error: String?
+    ): String = buildString {
+        append(intro)
+        if (extra != null) append(" $extra")
+        append(" CaseType: ${caseType.value}")
+        if (caseId != null) append(", Id: $caseId")
+        if (erikoistujanNimi != null) append(". Erikoistuva lääkäri: $erikoistujanNimi")
+        append(". Tiedosto: $filePath")
+        append(". Virhe: $error")
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/HelsinkiSiiloService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/HelsinkiSiiloService.kt
@@ -56,7 +56,10 @@ class HelsinkiSiiloService(
             okHttpClient.newCall(request).execute().use { response ->
                 val responseBody = response.body?.string()
                 if (!response.isSuccessful) {
-                    throw RuntimeException("HY arkistointi epäonnistui: ${response.code} - $responseBody")
+                    throw RuntimeException(
+                        "HY arkistointi epäonnistui: HTTP ${response.code} ${response.message}, " +
+                            "URL: $url. Palvelimen vastaus: ${responseBody?.take(500) ?: "(tyhjä)"}"
+                    )
                 }
                 log.info("HY arkistointivastaus: ${response.code} $responseBody")
             }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonKoulutussopimusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonKoulutussopimusServiceImpl.kt
@@ -193,8 +193,16 @@ class KoejaksonKoulutussopimusServiceImpl(
 
         val erikoisala = opintooikeus?.erikoisala!!
         val yek = erikoisala.id == YEK_ERIKOISALA_ID
+        val erikoistujanNimi = opintooikeus?.erikoistuvaLaakari?.kayttaja?.user?.getName()
         logger.info("Lahetetaan arkistopyynto: ${result.zipFilePath}")
-        arkistointiService.laheta(yliopisto, result.zipFilePath, CaseType.SOPIMUS, yek)
+        arkistointiService.laheta(
+            yliopisto = yliopisto,
+            filePath = result.zipFilePath,
+            caseType = CaseType.SOPIMUS,
+            yek = yek,
+            caseId = koulutussopimus.id!!.toString(),
+            erikoistujanNimi = erikoistujanNimi
+        )
         logger.info("Lahetettiin arkistopyynto")
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonVastuuhenkilonArvioServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/KoejaksonVastuuhenkilonArvioServiceImpl.kt
@@ -367,7 +367,15 @@ class KoejaksonVastuuhenkilonArvioServiceImpl(
                 caseType = CaseType.KOEJAKSO
             )
             val yek = erikoisala.id == YEK_ERIKOISALA_ID
-            arkistointiService.laheta(yliopisto, result.zipFilePath, CaseType.KOEJAKSO, yek)
+            val erikoistujanNimi = vastuuhenkilonArvio.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user?.getName()
+            arkistointiService.laheta(
+                yliopisto = yliopisto,
+                filePath = result.zipFilePath,
+                caseType = CaseType.KOEJAKSO,
+                yek = yek,
+                caseId = vastuuhenkilonArvio.id!!.toString(),
+                erikoistujanNimi = erikoistujanNimi
+            )
         }
 
     }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/ValmistumispyyntoServiceImpl.kt
@@ -367,7 +367,15 @@ class ValmistumispyyntoServiceImpl(
         )
         val erikoisala = valmistumispyynto.opintooikeus?.erikoisala!!
         val yek = erikoisala.id == YEK_ERIKOISALA_ID
-        arkistointiService.laheta(nimi!!, result.zipFilePath, CaseType.VALMISTUMINEN, yek)
+        val erikoistujanNimi = valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user?.getName()
+        arkistointiService.laheta(
+            yliopisto = nimi!!,
+            filePath = result.zipFilePath,
+            caseType = CaseType.VALMISTUMINEN,
+            yek = yek,
+            caseId = id.toString(),
+            erikoistujanNimi = erikoistujanNimi
+        )
         log.info("Sahke muodostettu ja lahetetty [valmistumispyyntoId=$id, yek=$yek]")
     }
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiAlertTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiAlertTest.kt
@@ -71,7 +71,9 @@ class ArkistointiAlertTest {
                 yliopisto = YliopistoEnum.HELSINGIN_YLIOPISTO,
                 filePath = "/tmp/test.zip",
                 caseType = CaseType.VALMISTUMINEN,
-                yek = false
+                yek = false,
+                caseId = "42",
+                erikoistujanNimi = "Matti Meikäläinen"
             )
         }
 
@@ -81,12 +83,15 @@ class ArkistointiAlertTest {
 
         assertThat(subjectCaptor.firstValue).contains("Helsinki")
         assertThat(messageCaptor.firstValue).contains("HY Siilo connection refused")
+        assertThat(messageCaptor.firstValue).contains("Id: 42")
+        assertThat(messageCaptor.firstValue).contains("Matti Meikäläinen")
     }
 
     @Test
     fun `alert is published when Helsinki archiving fails with non-200 response`() {
         whenever(helsinkiSiiloService.laheta(any(), any()))
-            .thenThrow(RuntimeException("HY arkistointi epäonnistui: HTTP 503 Service Unavailable, URL: http://esb-api.it.helsinki.fi/unisign/elsa/archive/abc123. Palvelimen vastaus: (tyhjä)"))
+            .thenThrow(RuntimeException("HY arkistointi epäonnistui: HTTP 503 Service Unavailable, " +
+                "URL: http://esb-api.it.helsinki.fi/unisign/elsa/archive/abc123. Palvelimen vastaus: (tyhjä)"))
 
         assertThrows(RuntimeException::class.java) {
             arkistointiService.laheta(
@@ -134,7 +139,9 @@ class ArkistointiAlertTest {
                 yliopisto = YliopistoEnum.TAMPEREEN_YLIOPISTO,
                 filePath = "/tmp/tre.zip",
                 caseType = CaseType.VALMISTUMINEN,
-                yek = false
+                yek = false,
+                caseId = "17",
+                erikoistujanNimi = "Aino Aaltonen"
             )
         }
 
@@ -145,6 +152,8 @@ class ArkistointiAlertTest {
         assertThat(subjectCaptor.firstValue).contains("Tampere")
         assertThat(messageCaptor.firstValue).contains("SFTP connection timed out")
         assertThat(messageCaptor.firstValue).contains("localhost") // SFTP host must be in the alert
+        assertThat(messageCaptor.firstValue).contains("Id: 17")
+        assertThat(messageCaptor.firstValue).contains("Aino Aaltonen")
     }
 
     @Test

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiAlertTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiAlertTest.kt
@@ -86,7 +86,7 @@ class ArkistointiAlertTest {
     @Test
     fun `alert is published when Helsinki archiving fails with non-200 response`() {
         whenever(helsinkiSiiloService.laheta(any(), any()))
-            .thenThrow(RuntimeException("HY arkistointi epäonnistui: 503 - Service Unavailable"))
+            .thenThrow(RuntimeException("HY arkistointi epäonnistui: HTTP 503 Service Unavailable, URL: http://esb-api.it.helsinki.fi/unisign/elsa/archive/abc123. Palvelimen vastaus: (tyhjä)"))
 
         assertThrows(RuntimeException::class.java) {
             arkistointiService.laheta(
@@ -97,7 +97,13 @@ class ArkistointiAlertTest {
             )
         }
 
-        verify(alertPublisherService).publishAlert(any(), any())
+        val subjectCaptor = argumentCaptor<String>()
+        val messageCaptor = argumentCaptor<String>()
+        verify(alertPublisherService).publishAlert(subjectCaptor.capture(), messageCaptor.capture())
+
+        assertThat(subjectCaptor.firstValue).contains("Helsinki")
+        assertThat(messageCaptor.firstValue).contains("HTTP 503")
+        assertThat(messageCaptor.firstValue).contains("URL: http://esb-api.it.helsinki.fi")
     }
 
     @Test
@@ -138,6 +144,7 @@ class ArkistointiAlertTest {
 
         assertThat(subjectCaptor.firstValue).contains("Tampere")
         assertThat(messageCaptor.firstValue).contains("SFTP connection timed out")
+        assertThat(messageCaptor.firstValue).contains("localhost") // SFTP host must be in the alert
     }
 
     @Test


### PR DESCRIPTION
This pull request enhances the archiving error alerting system by including more detailed context in alert messages, such as case IDs and the name of the specialist doctor involved. It also improves error reporting for Helsinki archiving failures and updates tests to verify the new alert message content. The main changes are grouped below.

**Error alert improvements:**

* The `ArkistointiService.laheta` method now accepts optional `caseId` and `erikoistujanNimi` parameters, which are included in alert messages when archiving fails. This provides more context for troubleshooting. [[1]](diffhunk://#diff-ea0fe84766478ef4ab7ce927c07ef361fab392b17c74c41e5efe33cc7c3da56dL24-R31) [[2]](diffhunk://#diff-0e7858052fd90ca86550c4768e8048b19db3979706dea4c1f1e6181a31243302L238-R240) [[3]](diffhunk://#diff-2eb96137f294ad87cd55505a520fe5940f972d0d34a70e5ae9d2b76332ae1afeR196-R205) [[4]](diffhunk://#diff-823cf0f6dd904633d1a1f64767a6319b44e8fae4eab669b4e701ceb9392569f5L370-R378) [[5]](diffhunk://#diff-9ec3fc470f26fc99c75093645353740256678af57bcefd8a40b742b763833a86L370-R378) [[6]](diffhunk://#diff-e62c67df843de949fe39fac67cce3f881cd3a4264d91882e558155d7631362b7L74-R76) [[7]](diffhunk://#diff-e62c67df843de949fe39fac67cce3f881cd3a4264d91882e558155d7631362b7L131-R144)
* Alert messages for both Tampere and Helsinki archiving failures are now constructed using a new `buildAlertMessage` helper, ensuring consistent formatting and inclusion of relevant details like SFTP host, case ID, and specialist name. [[1]](diffhunk://#diff-0e7858052fd90ca86550c4768e8048b19db3979706dea4c1f1e6181a31243302R249-R260) [[2]](diffhunk://#diff-0e7858052fd90ca86550c4768e8048b19db3979706dea4c1f1e6181a31243302L263-R281) [[3]](diffhunk://#diff-0e7858052fd90ca86550c4768e8048b19db3979706dea4c1f1e6181a31243302R326-R343)

**Archiving error reporting:**

* Helsinki archiving errors now include the HTTP status code, message, request URL, and a truncated server response in the thrown exception, making issues easier to diagnose.

**Test updates:**

* Unit tests for alert publishing have been updated to verify that alert messages now include the case ID, specialist name, and, for Tampere, the SFTP host. Tests also check for the improved error message details for Helsinki archiving failures. [[1]](diffhunk://#diff-e62c67df843de949fe39fac67cce3f881cd3a4264d91882e558155d7631362b7R86-R94) [[2]](diffhunk://#diff-e62c67df843de949fe39fac67cce3f881cd3a4264d91882e558155d7631362b7L100-R111) [[3]](diffhunk://#diff-e62c67df843de949fe39fac67cce3f881cd3a4264d91882e558155d7631362b7R154-R156)