### PR TITLE
RestConstants.kt

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/RestConstants.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/RestConstants.kt
@@ -1,0 +1,6 @@
+package fi.elsapalvelu.elsa.web.rest
+
+const val VALMISTUMISPYYNTO_ENTITY_NAME = "valmistumispyynto"
+const val TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME = "terveyskeskuskoulutusjakson_hyvaksynta"
+const val ENTITY_KOEJAKSON_SOPIMUS = "koejakson_koulutussopimus"
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoejaksoResource.kt
@@ -7,6 +7,7 @@ import fi.elsapalvelu.elsa.extensions.mapAsiakirja
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.*
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
+import fi.elsapalvelu.elsa.web.rest.ENTITY_KOEJAKSON_SOPIMUS
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
@@ -19,7 +20,6 @@ import jakarta.validation.Valid
 import org.springframework.web.multipart.MultipartFile
 import java.util.Date
 
-private const val ENTITY_KOEJAKSON_SOPIMUS = "koejakson_koulutussopimus"
 private const val ENTITY_KOEJAKSON_ALOITUSKESKUSTELU = "koejakson_aloituskeskustelu"
 private const val ENTITY_KOEJAKSON_VALIARVIOINTI = "koejakson_valiarviointi"
 private const val ENTITY_KOEJAKSON_KEHITTAMISTOIMENPITEET = "koejakson_kehittamistoimenpiteet"

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
@@ -8,6 +8,7 @@ import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.*
 import fi.elsapalvelu.elsa.service.dto.enumeration.TerveyskeskuskoulutusjaksoTila
+import fi.elsapalvelu.elsa.web.rest.TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.Valid
@@ -29,7 +30,6 @@ private const val TYOSKENTELYJAKSO_ENTITY_NAME = "tyoskentelyjakso"
 private const val KESKEYTYSAIKA_ENTITY_NAME = "keskeytysaika"
 private const val ASIAKIRJA_ENTITY_NAME = "asiakirja"
 private const val TYOSKENTELYPAIKKA_ENTITY_NAME = "tyoskentelypaikka"
-private const val TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME = "terveyskeskuskoulutusjakson_hyvaksynta"
 
 @Suppress("TooManyFunctions")
 @RestController

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariValmistumispyyntoResource.kt
@@ -2,6 +2,7 @@ package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.*
+import fi.elsapalvelu.elsa.web.rest.VALMISTUMISPYYNTO_ENTITY_NAME
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -10,7 +11,6 @@ import java.net.URI
 import java.security.Principal
 import jakarta.validation.Valid
 
-private const val VALMISTUMISPYYNTO_ENTITY_NAME = "valmistumispyynto"
 
 @RestController
 @RequestMapping("/api/erikoistuva-laakari")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoResource.kt
@@ -2,6 +2,7 @@ package fi.elsapalvelu.elsa.web.rest.kouluttaja
 
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.*
+import fi.elsapalvelu.elsa.web.rest.ENTITY_KOEJAKSON_SOPIMUS
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -9,7 +10,6 @@ import org.springframework.web.bind.annotation.*
 import tech.jhipster.web.util.ResponseUtil
 import java.security.Principal
 
-private const val ENTITY_KOEJAKSON_SOPIMUS = "koejakson_koulutussopimus"
 
 @RestController
 @RequestMapping("/api/kouluttaja")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloKoejaksoResource.kt
@@ -2,6 +2,7 @@ package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.*
+import fi.elsapalvelu.elsa.web.rest.ENTITY_KOEJAKSON_SOPIMUS
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import jakarta.validation.Valid
@@ -10,7 +11,6 @@ import org.springframework.web.bind.annotation.*
 import tech.jhipster.web.util.ResponseUtil
 import java.security.Principal
 
-private const val ENTITY_KOEJAKSON_SOPIMUS = "koejakson_koulutussopimus"
 private const val ENTITY_KOEJAKSON_VASTUUHENKILON_ARVIO = "koejakson_vastuuhenkilon_arvio"
 
 @RestController

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResource.kt
@@ -10,6 +10,7 @@ import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksoSimpleDTO
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksoUpdateDTO
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksonHyvaksyntaDTO
+import fi.elsapalvelu.elsa.web.rest.TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import org.springframework.data.domain.Page
@@ -20,7 +21,6 @@ import java.security.Principal
 import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.ValidationException
 
-private const val TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME = "terveyskeskuskoulutusjakson_hyvaksynta"
 
 @RestController
 @RequestMapping("/api/vastuuhenkilo")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoResource.kt
@@ -5,6 +5,7 @@ import fi.elsapalvelu.elsa.service.UserService
 import fi.elsapalvelu.elsa.service.ValmistumispyyntoService
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.*
+import fi.elsapalvelu.elsa.web.rest.VALMISTUMISPYYNTO_ENTITY_NAME
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import org.slf4j.LoggerFactory
@@ -15,7 +16,6 @@ import org.springframework.web.bind.annotation.*
 import java.security.Principal
 import jakarta.validation.Valid
 
-private const val VALMISTUMISPYYNTO_ENTITY_NAME = "valmistumispyynto"
 
 @RestController
 @RequestMapping("/api/vastuuhenkilo")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResource.kt
@@ -9,6 +9,7 @@ import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksoSimpleDTO
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksoUpdateDTO
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksonHyvaksyntaDTO
+import fi.elsapalvelu.elsa.web.rest.TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import org.springframework.data.domain.Page
@@ -21,7 +22,6 @@ import jakarta.validation.ValidationException
 import org.springframework.web.multipart.MultipartFile
 import java.time.LocalDate
 
-private const val TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME = "terveyskeskuskoulutusjakson_hyvaksynta"
 
 @RestController
 @RequestMapping("/api/virkailija")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaValmistumispyyntoResource.kt
@@ -9,6 +9,7 @@ import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.ValmistumispyynnonTarkistusDTO
 import fi.elsapalvelu.elsa.service.dto.ValmistumispyynnonTarkistusUpdateDTO
 import fi.elsapalvelu.elsa.service.dto.ValmistumispyyntoListItemDTO
+import fi.elsapalvelu.elsa.web.rest.VALMISTUMISPYYNTO_ENTITY_NAME
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import jakarta.validation.Valid
@@ -19,7 +20,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import java.security.Principal
 
-private const val VALMISTUMISPYYNTO_ENTITY_NAME = "valmistumispyynto"
 
 @RestController
 @RequestMapping("/api/virkailija")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResource.kt
@@ -8,6 +8,7 @@ import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.dto.*
 import fi.elsapalvelu.elsa.service.dto.enumeration.TerveyskeskuskoulutusjaksoTila
+import fi.elsapalvelu.elsa.web.rest.TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.Valid
@@ -28,7 +29,6 @@ private const val TYOSKENTELYJAKSO_ENTITY_NAME = "tyoskentelyjakso"
 private const val KESKEYTYSAIKA_ENTITY_NAME = "keskeytysaika"
 private const val ASIAKIRJA_ENTITY_NAME = "asiakirja"
 private const val TYOSKENTELYPAIKKA_ENTITY_NAME = "tyoskentelypaikka"
-private const val TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME = "terveyskeskuskoulutusjakson_hyvaksynta"
 
 @Suppress("TooManyFunctions")
 @RestController


### PR DESCRIPTION
This pull request refactors how certain entity name constants are defined and used across the codebase. Instead of defining string constants for entity names in multiple resource files, these constants are now centralized in the new `RestConstants.kt` file and imported where needed. This change improves maintainability and reduces duplication.

**Centralization of entity name constants:**

* Added `RestConstants.kt` with definitions for `VALMISTUMISPYYNTO_ENTITY_NAME`, `TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME`, and `ENTITY_KOEJAKSON_SOPIMUS`.

**Refactoring resource files to use centralized constants:**

* Updated all usages of `VALMISTUMISPYYNTO_ENTITY_NAME` in `ErikoistuvaLaakariValmistumispyyntoResource.kt`, `VastuuhenkiloValmistumispyyntoResource.kt`, and `VirkailijaValmistumispyyntoResource.kt` to import from `RestConstants.kt` and removed local definitions. [[1]](diffhunk://#diff-70f48b0aecd5417ef424992e7eeca655727fae473f2767701d5a1cf634332775R5) [[2]](diffhunk://#diff-70f48b0aecd5417ef424992e7eeca655727fae473f2767701d5a1cf634332775L13) [[3]](diffhunk://#diff-a6ed5674b353769927ed222ebfab1c48f272cf6fd0d02a3613b7925703840d14R8) [[4]](diffhunk://#diff-a6ed5674b353769927ed222ebfab1c48f272cf6fd0d02a3613b7925703840d14L18) [[5]](diffhunk://#diff-1d1eb1aae27e02da76b688322b86824bbbd938e9c7d01ba6b5cc38dc04ab295dR12) [[6]](diffhunk://#diff-1d1eb1aae27e02da76b688322b86824bbbd938e9c7d01ba6b5cc38dc04ab295dL22)

* Updated all usages of `TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME` in `ErikoistuvaLaakariTyoskentelyjaksoResource.kt`, `VastuuhenkiloTerveyskeskuskoulutusjaksoResource.kt`, `VirkailijaTerveyskeskuskoulutusjaksoResource.kt`, and `YekKoulutettavaTyoskentelyjaksoResource.kt` to import from `RestConstants.kt` and removed local definitions. [[1]](diffhunk://#diff-be8694d2d51ca8a492e1227a3c1e0dec3742b5712a33afaeb91f61edc9b1c2aeR11) [[2]](diffhunk://#diff-be8694d2d51ca8a492e1227a3c1e0dec3742b5712a33afaeb91f61edc9b1c2aeL32) [[3]](diffhunk://#diff-af22afc8e84a691fa6950d1d068bda4ca9c98d6b6defb2ffeebc2e5e31f1ced5R13) [[4]](diffhunk://#diff-af22afc8e84a691fa6950d1d068bda4ca9c98d6b6defb2ffeebc2e5e31f1ced5L23) [[5]](diffhunk://#diff-e12dbfa4703c6044da1dcaaa14b2614dd0db671cf8407c91db49bbe0e2675c97R12) [[6]](diffhunk://#diff-e12dbfa4703c6044da1dcaaa14b2614dd0db671cf8407c91db49bbe0e2675c97L24) [[7]](diffhunk://#diff-c276984cfb3c8ad187ec768c0de9c9e5aff7bcea04e231f2f43fe871f9bf9f6cR11) [[8]](diffhunk://#diff-c276984cfb3c8ad187ec768c0de9c9e5aff7bcea04e231f2f43fe871f9bf9f6cL31)

* Updated all usages of `ENTITY_KOEJAKSON_SOPIMUS` in `ErikoistuvaLaakariKoejaksoResource.kt`, `KouluttajaKoejaksoResource.kt`, and `VastuuhenkiloKoejaksoResource.kt` to import from `RestConstants.kt` and removed local definitions. [[1]](diffhunk://#diff-c0d88b858747417c2fd0bf08eccded96bb94fe30a06c9fc073917de7d564bd02R10) [[2]](diffhunk://#diff-c0d88b858747417c2fd0bf08eccded96bb94fe30a06c9fc073917de7d564bd02L22) [[3]](diffhunk://#diff-f6bf289d4cc4fbf066fc283c3a1e074bbba23a25399ec17fea24bf83f4892940R5-L12) [[4]](diffhunk://#diff-bc99b545e4c2d493cc5bf8a3a78f8c5398fa5851da65b558e4cd1ce25c1584acR5) [[5]](diffhunk://#diff-bc99b545e4c2d493cc5bf8a3a78f8c5398fa5851da65b558e4cd1ce25c1584acL13)

This refactoring ensures all entity name constants are defined in a single place, making future changes easier and reducing the risk of inconsistencies.