### PR TITLE
More e2e tests

### DIFF
--- a/e2e/cypress/e2e/asiakirjat/asiakirjat.cy.ts
+++ b/e2e/cypress/e2e/asiakirjat/asiakirjat.cy.ts
@@ -1,0 +1,33 @@
+import { E2E_ERIKOISTUVA_EMAIL } from '../../support/commands'
+
+export {}
+
+describe('Asiakirjat', () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions()
+    cy.task('db:cleanupErikoistuva', { email: E2E_ERIKOISTUVA_EMAIL })
+    cy.loginAsErikoistuva()
+  })
+
+  it('Erikoistuja lisää ja poistaa asiakirjan', () => {
+    cy.visit('/asiakirjat')
+    cy.contains('h1', 'Asiakirjat').should('be.visible')
+
+    cy.intercept('POST', '**/erikoistuva-laakari/asiakirjat').as('asiakirjaPost')
+    cy.get('input[type="file"]').selectFile('cypress/fixtures/test.pdf', { force: true })
+
+    cy.wait('@asiakirjaPost', { timeout: 30000 }).then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body?.[0]?.nimi).to.eq('test.pdf')
+    })
+
+    cy.contains('.asiakirjat-table', 'test.pdf').should('be.visible')
+
+    cy.intercept('DELETE', '**/erikoistuva-laakari/asiakirjat/*').as('asiakirjaDelete')
+    cy.contains('tr', 'test.pdf').find('button').last().click({ force: true })
+    cy.get('.modal-content').contains('button', 'Poista').click()
+
+    cy.wait('@asiakirjaDelete', { timeout: 15000 }).its('response.statusCode').should('eq', 204)
+    cy.contains('.asiakirjat-table', 'test.pdf').should('not.exist')
+  })
+})

--- a/e2e/cypress/e2e/paivittaiset-merkinnat/paivittainen-merkinta.cy.ts
+++ b/e2e/cypress/e2e/paivittaiset-merkinnat/paivittainen-merkinta.cy.ts
@@ -1,0 +1,58 @@
+import { E2E_ERIKOISTUVA_EMAIL } from '../../support/commands'
+
+export {}
+
+describe('Päivittäinen merkintä', () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions()
+    cy.task('db:cleanupErikoistuva', { email: E2E_ERIKOISTUVA_EMAIL })
+    cy.loginAsErikoistuva()
+  })
+
+  it('Erikoistuja lisää päivittäisen merkinnän ja näkee sen listalla', () => {
+    cy.visit('/paivittaiset-merkinnat')
+    cy.contains('h1', 'Päivittäiset merkinnät').should('be.visible')
+
+    cy.visit('/paivittaiset-merkinnat/uusi')
+    cy.contains('h1', 'Lisää merkintä').should('be.visible')
+    cy.get('[role="status"]', { timeout: 10000 }).should('not.exist')
+
+    cy.contains('label', 'Päivämäärä')
+      .parent()
+      .find('input.date-input, input[type="text"]')
+      .first()
+      .clear()
+      .type('15.05.2025')
+      .blur()
+
+    cy.get('input[name="paivakirja-merkinta-aihe"]').eq(1).check({ force: true })
+
+    cy.contains('label', 'Oppimistapahtuma')
+      .parent()
+      .find('input[type="text"]')
+      .clear()
+      .type('E2E ohjauskeskustelu')
+
+    cy.contains('label', 'Ajatuksia opitusta ja sen soveltamisesta')
+      .parent()
+      .find('textarea')
+      .clear()
+      .type('E2E reflektio päivittäisestä merkinnästä.')
+
+    cy.intercept('POST', '**/erikoistuva-laakari/paivakirjamerkinnat').as('paivakirjamerkintaPost')
+    cy.contains('button', 'Tallenna merkintä').click()
+
+    cy.wait('@paivakirjamerkintaPost', { timeout: 15000 }).then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body?.id).to.be.a('number')
+    })
+
+    cy.url().should('match', /\/paivittaiset-merkinnat\/\d+$/)
+    cy.contains('h1', 'E2E ohjauskeskustelu').should('be.visible')
+    cy.contains('E2E reflektio päivittäisestä merkinnästä.').should('be.visible')
+
+    cy.visit('/paivittaiset-merkinnat')
+    cy.contains('E2E ohjauskeskustelu').should('be.visible')
+    cy.contains('E2E reflektio päivittäisestä merkinnästä.').should('be.visible')
+  })
+})

--- a/e2e/cypress/e2e/seuranta/kouluttajan-seuranta.cy.ts
+++ b/e2e/cypress/e2e/seuranta/kouluttajan-seuranta.cy.ts
@@ -1,16 +1,12 @@
-import {E2E_ERIKOISTUVA_EMAIL} from "../../support/commands";
-import {KOULUTTAJA_EMAIL, VASTUUHENKILO_EMAIL, VIRKAILIJA_EMAIL} from "../../support/commands/credentials";
+import { E2E_ERIKOISTUVA_EMAIL } from '../../support/commands'
+import { KOULUTTAJA_EMAIL, VASTUUHENKILO_EMAIL, VIRKAILIJA_EMAIL } from '../../support/commands/credentials'
 
 const KOULUTTAJA_ETUNIMI = 'Lassekalevi'
 const KOULUTTAJA_SUKUNIMI = 'Hummaamistes'
 const VASTUUHENKILO_ETUNIMI = 'Mia'
 const VASTUUHENKILO_SUKUNIMI = 'Ålands'
-const VIRKAILIJA_ETUNIMI = 'Daniel'
-const VIRKAILIJA_SUKUNIMI = 'Siekkinen'
 
-
-describe('Erikoistuvan laakarin seuranta', () => {
-
+describe('Kouluttajan seuranta', () => {
   before(() => {
     Cypress.session.clearAllSavedSessions()
     cy.task('db:cleanupKoejakso', { erikoistuvaEmail: E2E_ERIKOISTUVA_EMAIL })
@@ -33,23 +29,21 @@ describe('Erikoistuvan laakarin seuranta', () => {
       email: VASTUUHENKILO_EMAIL,
       etunimi: VASTUUHENKILO_ETUNIMI,
       sukunimi: VASTUUHENKILO_SUKUNIMI,
-    }).then((result: any) => {
-      Cypress.env('vastuuhenkiloToken', result?.token)
     })
 
     cy.task('db:seedKouluttajavaltuutus', {
       erikoistuvaEmail: E2E_ERIKOISTUVA_EMAIL,
       kouluttajaEmail: KOULUTTAJA_EMAIL,
     })
-
-
   })
 
-  it('Erikoistuvan laakarin seuranta', () => {
-    cy.loginAsErikoistuva()
-    cy.luoTyoskentelyjakso()
+  it('Kouluttaja tarkistaa seurantasivun', () => {
+    cy.loginAsKouluttaja(Cypress.env('kouluttajaToken'))
+    cy.visit('/etusivu')
+    cy.get('.mt-5').should('be.visible')
+    cy.get('.btn > div').should('be.visible').click()
 
+    // Tarkistetaan, että palaa omaan profiiliin -painike on näkyvissä.
+    cy.get('.text-white > .btn').should('be.visible').click()
   })
-
 })
-

--- a/e2e/cypress/e2e/suoritemerkinnat/suoritemerkinta.cy.ts
+++ b/e2e/cypress/e2e/suoritemerkinnat/suoritemerkinta.cy.ts
@@ -51,7 +51,9 @@ describe('Suoritemerkintä', () => {
       Cypress.env('suoritemerkintaId', response?.body?.[0]?.id)
     })
 
-    cy.visit(`/suoritemerkinnat/${Cypress.env('suoritemerkintaId')}`)
+    cy.then(() => {
+      cy.visit(`/suoritemerkinnat/${Cypress.env('suoritemerkintaId')}`)
+    })
     cy.contains('h1', 'Suoritemerkintä').should('be.visible')
     cy.contains('E2E Testisairaala').should('be.visible')
     cy.contains(/1\.2\.2025|01\.02\.2025/).should('be.visible')

--- a/e2e/cypress/e2e/suoritemerkinnat/suoritemerkinta.cy.ts
+++ b/e2e/cypress/e2e/suoritemerkinnat/suoritemerkinta.cy.ts
@@ -1,0 +1,63 @@
+import { E2E_ERIKOISTUVA_EMAIL } from '../../support/commands'
+
+export {}
+
+describe('Suoritemerkintä', () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions()
+    cy.task('db:cleanupErikoistuva', { email: E2E_ERIKOISTUVA_EMAIL })
+    cy.loginAsErikoistuva()
+    cy.task('db:seedTyoskentelyjakso', { email: E2E_ERIKOISTUVA_EMAIL })
+  })
+
+  it('Erikoistuja lisää suoritemerkinnän ja tarkistaa sen tiedot', () => {
+    cy.visit('/suoritemerkinnat')
+    cy.contains('h1', 'Suoritemerkinnät').should('be.visible')
+
+    cy.visit('/suoritemerkinnat/uusi')
+    cy.contains('h1', 'Lisää suoritemerkintä').should('be.visible')
+    cy.get('[role="status"]', { timeout: 10000 }).should('not.exist')
+
+    cy.selectFirstMultiselectOption(cy.contains('label', 'Suorite').parent())
+
+    cy.get('body').then(($body) => {
+      if ($body.find('label:contains("Suoriutumisen taso"), label:contains("Etappi")').length > 0) {
+        cy.selectFirstMultiselectOption(cy.contains('label', /Suoriutumisen taso|Etappi/).parent())
+      }
+    })
+
+    cy.selectFirstMultiselectOption(cy.contains('label', 'Vaativuustaso').parent())
+
+    cy.contains('label', 'Suorituspäivä')
+      .parent()
+      .find('input.date-input, input[type="text"]')
+      .first()
+      .clear()
+      .type('01.02.2025')
+      .blur()
+
+    cy.contains('label', 'Lisätiedot')
+      .parent()
+      .find('textarea')
+      .clear()
+      .type('E2E lisätiedot suoritemerkinnälle.')
+
+    cy.intercept('POST', '**/erikoistuva-laakari/suoritemerkinnat').as('suoritemerkintaPost')
+    cy.contains('button', 'Tallenna').click()
+
+    cy.wait('@suoritemerkintaPost', { timeout: 15000 }).then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body).to.have.length(1)
+      Cypress.env('suoritemerkintaId', response?.body?.[0]?.id)
+    })
+
+    cy.visit(`/suoritemerkinnat/${Cypress.env('suoritemerkintaId')}`)
+    cy.contains('h1', 'Suoritemerkintä').should('be.visible')
+    cy.contains('E2E Testisairaala').should('be.visible')
+    cy.contains(/1\.2\.2025|01\.02\.2025/).should('be.visible')
+    cy.contains('E2E lisätiedot suoritemerkinnälle.').should('be.visible')
+
+    cy.visit('/suoritemerkinnat')
+    cy.contains(/1\.2\.2025|01\.02\.2025/).should('be.visible')
+  })
+})

--- a/e2e/cypress/plugins/db-tasks/erikoistuva.ts
+++ b/e2e/cypress/plugins/db-tasks/erikoistuva.ts
@@ -73,6 +73,14 @@ async function fetchTyoskentelypaikkaIds(client: Client, el_id: number): Promise
 
 async function deleteTyoskentelyjaksoRows(client: Client, el_id: number): Promise<void> {
   await client.query(
+    `DELETE FROM suoritemerkinta
+     WHERE tyoskentelyjakso_id IN (
+       SELECT id FROM tyoskentelyjakso
+       WHERE opintooikeus_id IN (SELECT id FROM opintooikeus WHERE erikoistuva_laakari_id = $1)
+     )`,
+    [el_id]
+  )
+  await client.query(
     `DELETE FROM suoritusarvioinnin_arvioitava_kokonaisuus
      WHERE suoritusarviointi_id IN (
        SELECT id FROM suoritusarviointi
@@ -153,6 +161,24 @@ async function deleteTeoriakoulutusRows(client: Client, el_id: number): Promise<
   )
 }
 
+// ─── Paivakirjamerkinta cleanup ──────────────────────────────────────────────
+
+async function deletePaivakirjamerkintaRows(client: Client, el_id: number): Promise<void> {
+  await client.query(
+    `DELETE FROM rel_paivakirjamerkinta__aihekategoria
+     WHERE paivakirjamerkinta_id IN (
+       SELECT id FROM paivakirjamerkinta
+       WHERE opintooikeus_id IN (SELECT id FROM opintooikeus WHERE erikoistuva_laakari_id = $1)
+     )`,
+    [el_id]
+  )
+  await client.query(
+    `DELETE FROM paivakirjamerkinta
+     WHERE opintooikeus_id IN (SELECT id FROM opintooikeus WHERE erikoistuva_laakari_id = $1)`,
+    [el_id]
+  )
+}
+
 // ─── Opintooikeus cleanup ─────────────────────────────────────────────────────
 
 async function deleteOpintooikeusRows(client: Client, el_id: number): Promise<void> {
@@ -193,6 +219,7 @@ async function deleteErikoistuvaLaakari(client: Client, ids: UserIds): Promise<v
     await deleteKoulutussuunnitelmaRows(client, el_id)
     await deleteTyoskentelyjaksoRows(client, el_id)
     await deleteTyoskentelypaikkaRows(client, paikkaIds)
+    await deletePaivakirjamerkintaRows(client, el_id)
     await deleteTeoriakoulutusRows(client, el_id)
     await deleteOpintooikeusRows(client, el_id)
 

--- a/e2e/cypress/support/commands/erikoistuva.ts
+++ b/e2e/cypress/support/commands/erikoistuva.ts
@@ -8,7 +8,7 @@ declare global {
        * @param container - Cypress chainable pointing to the multiselect wrapper element.
        */
       luoTyoskentelyjakso(token?: string): void
-      pyydaaArviointi(token?: string): void
+      pyydaArviointi(token?: string): void
     }
   }
 }
@@ -87,4 +87,3 @@ Cypress.Commands.add("pyydaArviointi", (token?: string) => {
 
 
 export {}
-


### PR DESCRIPTION
This pull request introduces several new end-to-end (E2E) Cypress test suites for core user flows and improves the reliability of test data cleanup. The main focus is on adding comprehensive tests for document management, daily notes, performance markings, and supervisor tracking, as well as enhancing database cleanup logic to ensure tests run in isolation.

**New E2E test suites:**

* Added test for document management, covering adding and deleting documents as a user (`asiakirjat.cy.ts`).
* Added test for daily notes, verifying that a user can add a daily note and see it in the list (`paivittainen-merkinta.cy.ts`).
* Added test for performance markings, ensuring a user can add a marking and verify its details (`suoritemerkinta.cy.ts`).
* Added test for supervisor tracking, including setup for related users and verifying supervisor page access (`kouluttajan-seuranta.cy.ts`).

**Test data cleanup improvements:**

* Enhanced the `deleteErikoistuvaLaakari` database cleanup task to also remove related daily notes (`paivakirjamerkinta`) and their associated categories, ensuring a clean state before tests (`erikoistuva.ts`). [[1]](diffhunk://#diff-654c93cfd5bbbe64fd85d23e043145b99ee937e2884a2e888dd3c3cdf42ada70R164-R181) [[2]](diffhunk://#diff-654c93cfd5bbbe64fd85d23e043145b99ee937e2884a2e888dd3c3cdf42ada70R222)
* Improved cleanup for performance markings linked to work periods (`tyoskentelyjakso`), preventing leftover test data (`erikoistuva.ts`).

**Other changes:**

* Removed a redundant test from `erikoistuvan-seuranta.cy.ts` that is now covered by the new supervisor tracking test.
* Fixed a minor typo in the custom Cypress command name (`pyydaArviointi`).

These changes significantly improve E2E coverage for critical user workflows and make the test suite more robust and reliable.