### PR TITLE
bump spring boot and spring security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,10 @@ repositories {
 }
 
 dependencies {
+    constraints {
+        implementation("org.bouncycastle:bcprov-jdk18on:1.84")
+    }
+
     implementation "tech.jhipster:jhipster-framework:${jhipsterDependenciesVersion}"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-hibernate5-jakarta"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ profile=dev
 jhipsterDependenciesVersion=8.8.0
 # The spring-boot version should match the one managed by
 # https://mvnrepository.com/artifact/tech.jhipster/jhipster-dependencies/7.3.1
-springBootVersion=3.5.15
-springSecurityVersion=6.5.10
+springBootVersion=3.5.16
+springSecurityVersion=6.5.11
 # The hibernate version should match the one managed by
 # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/2.5.5
 hibernateVersion=6.6.4.Final

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/oulu/PeppiOuluExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/peppi/oulu/PeppiOuluExternalIntegrationTests.kt
@@ -44,7 +44,7 @@ class PeppiOuluExternalIntegrationTests : FetchingServiceExternalIntegrationBase
     override val opintosuorituksetService: OpintosuorituksetFetchingService
         get() = peppiOuluOpintosuorituksetFetchingServiceImpl
 
-    override fun getTestHetu() = "010190-982B"
+    override fun getTestHetu() = "260863-997M"
 
     @Test
     fun shouldBuildApolloClientWithoutRuntimeLinkageErrors() {


### PR DESCRIPTION
This pull request includes dependency version updates and a test data change. The most important changes are:

**Dependency Updates:**
* Updated `springBootVersion` from `3.5.15` to `3.5.16` in `gradle.properties` to ensure the project uses the latest Spring Boot patch release.
* Updated `springSecurityVersion` from `6.5.10` to `6.5.11` in `gradle.properties` to incorporate the latest security fixes.

**Test Data Update:**
* Changed the test personal identity code returned by `getTestHetu()` in `PeppiOuluExternalIntegrationTests.kt` from `"010190-982B"` to `"260863-997M"` for improved or updated test coverage.