### PR TITLE
change error logging to warning for incorrect login name and remove alert publishing

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -3,6 +3,10 @@ style:
     maxLineLength: 180
   UnusedVariable:
     active: true
+  UnusedPrivateProperty:
+    active: true
+  UnusedPrivateFunction:
+    active: true
   VarCouldBeVal:
     ignoreLateinitVar: true
   WildcardImport:

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/UserServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/UserServiceImpl.kt
@@ -5,7 +5,6 @@ import fi.elsapalvelu.elsa.config.LoginException
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.enumeration.KayttajatilinTila
 import fi.elsapalvelu.elsa.repository.*
-import fi.elsapalvelu.elsa.service.AlertPublisherService
 import fi.elsapalvelu.elsa.service.UserService
 import fi.elsapalvelu.elsa.service.constants.KAYTTAJA_NOT_FOUND_ERROR
 import fi.elsapalvelu.elsa.service.dto.OmatTiedotDTO
@@ -47,8 +46,7 @@ class UserServiceImpl(
     private val koejaksonKehittamistoimenpiteetRepository: KoejaksonKehittamistoimenpiteetRepository,
     private val koejaksonLoppukeskusteluRepository: KoejaksonLoppukeskusteluRepository,
     private val seurantajaksoRepository: SeurantajaksoRepository,
-    private val entityManager: EntityManager,
-    private val alertPublisherService: AlertPublisherService
+    private val entityManager: EntityManager
 ) : UserService {
 
     private val log = LoggerFactory.getLogger(javaClass)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/UserServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/UserServiceImpl.kt
@@ -315,14 +315,8 @@ class UserServiceImpl(
         if ((firstNameDistFirst > treshhold && firstNameDistLast > treshhold)
             || (lastNameDistFirst > treshhold && lastNameDistLast > treshhold)
         ) {
-            log.error(
+            log.warn(
                 "Kirjautuminen epäonnistui käyttäjälle $firstName $lastName (eppn $eppn). " +
-                    "Kutsussa annettu nimi ${tokenUser.firstName} ${tokenUser.lastName} ei ole " +
-                    "tarpeeksi lähellä käyttäjän nimeä."
-            )
-            alertPublisherService.publishAlert(
-                subject = "Kirjautuminen epäonnistui: virheellinen nimi",
-                message = "Kirjautuminen epäonnistui käyttäjälle $firstName $lastName (eppn $eppn). " +
                     "Kutsussa annettu nimi ${tokenUser.firstName} ${tokenUser.lastName} ei ole " +
                     "tarpeeksi lähellä käyttäjän nimeä."
             )

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ValidateNameAlertTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ValidateNameAlertTest.kt
@@ -1,15 +1,9 @@
 package fi.elsapalvelu.elsa.service.impl
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
 import fi.elsapalvelu.elsa.domain.User
 import fi.elsapalvelu.elsa.domain.VerificationToken
 import fi.elsapalvelu.elsa.repository.*
-import fi.elsapalvelu.elsa.service.AlertPublisherService
 import jakarta.persistence.EntityManager
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -35,7 +29,6 @@ class ValidateNameAlertTest {
     @Mock private lateinit var koejaksonLoppukeskusteluRepository: KoejaksonLoppukeskusteluRepository
     @Mock private lateinit var seurantajaksoRepository: SeurantajaksoRepository
     @Mock private lateinit var entityManager: EntityManager
-    @Mock private lateinit var alertPublisherService: AlertPublisherService
 
     private lateinit var userService: UserServiceImpl
     private lateinit var cipher: Cipher
@@ -56,61 +49,23 @@ class ValidateNameAlertTest {
             koejaksonKehittamistoimenpiteetRepository = koejaksonKehittamistoimenpiteetRepository,
             koejaksonLoppukeskusteluRepository = koejaksonLoppukeskusteluRepository,
             seurantajaksoRepository = seurantajaksoRepository,
-            entityManager = entityManager,
-            alertPublisherService = alertPublisherService
+            entityManager = entityManager
         )
 
         cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
-
         token = VerificationToken()
     }
 
     // -------------------------------------------------------------------------
-    // Name mismatch → alert expected
+    // Name mismatch → exception expected
     // -------------------------------------------------------------------------
 
     @Test
-    fun `alert is published when token user name is too different from login name`() {
+    fun `exception is thrown when token user name is too different from login name`() {
         val tokenUser = User().apply {
             id = "user-1"
             firstName = "Matti"
             lastName = "Virtanen"
-        }
-
-        // "Completely Different" is far from "Matti Virtanen" → validation should fail
-        assertThrows(Exception::class.java) {
-            userService.createOrUpdateUserWithToken(
-                tokenUser = tokenUser,
-                token = token,
-                cipher = cipher,
-                originalKey = cipher.parameters?.let { null } ?: run {
-                    val kg = KeyGenerator.getInstance("AES")
-                    kg.init(128)
-                    kg.generateKey()
-                }!!,
-                hetu = null,
-                eppn = "matti.virtanen@test.fi",
-                firstName = "Completely",
-                lastName = "Different"
-            )
-        }
-
-        val subjectCaptor = argumentCaptor<String>()
-        val messageCaptor = argumentCaptor<String>()
-        verify(alertPublisherService).publishAlert(subjectCaptor.capture(), messageCaptor.capture())
-
-        assertThat(subjectCaptor.firstValue).contains("virheellinen nimi")
-        assertThat(messageCaptor.firstValue).contains("Completely")
-        assertThat(messageCaptor.firstValue).contains("Different")
-        assertThat(messageCaptor.firstValue).contains("matti.virtanen@test.fi")
-    }
-
-    @Test
-    fun `alert message contains token user name`() {
-        val tokenUser = User().apply {
-            id = "user-2"
-            firstName = "Pekka"
-            lastName = "Korhonen"
         }
 
         assertThrows(Exception::class.java) {
@@ -124,25 +79,19 @@ class ValidateNameAlertTest {
                     kg.generateKey()
                 },
                 hetu = null,
-                eppn = "pekka.korhonen@test.fi",
-                firstName = "Xyz",
-                lastName = "Abc"
+                eppn = "matti.virtanen@test.fi",
+                firstName = "Completely",
+                lastName = "Different"
             )
         }
-
-        val messageCaptor = argumentCaptor<String>()
-        verify(alertPublisherService).publishAlert(any(), messageCaptor.capture())
-
-        assertThat(messageCaptor.firstValue).contains("Pekka")
-        assertThat(messageCaptor.firstValue).contains("Korhonen")
     }
 
     // -------------------------------------------------------------------------
-    // Name close enough → no alert expected
+    // Name close enough → no exception from name validation
     // -------------------------------------------------------------------------
 
     @Test
-    fun `no alert is published when token user name is close enough to login name`() {
+    fun `no exception from name validation when token user name is close enough to login name`() {
         val secretKey = run {
             val kg = KeyGenerator.getInstance("AES")
             kg.init(128)
@@ -156,10 +105,10 @@ class ValidateNameAlertTest {
             lastName = "Virtanen"
         }
 
-        // Names match closely (Levenshtein distance ≤ 2) – validation passes
-        // but further processing will throw because kayttajaRepository is a mock
-        // returning empty; we only care that no alert was published.
-        try {
+        // Names match closely (Levenshtein distance ≤ 2) – name validation passes;
+        // further processing will throw because repos are mocked with default no-op behaviour,
+        // but that is unrelated to name validation.
+        val ex = runCatching {
             userService.createOrUpdateUserWithToken(
                 tokenUser = tokenUser,
                 token = token,
@@ -170,11 +119,13 @@ class ValidateNameAlertTest {
                 firstName = "Matti",
                 lastName = "Virtanen"
             )
-        } catch (_: Exception) {
-            // expected – repos are mocked with default no-op / empty behaviour
-        }
+        }.exceptionOrNull()
 
-        verify(alertPublisherService, never()).publishAlert(any(), any())
+        // If an exception was thrown it must NOT be the VIRHEELLINEN_NIMI login error
+        if (ex != null) {
+            assert(ex.message != fi.elsapalvelu.elsa.config.LoginException.VIRHEELLINEN_NIMI.name) {
+                "Name validation should not fail for matching names, but got: ${ex.message}"
+            }
+        }
     }
 }
-


### PR DESCRIPTION
This pull request removes the alert publishing functionality when a user's login fails due to a name mismatch, both in the main service implementation and in the related tests. Now, instead of sending alerts, the system only logs a warning and throws an exception. The test suite has been updated to reflect this change, focusing on exception handling rather than alert publication. Additionally, some new static analysis rules are enabled.

Main service changes:

* Removed the dependency on `AlertPublisherService` from `UserServiceImpl` and stopped publishing alerts on name mismatch; now only a warning is logged and an exception is thrown. [[1]](diffhunk://#diff-b64aea11f02bdee24e552cc314652804b9d1a481ea78f648d948d3862858aa09L8) [[2]](diffhunk://#diff-b64aea11f02bdee24e552cc314652804b9d1a481ea78f648d948d3862858aa09L50-R49) [[3]](diffhunk://#diff-b64aea11f02bdee24e552cc314652804b9d1a481ea78f648d948d3862858aa09L318-L328)

Test suite updates:

* Refactored `ValidateNameAlertTest` to remove all references to `AlertPublisherService`, deleted alert-related assertions, and updated test descriptions and logic to focus on exception handling for name mismatches. [[1]](diffhunk://#diff-0c9362c5018075e41915929542eee2379af0bebcd6c353bfb3239740cccb2d96L3-L12) [[2]](diffhunk://#diff-0c9362c5018075e41915929542eee2379af0bebcd6c353bfb3239740cccb2d96L38) [[3]](diffhunk://#diff-0c9362c5018075e41915929542eee2379af0bebcd6c353bfb3239740cccb2d96L59-R94) [[4]](diffhunk://#diff-0c9362c5018075e41915929542eee2379af0bebcd6c353bfb3239740cccb2d96L159-R111) [[5]](diffhunk://#diff-0c9362c5018075e41915929542eee2379af0bebcd6c353bfb3239740cccb2d96L173-L180)

Static analysis configuration:

* Enabled `UnusedPrivateProperty` and `UnusedPrivateFunction` rules in `detekt-config.yml` to catch unused private code.
