### PR TITLE
arviointityökalut e2e tests

### DIFF
--- a/e2e/cypress/e2e/arvioinnit/arviointityokalut-kouluttaja.cy.ts
+++ b/e2e/cypress/e2e/arvioinnit/arviointityokalut-kouluttaja.cy.ts
@@ -11,12 +11,15 @@ export {}
 //   GET /api/kouluttaja/arviointityokalut
 //   GET /api/kouluttaja/arviointityokalut/kategoriat
 
-const KOULUTTAJA_ETUNIMI  = 'E2E'
-const KOULUTTAJA_SUKUNIMI = 'ArviointityokaluKouluttaja'
+const KOULUTTAJA_ETUNIMI  = 'Lassekalevi'
+const KOULUTTAJA_SUKUNIMI = 'Hummaamistes'
 
 describe('Arviointityökalut – kouluttaja', () => {
   before(() => {
     Cypress.session.clearAllSavedSessions()
+
+    cy.task('db:cleanupErikoistuva', { email: KOULUTTAJA_EMAIL })
+    cy.task('db:cleanupKouluttaja', { email: KOULUTTAJA_EMAIL })
 
     cy.task('db:seedKouluttaja', {
       email: KOULUTTAJA_EMAIL,

--- a/e2e/cypress/e2e/arvioinnit/arviointityokalut-kouluttaja.cy.ts
+++ b/e2e/cypress/e2e/arvioinnit/arviointityokalut-kouluttaja.cy.ts
@@ -1,0 +1,52 @@
+import { KOULUTTAJA_EMAIL } from '../../support/commands/credentials'
+
+export {}
+
+// Käyttötapaus: Kouluttaja selaa arviointityökalut-esittelysivua
+// Käyttäjä: Kouluttaja
+// Tavoite: Varmistaa, että kouluttajan arviointityökalut-endpointit toimivat
+//          ArviointityokalutResource-kantaluokan refaktoroinnin jälkeen.
+// Sivu: /arviointityokalut/esittely  (allowedRoles: Kouluttaja, Vastuuhenkilo)
+// Testatut endpointit (sivun mount() käynnistää):
+//   GET /api/kouluttaja/arviointityokalut
+//   GET /api/kouluttaja/arviointityokalut/kategoriat
+
+const KOULUTTAJA_ETUNIMI  = 'E2E'
+const KOULUTTAJA_SUKUNIMI = 'ArviointityokaluKouluttaja'
+
+describe('Arviointityökalut – kouluttaja', () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions()
+
+    cy.task('db:seedKouluttaja', {
+      email: KOULUTTAJA_EMAIL,
+      etunimi: KOULUTTAJA_ETUNIMI,
+      sukunimi: KOULUTTAJA_SUKUNIMI,
+    }).then((result: any) => {
+      Cypress.env('kouluttajaToken', result?.token)
+    })
+  })
+
+  it('Kouluttaja avaa arviointityökalut-esittelysivun ja sivu lataa API-datat onnistuneesti', () => {
+    cy.loginAsKouluttaja(Cypress.env('kouluttajaToken'))
+
+    cy.intercept('GET', '**/kouluttaja/arviointityokalut/kategoriat').as('getKategoriat')
+    cy.intercept('GET', '**/kouluttaja/arviointityokalut').as('getArviointityokalut')
+
+    cy.visit('/arviointityokalut/esittely')
+
+    cy.wait('@getKategoriat').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200)
+      expect(response?.body).to.be.an('array')
+    })
+
+    cy.wait('@getArviointityokalut').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200)
+      expect(response?.body).to.be.an('array')
+    })
+
+    // Varmistetaan, että sivu on renderöitynyt oikein
+    cy.contains('h1', 'Arviointityökalut').should('be.visible')
+    cy.get('[role="status"]').should('not.exist')
+  })
+})

--- a/e2e/cypress/e2e/arvioinnit/arviointityokalut-vastuuhenkilo.cy.ts
+++ b/e2e/cypress/e2e/arvioinnit/arviointityokalut-vastuuhenkilo.cy.ts
@@ -1,0 +1,52 @@
+import { VASTUUHENKILO_EMAIL } from '../../support/commands/credentials'
+
+export {}
+
+// Käyttötapaus: Vastuuhenkilö selaa arviointityökalut-esittelysivua
+// Käyttäjä: Vastuuhenkilö
+// Tavoite: Varmistaa, että vastuuhenkilön arviointityökalut-endpointit toimivat
+//          ArviointityokalutResource-kantaluokan refaktoroinnin jälkeen.
+// Sivu: /arviointityokalut/esittely  (allowedRoles: Kouluttaja, Vastuuhenkilo)
+// Testatut endpointit (sivun mount() käynnistää):
+//   GET /api/vastuuhenkilo/arviointityokalut
+//   GET /api/vastuuhenkilo/arviointityokalut/kategoriat
+
+const VASTUUHENKILO_ETUNIMI  = 'E2E'
+const VASTUUHENKILO_SUKUNIMI = 'ArviointityokaluVastuuhenkilo'
+
+describe('Arviointityökalut – vastuuhenkilö', () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions()
+
+    cy.task('db:seedVastuuhenkilo', {
+      email: VASTUUHENKILO_EMAIL,
+      etunimi: VASTUUHENKILO_ETUNIMI,
+      sukunimi: VASTUUHENKILO_SUKUNIMI,
+    }).then((result: any) => {
+      Cypress.env('vastuuhenkiloToken', result?.token)
+    })
+  })
+
+  it('Vastuuhenkilö avaa arviointityökalut-esittelysivun ja sivu lataa API-datat onnistuneesti', () => {
+    cy.loginAsVastuuhenkilo(Cypress.env('vastuuhenkiloToken'))
+
+    cy.intercept('GET', '**/vastuuhenkilo/arviointityokalut/kategoriat').as('getKategoriat')
+    cy.intercept('GET', '**/vastuuhenkilo/arviointityokalut').as('getArviointityokalut')
+
+    cy.visit('/arviointityokalut/esittely')
+
+    cy.wait('@getKategoriat').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200)
+      expect(response?.body).to.be.an('array')
+    })
+
+    cy.wait('@getArviointityokalut').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200)
+      expect(response?.body).to.be.an('array')
+    })
+
+    // Varmistetaan, että sivu on renderöitynyt oikein
+    cy.contains('h1', 'Arviointityökalut').should('be.visible')
+    cy.get('[role="status"]').should('not.exist')
+  })
+})

--- a/e2e/cypress/e2e/arvioinnit/arviointityokalut-vastuuhenkilo.cy.ts
+++ b/e2e/cypress/e2e/arvioinnit/arviointityokalut-vastuuhenkilo.cy.ts
@@ -11,12 +11,15 @@ export {}
 //   GET /api/vastuuhenkilo/arviointityokalut
 //   GET /api/vastuuhenkilo/arviointityokalut/kategoriat
 
-const VASTUUHENKILO_ETUNIMI  = 'E2E'
-const VASTUUHENKILO_SUKUNIMI = 'ArviointityokaluVastuuhenkilo'
+const VASTUUHENKILO_ETUNIMI  = 'Mia'
+const VASTUUHENKILO_SUKUNIMI = 'Ålands'
 
 describe('Arviointityökalut – vastuuhenkilö', () => {
   before(() => {
     Cypress.session.clearAllSavedSessions()
+
+    cy.task('db:cleanupErikoistuva', { email: VASTUUHENKILO_EMAIL })
+    cy.task('db:cleanupVastuuhenkilo', { email: VASTUUHENKILO_EMAIL })
 
     cy.task('db:seedVastuuhenkilo', {
       email: VASTUUHENKILO_EMAIL,

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/ArviointityokalutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/ArviointityokalutResource.kt
@@ -1,0 +1,47 @@
+package fi.elsapalvelu.elsa.web.rest.common
+
+import fi.elsapalvelu.elsa.service.ArviointityokaluKategoriaService
+import fi.elsapalvelu.elsa.service.ArviointityokaluService
+import fi.elsapalvelu.elsa.service.dto.ArviointityokaluDTO
+import fi.elsapalvelu.elsa.service.dto.ArviointityokaluKategoriaDTO
+import fi.elsapalvelu.elsa.service.dto.AsiakirjaDataDTO
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import java.net.URLEncoder
+
+abstract class ArviointityokalutResource(
+    private val arviointityokaluService: ArviointityokaluService,
+    private val arviointityokaluKategoriaService: ArviointityokaluKategoriaService,
+) {
+    @GetMapping("/arviointityokalut")
+    fun getArviointityokalut(): ResponseEntity<List<ArviointityokaluDTO>> {
+        return ResponseEntity.ok(arviointityokaluService.findAllJulkaistut())
+    }
+
+    @GetMapping("/arviointityokalut/kategoriat")
+    fun getArviointityokaluKategoriat(): ResponseEntity<List<ArviointityokaluKategoriaDTO>> {
+        return ResponseEntity.ok(arviointityokaluKategoriaService.findAll())
+    }
+
+    @GetMapping("/asiakirjat/{id}")
+    fun getAsiakirja(
+        @PathVariable id: Long
+    ): ResponseEntity<ByteArray> {
+        val arviointityokalu = arviointityokaluService.findOneByLiiteId(id)
+        val asiakirjaData: AsiakirjaDataDTO = arviointityokaluService.getAsiakirjaDataDTO(arviointityokalu.liite)
+        asiakirjaData.fileInputStream?.use {
+            return ResponseEntity.ok()
+                .header(
+                    HttpHeaders.CONTENT_DISPOSITION,
+                    "attachment; filename=\"" + URLEncoder.encode(arviointityokalu.liitetiedostonNimi, "UTF-8") + "\""
+                )
+                .header(HttpHeaders.CONTENT_TYPE, arviointityokalu.liitetiedostonTyyppi + "; charset=UTF-8")
+                .body(it.readBytes())
+        }
+
+        return ResponseEntity.notFound().build()
+    }
+}
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaArviointityokalutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaArviointityokalutResource.kt
@@ -2,51 +2,13 @@ package fi.elsapalvelu.elsa.web.rest.kouluttaja
 
 import fi.elsapalvelu.elsa.service.ArviointityokaluKategoriaService
 import fi.elsapalvelu.elsa.service.ArviointityokaluService
-import fi.elsapalvelu.elsa.service.dto.ArviointityokaluDTO
-import fi.elsapalvelu.elsa.service.dto.ArviointityokaluKategoriaDTO
-import fi.elsapalvelu.elsa.service.dto.AsiakirjaDataDTO
-import org.springframework.http.HttpHeaders
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
+import fi.elsapalvelu.elsa.web.rest.common.ArviointityokalutResource
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.net.URLEncoder
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/kouluttaja")
-class KouluttajaArviointityokalutResource (
-    private val arviointityokaluService: ArviointityokaluService,
-    private val arviointityokaluKategoriaService: ArviointityokaluKategoriaService,
-) {
-    @GetMapping("/arviointityokalut")
-    fun getArviointityokalut(): ResponseEntity<List<ArviointityokaluDTO>> {
-        return ResponseEntity.ok(arviointityokaluService.findAllJulkaistut())
-    }
-
-    @GetMapping("/arviointityokalut/kategoriat")
-    fun getArviointityokaluKategoriat(): ResponseEntity<List<ArviointityokaluKategoriaDTO>> {
-        return ResponseEntity.ok(arviointityokaluKategoriaService.findAll())
-    }
-
-    @GetMapping("/asiakirjat/{id}")
-    fun getAsiakirja(
-        @PathVariable id: Long
-    ): ResponseEntity<ByteArray> {
-        val arviointityokalu = arviointityokaluService.findOneByLiiteId(id)
-        val asiakirjaData: AsiakirjaDataDTO = arviointityokaluService.getAsiakirjaDataDTO(arviointityokalu.liite)
-        asiakirjaData.fileInputStream?.use {
-            return ResponseEntity.ok()
-                .header(
-                    HttpHeaders.CONTENT_DISPOSITION,
-                    "attachment; filename=\"" + URLEncoder.encode(arviointityokalu.liitetiedostonNimi, "UTF-8") + "\""
-                )
-                .header(HttpHeaders.CONTENT_TYPE, arviointityokalu.liitetiedostonTyyppi + "; charset=UTF-8")
-                .body(it.readBytes())
-        }
-
-        return ResponseEntity.notFound().build()
-    }
-
-}
+class KouluttajaArviointityokalutResource(
+    arviointityokaluService: ArviointityokaluService,
+    arviointityokaluKategoriaService: ArviointityokaluKategoriaService,
+) : ArviointityokalutResource(arviointityokaluService, arviointityokaluKategoriaService)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloArviointityokalutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloArviointityokalutResource.kt
@@ -2,51 +2,13 @@ package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
 import fi.elsapalvelu.elsa.service.ArviointityokaluKategoriaService
 import fi.elsapalvelu.elsa.service.ArviointityokaluService
-import fi.elsapalvelu.elsa.service.dto.ArviointityokaluDTO
-import fi.elsapalvelu.elsa.service.dto.ArviointityokaluKategoriaDTO
-import fi.elsapalvelu.elsa.service.dto.AsiakirjaDataDTO
-import org.springframework.http.HttpHeaders
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
+import fi.elsapalvelu.elsa.web.rest.common.ArviointityokalutResource
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.net.URLEncoder
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/vastuuhenkilo")
-class VastuuhenkiloArviointityokalutResource (
-    private val arviointityokaluService: ArviointityokaluService,
-    private val arviointityokaluKategoriaService: ArviointityokaluKategoriaService,
-) {
-    @GetMapping("/arviointityokalut")
-    fun getArviointityokalut(): ResponseEntity<List<ArviointityokaluDTO>> {
-        return ResponseEntity.ok(arviointityokaluService.findAllJulkaistut())
-    }
-
-    @GetMapping("/arviointityokalut/kategoriat")
-    fun getArviointityokaluKategoriat(): ResponseEntity<List<ArviointityokaluKategoriaDTO>> {
-        return ResponseEntity.ok(arviointityokaluKategoriaService.findAll())
-    }
-
-    @GetMapping("/asiakirjat/{id}")
-    fun getAsiakirja(
-        @PathVariable id: Long,
-    ): ResponseEntity<ByteArray> {
-        val arviointityokalu = arviointityokaluService.findOneByLiiteId(id)
-        val asiakirjaData: AsiakirjaDataDTO = arviointityokaluService.getAsiakirjaDataDTO(arviointityokalu.liite)
-        asiakirjaData.fileInputStream?.use {
-            return ResponseEntity.ok()
-                .header(
-                    HttpHeaders.CONTENT_DISPOSITION,
-                    "attachment; filename=\"" + URLEncoder.encode(arviointityokalu.liitetiedostonNimi, "UTF-8") + "\""
-                )
-                .header(HttpHeaders.CONTENT_TYPE, arviointityokalu.liitetiedostonTyyppi + "; charset=UTF-8")
-                .body(it.readBytes())
-        }
-
-        return ResponseEntity.notFound().build()
-    }
-
-}
+class VastuuhenkiloArviointityokalutResource(
+    arviointityokaluService: ArviointityokaluService,
+    arviointityokaluKategoriaService: ArviointityokaluKategoriaService,
+) : ArviointityokalutResource(arviointityokaluService, arviointityokaluKategoriaService)


### PR DESCRIPTION
This pull request refactors the arviointityökalut (assessment tools) API resources for kouluttaja (trainer) and vastuuhenkilö (responsible person) roles to use a new shared abstract base class, improving code reuse and maintainability. It also adds new end-to-end Cypress tests to ensure that the refactored endpoints work correctly for both roles.

Key changes:

### Backend refactoring for arviointityökalut endpoints

* Introduced a new abstract base class `ArviointityokalutResource` in `fi.elsapalvelu.elsa.web.rest.common`, which implements the shared arviointityökalut endpoints and document download logic. (`src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/ArviointityokalutResource.kt`)
* Refactored `KouluttajaArviointityokalutResource` and `VastuuhenkiloArviointityokalutResource` to extend the new base class, removing duplicate endpoint implementations and delegating to the shared logic. (`src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaArviointityokalutResource.kt`, `src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloArviointityokalutResource.kt`) [[1]](diffhunk://#diff-b0fe27de575210fba757433b024c7b119eabd13d4acf03ffb5d8968974da60f4L5-R14) [[2]](diffhunk://#diff-5b8c6c91ca018299d413c5415a9791e48bc9ccabd5f8d24f6f4c8196fdcbdf92L5-R14)

### End-to-end test coverage

* Added Cypress E2E tests for kouluttaja and vastuuhenkilö arviointityökalut-esittelysivu (assessment tools introduction page) to verify that the refactored endpoints work as expected for both roles. (`e2e/cypress/e2e/arvioinnit/arviointityokalut-kouluttaja.cy.ts`, `e2e/cypress/e2e/arvioinnit/arviointityokalut-vastuuhenkilo.cy.ts`) [[1]](diffhunk://#diff-93e2b9f5da14b0445e6f9f633d9a68f9c8ca8f8920745c5f4f10cd314abcf291R1-R55) [[2]](diffhunk://#diff-b64148f2895eec59803a3b1b524610ed8159f289c555b3b1b7e5ad5ed428c347R1-R55)