### PR TITLE
More e2e tests

### DIFF
--- a/e2e/cypress/e2e/opintosuoritukset/opintosuoritukset.cy.ts
+++ b/e2e/cypress/e2e/opintosuoritukset/opintosuoritukset.cy.ts
@@ -1,0 +1,37 @@
+import { E2E_ERIKOISTUVA_EMAIL } from '../../support/commands'
+
+export {}
+
+describe('Opintosuoritukset', () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions()
+    cy.task('db:cleanupErikoistuva', { email: E2E_ERIKOISTUVA_EMAIL })
+    cy.loginAsErikoistuva()
+  })
+
+  it('Erikoistuja tarkistaa opintosuoritusten välilehdet', () => {
+    cy.intercept('GET', '**/erikoistuva-laakari/opintosuoritukset').as('opintosuorituksetGet')
+
+    cy.visit('/opintosuoritukset')
+    cy.wait('@opintosuorituksetGet', { timeout: 15000 }).then(({ response }) => {
+      expect(response?.statusCode).to.eq(200)
+      expect(response?.body).to.have.property('opintosuoritukset')
+      expect(response?.body.opintosuoritukset).to.be.an('array')
+    })
+
+    cy.contains('h1', 'Opintosuoritukset').should('be.visible')
+    cy.contains('a', 'sähköpostitse').should('have.attr', 'href').and('include', 'laaketieteelliset.fi')
+    cy.contains('.nav-link', 'Johtamisopinnot').should('be.visible')
+    cy.contains('.nav-link', 'Kuulustelu').should('be.visible')
+    cy.contains('.nav-link', 'Muut').should('be.visible')
+
+    cy.contains('.nav-link', 'Johtamisopinnot').click()
+    cy.get('.tab-pane.active').should('be.visible')
+
+    cy.contains('.nav-link', 'Kuulustelu').click()
+    cy.get('.tab-pane.active').should('be.visible')
+
+    cy.contains('.nav-link', 'Muut').click()
+    cy.get('.tab-pane.active').should('be.visible')
+  })
+})

--- a/e2e/cypress/e2e/tyokertymalaskuri/tyokertymalaskuri.cy.ts
+++ b/e2e/cypress/e2e/tyokertymalaskuri/tyokertymalaskuri.cy.ts
@@ -1,0 +1,75 @@
+export {}
+
+describe('Työkertymälaskuri', () => {
+  it('Käyttäjä lisää työskentelyjakson julkiseen työkertymälaskuriin ja muokkaa sitä', () => {
+    cy.intercept('GET', '**/julkinen/poissaolon-syyt').as('poissaolonSyyt')
+
+    cy.visit('/tyokertymalaskuri', {
+      onBeforeLoad(win) {
+        win.localStorage.removeItem('laskuri-tyoskentelyjaksot')
+      },
+    })
+
+    cy.contains('h1', 'Työkertymälaskuri').should('be.visible')
+    cy.contains('h2', 'Laskennan yhteenveto').should('be.visible')
+    cy.contains('span', 'Työkertymä yhteensä')
+      .parent()
+      .find('.duration-text')
+      .should('have.text', '0 vrk')
+
+    cy.contains('button', 'Lisää työskentelyjakso').click()
+    cy.wait('@poissaolonSyyt', { timeout: 15000 }).its('response.statusCode').should('eq', 200)
+    cy.get('.modal-content').within(() => {
+      cy.contains('h5', 'Lisää työskentelyjakso').should('be.visible')
+      cy.contains('label', 'Työskentelypaikka')
+        .parent()
+        .find('input[type="text"]')
+        .clear()
+        .type('E2E Laskurisairaala')
+      cy.get('input[type="radio"][name="kaytannon-koulutus-tyyppi"]').first().check({ force: true })
+      cy.contains('label', 'Alkamispäivä')
+        .parent()
+        .find('input.date-input, input[type="text"]')
+        .first()
+        .clear()
+        .type('01.01.2025')
+        .blur()
+      cy.contains('label', 'Päättymispäivä')
+        .parent()
+        .find('input.date-input, input[type="text"]')
+        .first()
+        .clear()
+        .type('31.03.2025')
+        .blur()
+      cy.contains('label', 'Työaika täydestä työpäivästä')
+        .parent()
+        .find('input[type="number"]')
+        .clear()
+        .type('100')
+      cy.contains('button', 'Tallenna jakso').click()
+    })
+
+    cy.get('.modal-content').should('not.exist')
+    cy.contains('.tyoskentelyjaksot-table', 'E2E Laskurisairaala').should('be.visible')
+    cy.contains('.tyoskentelyjaksot-table', /1\.1\.2025.*31\.3\.2025/).should('be.visible')
+    cy.contains('span', 'Työkertymä yhteensä')
+      .parent()
+      .find('.duration-text')
+      .invoke('text')
+      .should('not.eq', '0 vrk')
+
+    cy.contains('.tyoskentelyjaksot-table button', 'E2E Laskurisairaala').click()
+    cy.get('.modal-content').within(() => {
+      cy.contains('h5', 'Muokkaa työskentelyjaksoa').should('be.visible')
+      cy.contains('label', 'Työskentelypaikka')
+        .parent()
+        .find('input[type="text"]')
+        .clear()
+        .type('E2E Muokattu laskurisairaala')
+      cy.contains('button', 'Tallenna').click()
+    })
+
+    cy.get('.modal-content').should('not.exist')
+    cy.contains('.tyoskentelyjaksot-table', 'E2E Muokattu laskurisairaala').should('be.visible')
+  })
+})

--- a/e2e/cypress/e2e/tyokertymalaskuri/tyokertymalaskuri.cy.ts
+++ b/e2e/cypress/e2e/tyokertymalaskuri/tyokertymalaskuri.cy.ts
@@ -15,7 +15,9 @@ describe('Työkertymälaskuri', () => {
     cy.contains('span', 'Työkertymä yhteensä')
       .parent()
       .find('.duration-text')
-      .should('have.text', '0 vrk')
+      .invoke('text')
+      .invoke('trim')
+      .should('eq', '0 vrk')
 
     cy.contains('button', 'Lisää työskentelyjakso').click()
     cy.wait('@poissaolonSyyt', { timeout: 15000 }).its('response.statusCode').should('eq', 200)
@@ -41,7 +43,7 @@ describe('Työkertymälaskuri', () => {
         .clear()
         .type('31.03.2025')
         .blur()
-      cy.contains('label', 'Työaika täydestä työpäivästä')
+      cy.contains('label', 'Työaika (50–100 %)')
         .parent()
         .find('input[type="number"]')
         .clear()
@@ -56,6 +58,7 @@ describe('Työkertymälaskuri', () => {
       .parent()
       .find('.duration-text')
       .invoke('text')
+      .invoke('trim')
       .should('not.eq', '0 vrk')
 
     cy.contains('.tyoskentelyjaksot-table button', 'E2E Laskurisairaala').click()
@@ -71,5 +74,21 @@ describe('Työkertymälaskuri', () => {
 
     cy.get('.modal-content').should('not.exist')
     cy.contains('.tyoskentelyjaksot-table', 'E2E Muokattu laskurisairaala').should('be.visible')
+
+    // Summary card assertions
+    cy.contains('span', 'Työkertymä yhteensä')
+      .parent()
+      .find('.duration-text')
+      .invoke('text')
+      .invoke('trim')
+      .should('not.eq', '0 vrk')
+
+    // Table row assertions
+    cy.get('.tyoskentelyjaksot-table').within(() => {
+      cy.contains('E2E Muokattu laskurisairaala').should('be.visible')
+      cy.contains(/1\.1\.2025.*31\.3\.2025/).should('be.visible')
+      cy.contains('100 %').should('be.visible')
+      cy.contains('Ei poissaoloja').should('be.visible')
+    })
   })
 })


### PR DESCRIPTION
This pull request adds new end-to-end Cypress test suites for the `Opintosuoritukset` and `Työkertymälaskuri` features. These tests cover key user flows and assertions to ensure the correct functionality and UI elements for both areas.

**New end-to-end tests:**

* Opintosuoritukset:
  - Added a test to verify that the 'Erikoistuja' user can access and interact with the Opintosuoritukset page, including checking for correct API responses and the presence of all relevant navigation tabs (`Johtamisopinnot`, `Kuulustelu`, `Muut`).

* Työkertymälaskuri:
  - Added a test to simulate a user adding a new work period, editing it, and verifying that the changes are reflected in the summary and table, including checks for correct API responses and UI updates.