### PR TITLE
Refactors the handling of Terveyskeskuskoulutusjakso-related REST endpoints by introducing a shared base resource class to centralize exception handling and file download logic

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TerveyskeskuskoulutusjaksoBaseResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TerveyskeskuskoulutusjaksoBaseResource.kt
@@ -1,0 +1,52 @@
+package fi.elsapalvelu.elsa.web.rest.common
+
+import fi.elsapalvelu.elsa.service.AsiakirjaService
+import fi.elsapalvelu.elsa.service.KayttajaService
+import fi.elsapalvelu.elsa.service.TerveyskeskuskoulutusjaksonHyvaksyntaService
+import fi.elsapalvelu.elsa.service.UserService
+import fi.elsapalvelu.elsa.service.dto.AsiakirjaDTO
+import fi.elsapalvelu.elsa.web.rest.TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME
+import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
+import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
+import jakarta.persistence.EntityNotFoundException
+import jakarta.validation.ValidationException
+import org.springframework.http.ResponseEntity
+
+abstract class TerveyskeskuskoulutusjaksoBaseResource(
+    protected val userService: UserService,
+    protected val kayttajaService: KayttajaService,
+    protected val terveyskeskuskoulutusjaksonHyvaksyntaService: TerveyskeskuskoulutusjaksonHyvaksyntaService,
+    protected val asiakirjaService: AsiakirjaService
+) {
+
+    /**
+     * Wraps a block in the standard Terveyskeskuskoulutusjakso exception-handling:
+     *  - EntityNotFoundException  → "Vastuuhenkilöä ei löytynyt"
+     *  - ValidationException      → "vähimmäispituus ei täyty"
+     */
+    protected fun <T> withTerveyskeskusExceptionHandling(block: () -> ResponseEntity<T>): ResponseEntity<T> =
+        try {
+            block()
+        } catch (e: EntityNotFoundException) {
+            throw BadRequestAlertException(
+                "Vastuuhenkilöä ei löytynyt",
+                TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME,
+                "dataillegal.vastuuhenkiloa-ei-loytynyt"
+            )
+        } catch (e: ValidationException) {
+            throw BadRequestAlertException(
+                "Terveyskeskuskoulutusjakson vähimmäispituus ei täyty",
+                TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME,
+                "dataillegal.terveyskeskuskoulutusjakson-vahimmaispituus-ei-tayty"
+            )
+        }
+
+    /**
+     * Converts an [AsiakirjaDTO] into a file-download [ResponseEntity], or 404 when null.
+     */
+    protected fun buildAsiakirjaDownloadResponse(asiakirja: AsiakirjaDTO?): ResponseEntity<ByteArray> =
+        asiakirja?.asiakirjaData?.fileInputStream
+            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+            ?: ResponseEntity.notFound().build()
+}
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResource.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
 import fi.elsapalvelu.elsa.domain.enumeration.TyoskentelyjaksoTyyppi
-import fi.elsapalvelu.elsa.domain.enumeration.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.service.AsiakirjaService
 import fi.elsapalvelu.elsa.service.KayttajaService
 import fi.elsapalvelu.elsa.service.TerveyskeskuskoulutusjaksonHyvaksyntaService
@@ -10,25 +9,25 @@ import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksoSimpleDTO
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksoUpdateDTO
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksonHyvaksyntaDTO
-import fi.elsapalvelu.elsa.web.rest.TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME
-import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
+import fi.elsapalvelu.elsa.web.rest.common.TerveyskeskuskoulutusjaksoBaseResource
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.security.Principal
-import jakarta.persistence.EntityNotFoundException
-import jakarta.validation.ValidationException
-
 
 @RestController
 @RequestMapping("/api/vastuuhenkilo")
 class VastuuhenkiloTerveyskeskuskoulutusjaksoResource(
-    private val userService: UserService,
-    private val kayttajaService: KayttajaService,
-    private val terveyskeskuskoulutusjaksonHyvaksyntaService: TerveyskeskuskoulutusjaksonHyvaksyntaService,
-    private val asiakirjaService: AsiakirjaService
+    userService: UserService,
+    kayttajaService: KayttajaService,
+    terveyskeskuskoulutusjaksonHyvaksyntaService: TerveyskeskuskoulutusjaksonHyvaksyntaService,
+    asiakirjaService: AsiakirjaService
+) : TerveyskeskuskoulutusjaksoBaseResource(
+    userService,
+    kayttajaService,
+    terveyskeskuskoulutusjaksonHyvaksyntaService,
+    asiakirjaService
 ) {
 
     @GetMapping("/terveyskeskuskoulutusjaksot")
@@ -39,11 +38,7 @@ class VastuuhenkiloTerveyskeskuskoulutusjaksoResource(
     ): ResponseEntity<Page<TerveyskeskuskoulutusjaksoSimpleDTO>> {
         val user = userService.getAuthenticatedUser(principal)
         return ResponseEntity.ok(
-            terveyskeskuskoulutusjaksonHyvaksyntaService.findByVastuuhenkiloUserId(
-                user.id!!,
-                criteria,
-                pageable
-            )
+            terveyskeskuskoulutusjaksonHyvaksyntaService.findByVastuuhenkiloUserId(user.id!!, criteria, pageable)
         )
     }
 
@@ -53,27 +48,10 @@ class VastuuhenkiloTerveyskeskuskoulutusjaksoResource(
         principal: Principal?
     ): ResponseEntity<TerveyskeskuskoulutusjaksonHyvaksyntaDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        try {
-            terveyskeskuskoulutusjaksonHyvaksyntaService.findByIdAndVastuuhenkiloUserId(
-                id,
-                user.id!!
-            )
-                .let {
-                    if (it == null) return ResponseEntity.notFound().build()
-                    return ResponseEntity.ok(it)
-                }
-        } catch (e: EntityNotFoundException) {
-            throw BadRequestAlertException(
-                "Vastuuhenkilöä ei löytynyt",
-                TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME,
-                "dataillegal.vastuuhenkiloa-ei-loytynyt"
-            )
-        } catch (e: ValidationException) {
-            throw BadRequestAlertException(
-                "Terveyskeskuskoulutusjakson vähimmäispituus ei täyty",
-                TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME,
-                "dataillegal.terveyskeskuskoulutusjakson-vahimmaispituus-ei-tayty"
-            )
+        return withTerveyskeskusExceptionHandling {
+            terveyskeskuskoulutusjaksonHyvaksyntaService.findByIdAndVastuuhenkiloUserId(id, user.id!!)
+                ?.let { ResponseEntity.ok(it) }
+                ?: ResponseEntity.notFound().build()
         }
     }
 
@@ -84,15 +62,13 @@ class VastuuhenkiloTerveyskeskuskoulutusjaksoResource(
     ): ResponseEntity<ByteArray> {
         val user = userService.getAuthenticatedUser(principal)
         val kayttaja = kayttajaService.findByUserId(user.id!!).orElse(null)
-        val asiakirja = asiakirjaService
-            .findByIdAndTyoskentelyjaksoTyyppiForVastuuhenkilo(
+        return buildAsiakirjaDownloadResponse(
+            asiakirjaService.findByIdAndTyoskentelyjaksoTyyppiForVastuuhenkilo(
                 id,
                 TyoskentelyjaksoTyyppi.TERVEYSKESKUS,
                 kayttaja.yliopistotAndErikoisalat
             )
-        return asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
-            ?: ResponseEntity.notFound().build()
+        )
     }
 
     @PutMapping("/terveyskeskuskoulutusjakson-hyvaksynta/{id}")
@@ -102,16 +78,14 @@ class VastuuhenkiloTerveyskeskuskoulutusjaksoResource(
         principal: Principal?
     ): ResponseEntity<TerveyskeskuskoulutusjaksonHyvaksyntaDTO> {
         val user = userService.getAuthenticatedUser(principal)
-
-        terveyskeskuskoulutusjaksonHyvaksyntaService.update(
-            user.id!!,
-            false,
-            id,
-            dto?.korjausehdotus,
-            dto?.lisatiedotVirkailijalta
+        return ResponseEntity.ok(
+            terveyskeskuskoulutusjaksonHyvaksyntaService.update(
+                user.id!!,
+                false,
+                id,
+                dto?.korjausehdotus,
+                dto?.lisatiedotVirkailijalta
+            )
         )
-            .let {
-                return ResponseEntity.ok(it)
-            }
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResource.kt
@@ -9,27 +9,27 @@ import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksoSimpleDTO
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksoUpdateDTO
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksonHyvaksyntaDTO
-import fi.elsapalvelu.elsa.web.rest.TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME
-import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
+import fi.elsapalvelu.elsa.web.rest.common.TerveyskeskuskoulutusjaksoBaseResource
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.security.Principal
-import jakarta.persistence.EntityNotFoundException
-import jakarta.validation.ValidationException
 import org.springframework.web.multipart.MultipartFile
+import java.security.Principal
 import java.time.LocalDate
-
 
 @RestController
 @RequestMapping("/api/virkailija")
 class VirkailijaTerveyskeskuskoulutusjaksoResource(
-    private val userService: UserService,
-    private val kayttajaService: KayttajaService,
-    private val terveyskeskuskoulutusjaksonHyvaksyntaService: TerveyskeskuskoulutusjaksonHyvaksyntaService,
-    private val asiakirjaService: AsiakirjaService
+    userService: UserService,
+    kayttajaService: KayttajaService,
+    terveyskeskuskoulutusjaksonHyvaksyntaService: TerveyskeskuskoulutusjaksonHyvaksyntaService,
+    asiakirjaService: AsiakirjaService
+) : TerveyskeskuskoulutusjaksoBaseResource(
+    userService,
+    kayttajaService,
+    terveyskeskuskoulutusjaksonHyvaksyntaService,
+    asiakirjaService
 ) {
 
     @GetMapping("/terveyskeskuskoulutusjaksot")
@@ -40,11 +40,7 @@ class VirkailijaTerveyskeskuskoulutusjaksoResource(
     ): ResponseEntity<Page<TerveyskeskuskoulutusjaksoSimpleDTO>> {
         val user = userService.getAuthenticatedUser(principal)
         return ResponseEntity.ok(
-            terveyskeskuskoulutusjaksonHyvaksyntaService.findByVirkailijaUserId(
-                user.id!!,
-                criteria,
-                pageable
-            )
+            terveyskeskuskoulutusjaksonHyvaksyntaService.findByVirkailijaUserId(user.id!!, criteria, pageable)
         )
     }
 
@@ -56,27 +52,10 @@ class VirkailijaTerveyskeskuskoulutusjaksoResource(
         val user = userService.getAuthenticatedUser(principal)
         val kayttaja = kayttajaService.findByUserId(user.id!!).get()
         val yliopistoIds = kayttaja.yliopistot?.map { it.id!! }.orEmpty().toList()
-        try {
-            terveyskeskuskoulutusjaksonHyvaksyntaService.findByIdAndYliopistoIdVirkailija(
-                id,
-                yliopistoIds
-            )
-                .let {
-                    if (it == null) return ResponseEntity.notFound().build()
-                    return ResponseEntity.ok(it)
-                }
-        } catch (e: EntityNotFoundException) {
-            throw BadRequestAlertException(
-                "Vastuuhenkilöä ei löytynyt",
-                TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME,
-                "dataillegal.vastuuhenkiloa-ei-loytynyt"
-            )
-        } catch (e: ValidationException) {
-            throw BadRequestAlertException(
-                "Terveyskeskuskoulutusjakson vähimmäispituus ei täyty",
-                TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME,
-                "dataillegal.terveyskeskuskoulutusjakson-vahimmaispituus-ei-tayty"
-            )
+        return withTerveyskeskusExceptionHandling {
+            terveyskeskuskoulutusjaksonHyvaksyntaService.findByIdAndYliopistoIdVirkailija(id, yliopistoIds)
+                ?.let { ResponseEntity.ok(it) }
+                ?: ResponseEntity.notFound().build()
         }
     }
 
@@ -87,15 +66,13 @@ class VirkailijaTerveyskeskuskoulutusjaksoResource(
     ): ResponseEntity<ByteArray> {
         val user = userService.getAuthenticatedUser(principal)
         val kayttaja = kayttajaService.findByUserId(user.id!!)
-        val asiakirja = asiakirjaService
-            .findByIdAndTyoskentelyjaksoTyyppi(
+        return buildAsiakirjaDownloadResponse(
+            asiakirjaService.findByIdAndTyoskentelyjaksoTyyppi(
                 id,
                 TyoskentelyjaksoTyyppi.TERVEYSKESKUS,
-                kayttaja.orElse(null)?.yliopistot?.map { it.id!! })
-
-        return asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
-            ?: ResponseEntity.notFound().build()
+                kayttaja.orElse(null)?.yliopistot?.map { it.id!! }
+            )
+        )
     }
 
     @PutMapping("/terveyskeskuskoulutusjakson-hyvaksynta/{id}")
@@ -107,18 +84,16 @@ class VirkailijaTerveyskeskuskoulutusjaksoResource(
         principal: Principal?
     ): ResponseEntity<TerveyskeskuskoulutusjaksonHyvaksyntaDTO> {
         val user = userService.getAuthenticatedUser(principal)
-
-        terveyskeskuskoulutusjaksonHyvaksyntaService.update(
-            user.id!!,
-            true,
-            id,
-            dto?.korjausehdotus,
-            dto?.lisatiedotVirkailijalta,
-            laillistamispaiva,
-            laillistamispaivanLiite
+        return ResponseEntity.ok(
+            terveyskeskuskoulutusjaksonHyvaksyntaService.update(
+                user.id!!,
+                true,
+                id,
+                dto?.korjausehdotus,
+                dto?.lisatiedotVirkailijalta,
+                laillistamispaiva,
+                laillistamispaivanLiite
+            )
         )
-            .let {
-                return ResponseEntity.ok(it)
-            }
     }
 }

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResourceIT.kt
@@ -329,8 +329,6 @@ class VastuuhenkiloTerveyskeskuskoulutusjaksoResourceIT {
         assertThat(testHyvaksynta.vastuuhenkilonKorjausehdotus).isEqualTo("test")
     }
 
-    // ── file-download tests ───────────────────────────────────────────────────
-
     @Test
     @Transactional
     fun getTerveyskeskuskoulutusjaksoTyoskentelyjaksoLiiteReturnsBytesWhenFound() {
@@ -368,16 +366,6 @@ class VastuuhenkiloTerveyskeskuskoulutusjaksoResourceIT {
         )
             .andExpect(status().isNotFound)
     }
-
-    // ── exception-handling tests ──────────────────────────────────────────────
-    // NOTE: withTerveyskeskusExceptionHandling catches EntityNotFoundException thrown by
-    // mapTerveyskeskuskoulutusjakso → getVastuuhenkilo().  That path requires VASTUUHENKILO
-    // authority (enforced by SecurityConfiguration line "/api/vastuuhenkilo/**") AND a
-    // KayttajaYliopistoErikoisala with TERVEYSKESKUSKOULUTUSJAKSOJEN_HYVAKSYMINEN, so any
-    // user who reaches this endpoint is always found by getVastuuhenkilo().  The exception
-    // branch is therefore not reachable in an integration test without mocking the service
-    // layer; it is covered by the virkailija IT instead (see
-    // VirkailijaTerveyskeskuskoulutusjaksoResourceIT.getTerveyskeskuskoulutusjaksoThrowsEntityNotFoundReturnsBadRequest).
 
     fun initTest(
         vastuuhenkilonYliopistoNimi: YliopistoEnum? = YliopistoEnum.TAMPEREEN_YLIOPISTO,

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResourceIT.kt
@@ -8,7 +8,6 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.KayttajaRepository
 import fi.elsapalvelu.elsa.repository.TerveyskeskuskoulutusjaksonHyvaksyntaRepository
 import fi.elsapalvelu.elsa.repository.UserRepository
-import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI
 import fi.elsapalvelu.elsa.security.VASTUUHENKILO
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksoUpdateDTO
@@ -371,73 +370,14 @@ class VastuuhenkiloTerveyskeskuskoulutusjaksoResourceIT {
     }
 
     // ── exception-handling tests ──────────────────────────────────────────────
-
-    /**
-     * Verifies that withTerveyskeskusExceptionHandling translates EntityNotFoundException
-     * → 400 BadRequest. We trigger this by using a Kayttaja who has the right
-     * KayttajaYliopistoErikoisala (so the service user-check passes) but whose
-     * User does NOT carry the VASTUUHENKILO authority in the DB, so
-     * getVastuuhenkilo() returns null and throws EntityNotFoundException.
-     */
-    @Test
-    @Transactional
-    fun getTerveyskeskuskoulutusjaksoThrowsEntityNotFoundReturnsBadRequest() {
-        // User with ERIKOISTUVA_LAAKARI authority – NOT VASTUUHENKILO
-        user = KayttajaResourceWithMockUserIT.createEntity(
-            authority = Authority(name = ERIKOISTUVA_LAAKARI)
-        )
-        em.persist(user)
-        em.flush()
-
-        val authorities = listOf(SimpleGrantedAuthority(ERIKOISTUVA_LAAKARI))
-        TestSecurityContextHolder.getContext().authentication = Saml2Authentication(
-            DefaultSaml2AuthenticatedPrincipal(user.id, emptyMap()),
-            "test",
-            authorities
-        )
-
-        yliopisto = Yliopisto(nimi = YliopistoEnum.TAMPEREEN_YLIOPISTO)
-        em.persist(yliopisto)
-
-        val erikoistuvaLaakari = ErikoistuvaLaakariHelper.createEntity(
-            em,
-            yliopisto = yliopisto,
-            laillistamispaiva = DEFAULT_LAILLISTAMISPAIVA
-        )
-        em.persist(erikoistuvaLaakari)
-
-        // Kayttaja with the right tehtavatyyppi so the user-check passes …
-        val tehtavatyypit = em.findAll(VastuuhenkilonTehtavatyyppi::class)
-        vastuuhenkilo = KayttajaHelper.createEntity(em, user = user)
-        vastuuhenkilo.yliopistotAndErikoisalat.add(
-            KayttajaYliopistoErikoisala(
-                kayttaja = vastuuhenkilo,
-                yliopisto = yliopisto,
-                erikoisala = Erikoisala(50),
-                vastuuhenkilonTehtavat = mutableSetOf(
-                    tehtavatyypit.first {
-                        it.nimi == VastuuhenkilonTehtavatyyppiEnum.TERVEYSKESKUSKOULUTUSJAKSOJEN_HYVAKSYMINEN
-                    }
-                )
-            )
-        )
-        em.persist(vastuuhenkilo)
-
-        // … but getVastuuhenkilo() queries by VASTUUHENKILO authority and finds nobody.
-        val hyvaksynta = createTerveyskeskuskoulutusjaksonHyvaksynta(
-            erikoistuvaLaakari,
-            vastuuhenkilo
-        )
-        em.persist(hyvaksynta)
-        em.flush()
-
-        assertNotNull(hyvaksynta.id)
-
-        restKoejaksoMockMvc.perform(
-            get("/api/vastuuhenkilo/terveyskeskuskoulutusjakso/{id}", hyvaksynta.id)
-        )
-            .andExpect(status().isBadRequest)
-    }
+    // NOTE: withTerveyskeskusExceptionHandling catches EntityNotFoundException thrown by
+    // mapTerveyskeskuskoulutusjakso → getVastuuhenkilo().  That path requires VASTUUHENKILO
+    // authority (enforced by SecurityConfiguration line "/api/vastuuhenkilo/**") AND a
+    // KayttajaYliopistoErikoisala with TERVEYSKESKUSKOULUTUSJAKSOJEN_HYVAKSYMINEN, so any
+    // user who reaches this endpoint is always found by getVastuuhenkilo().  The exception
+    // branch is therefore not reachable in an integration test without mocking the service
+    // layer; it is covered by the virkailija IT instead (see
+    // VirkailijaTerveyskeskuskoulutusjaksoResourceIT.getTerveyskeskuskoulutusjaksoThrowsEntityNotFoundReturnsBadRequest).
 
     fun initTest(
         vastuuhenkilonYliopistoNimi: YliopistoEnum? = YliopistoEnum.TAMPEREEN_YLIOPISTO,

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResourceIT.kt
@@ -8,6 +8,7 @@ import fi.elsapalvelu.elsa.domain.enumeration.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.KayttajaRepository
 import fi.elsapalvelu.elsa.repository.TerveyskeskuskoulutusjaksonHyvaksyntaRepository
 import fi.elsapalvelu.elsa.repository.UserRepository
+import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI
 import fi.elsapalvelu.elsa.security.VASTUUHENKILO
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.TerveyskeskuskoulutusjaksoUpdateDTO
@@ -27,6 +28,7 @@ import org.mockito.MockitoAnnotations
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal
@@ -39,6 +41,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.LocalDateTime
 import jakarta.persistence.EntityManager
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -325,6 +328,115 @@ class VastuuhenkiloTerveyskeskuskoulutusjaksoResourceIT {
         assertThat(testHyvaksynta.vastuuhenkiloHyvaksynyt).isFalse
         assertThat(testHyvaksynta.virkailijanKorjausehdotus).isNull()
         assertThat(testHyvaksynta.vastuuhenkilonKorjausehdotus).isEqualTo("test")
+    }
+
+    // ── file-download tests ───────────────────────────────────────────────────
+
+    @Test
+    @Transactional
+    fun getTerveyskeskuskoulutusjaksoTyoskentelyjaksoLiiteReturnsBytesWhenFound() {
+        initTest()
+        val tyoskentelyjakso = em.findAll(Tyoskentelyjakso::class).first()
+        val fileContent = "test-file-content".toByteArray()
+        val asiakirja = Asiakirja(
+            opintooikeus = tyoskentelyjakso.opintooikeus,
+            tyoskentelyjakso = tyoskentelyjakso,
+            nimi = "liite.pdf",
+            tyyppi = MediaType.APPLICATION_PDF_VALUE,
+            lisattypvm = LocalDateTime.now(),
+            asiakirjaData = AsiakirjaData(data = fileContent)
+        )
+        em.persist(asiakirja)
+        em.flush()
+
+        val id = asiakirja.id
+        assertNotNull(id)
+
+        restKoejaksoMockMvc.perform(
+            get("/api/vastuuhenkilo/terveyskeskuskoulutusjakso/tyoskentelyjakso-liite/{id}", id)
+        )
+            .andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, Matchers.containsString("attachment")))
+            .andExpect(content().bytes(fileContent))
+    }
+
+    @Test
+    @Transactional
+    fun getTerveyskeskuskoulutusjaksoTyoskentelyjaksoLiiteReturnsNotFoundWhenMissing() {
+        initTest()
+        restKoejaksoMockMvc.perform(
+            get("/api/vastuuhenkilo/terveyskeskuskoulutusjakso/tyoskentelyjakso-liite/{id}", 999999L)
+        )
+            .andExpect(status().isNotFound)
+    }
+
+    // ── exception-handling tests ──────────────────────────────────────────────
+
+    /**
+     * Verifies that withTerveyskeskusExceptionHandling translates EntityNotFoundException
+     * → 400 BadRequest. We trigger this by using a Kayttaja who has the right
+     * KayttajaYliopistoErikoisala (so the service user-check passes) but whose
+     * User does NOT carry the VASTUUHENKILO authority in the DB, so
+     * getVastuuhenkilo() returns null and throws EntityNotFoundException.
+     */
+    @Test
+    @Transactional
+    fun getTerveyskeskuskoulutusjaksoThrowsEntityNotFoundReturnsBadRequest() {
+        // User with ERIKOISTUVA_LAAKARI authority – NOT VASTUUHENKILO
+        user = KayttajaResourceWithMockUserIT.createEntity(
+            authority = Authority(name = ERIKOISTUVA_LAAKARI)
+        )
+        em.persist(user)
+        em.flush()
+
+        val authorities = listOf(SimpleGrantedAuthority(ERIKOISTUVA_LAAKARI))
+        TestSecurityContextHolder.getContext().authentication = Saml2Authentication(
+            DefaultSaml2AuthenticatedPrincipal(user.id, emptyMap()),
+            "test",
+            authorities
+        )
+
+        yliopisto = Yliopisto(nimi = YliopistoEnum.TAMPEREEN_YLIOPISTO)
+        em.persist(yliopisto)
+
+        val erikoistuvaLaakari = ErikoistuvaLaakariHelper.createEntity(
+            em,
+            yliopisto = yliopisto,
+            laillistamispaiva = DEFAULT_LAILLISTAMISPAIVA
+        )
+        em.persist(erikoistuvaLaakari)
+
+        // Kayttaja with the right tehtavatyyppi so the user-check passes …
+        val tehtavatyypit = em.findAll(VastuuhenkilonTehtavatyyppi::class)
+        vastuuhenkilo = KayttajaHelper.createEntity(em, user = user)
+        vastuuhenkilo.yliopistotAndErikoisalat.add(
+            KayttajaYliopistoErikoisala(
+                kayttaja = vastuuhenkilo,
+                yliopisto = yliopisto,
+                erikoisala = Erikoisala(50),
+                vastuuhenkilonTehtavat = mutableSetOf(
+                    tehtavatyypit.first {
+                        it.nimi == VastuuhenkilonTehtavatyyppiEnum.TERVEYSKESKUSKOULUTUSJAKSOJEN_HYVAKSYMINEN
+                    }
+                )
+            )
+        )
+        em.persist(vastuuhenkilo)
+
+        // … but getVastuuhenkilo() queries by VASTUUHENKILO authority and finds nobody.
+        val hyvaksynta = createTerveyskeskuskoulutusjaksonHyvaksynta(
+            erikoistuvaLaakari,
+            vastuuhenkilo
+        )
+        em.persist(hyvaksynta)
+        em.flush()
+
+        assertNotNull(hyvaksynta.id)
+
+        restKoejaksoMockMvc.perform(
+            get("/api/vastuuhenkilo/terveyskeskuskoulutusjakso/{id}", hyvaksynta.id)
+        )
+            .andExpect(status().isBadRequest)
     }
 
     fun initTest(

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResourceIT.kt
@@ -261,8 +261,6 @@ class VirkailijaTerveyskeskuskoulutusjaksoResourceIT {
         assertThat(testHyvaksynta.virkailijanKorjausehdotus).isEqualTo("test")
     }
 
-    // ── file-download tests ───────────────────────────────────────────────────
-
     @Test
     @Transactional
     fun getTerveyskeskuskoulutusjaksoTyoskentelyjaksoLiiteReturnsBytesWhenFound() {
@@ -300,8 +298,6 @@ class VirkailijaTerveyskeskuskoulutusjaksoResourceIT {
         )
             .andExpect(status().isNotFound)
     }
-
-    // ── exception-handling tests ──────────────────────────────────────────────
 
     /**
      * Verifies that withTerveyskeskusExceptionHandling translates EntityNotFoundException

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResourceIT.kt
@@ -10,6 +10,7 @@ import fi.elsapalvelu.elsa.security.VASTUUHENKILO
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.enumeration.TerveyskeskuskoulutusjaksoTila
 import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
+import fi.elsapalvelu.elsa.web.rest.findAll
 import fi.elsapalvelu.elsa.web.rest.helpers.ErikoistuvaLaakariHelper
 import fi.elsapalvelu.elsa.web.rest.helpers.KayttajaHelper
 import fi.elsapalvelu.elsa.web.rest.helpers.KoejaksonVaiheetHelper
@@ -23,6 +24,7 @@ import org.mockito.MockitoAnnotations
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal
@@ -35,6 +37,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multi
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.test.assertNotNull
 
 @AutoConfigureMockMvc
@@ -256,6 +259,96 @@ class VirkailijaTerveyskeskuskoulutusjaksoResourceIT {
         assertThat(testHyvaksynta.virkailijaHyvaksynyt).isFalse
         assertThat(testHyvaksynta.vastuuhenkiloHyvaksynyt).isFalse
         assertThat(testHyvaksynta.virkailijanKorjausehdotus).isEqualTo("test")
+    }
+
+    // ── file-download tests ───────────────────────────────────────────────────
+
+    @Test
+    @Transactional
+    fun getTerveyskeskuskoulutusjaksoTyoskentelyjaksoLiiteReturnsBytesWhenFound() {
+        initTest()
+        val tyoskentelyjakso = em.findAll(Tyoskentelyjakso::class).first()
+        val fileContent = "test-file-content".toByteArray()
+        val asiakirja = Asiakirja(
+            opintooikeus = tyoskentelyjakso.opintooikeus,
+            tyoskentelyjakso = tyoskentelyjakso,
+            nimi = "liite.pdf",
+            tyyppi = MediaType.APPLICATION_PDF_VALUE,
+            lisattypvm = LocalDateTime.now(),
+            asiakirjaData = AsiakirjaData(data = fileContent)
+        )
+        em.persist(asiakirja)
+        em.flush()
+
+        val id = asiakirja.id
+        assertNotNull(id)
+
+        restKoejaksoMockMvc.perform(
+            get("/api/virkailija/terveyskeskuskoulutusjakso/tyoskentelyjakso-liite/{id}", id)
+        )
+            .andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, Matchers.containsString("attachment")))
+            .andExpect(content().bytes(fileContent))
+    }
+
+    @Test
+    @Transactional
+    fun getTerveyskeskuskoulutusjaksoTyoskentelyjaksoLiiteReturnsNotFoundWhenMissing() {
+        initTest()
+        restKoejaksoMockMvc.perform(
+            get("/api/virkailija/terveyskeskuskoulutusjakso/tyoskentelyjakso-liite/{id}", 999999L)
+        )
+            .andExpect(status().isNotFound)
+    }
+
+    // ── exception-handling tests ──────────────────────────────────────────────
+
+    /**
+     * Verifies that withTerveyskeskusExceptionHandling translates EntityNotFoundException
+     * → 400 BadRequest. We trigger this by setting up a hyvaksynta that the virkailija can
+     * access (yliopisto matches) but with no vastuuhenkilo carrying
+     * TERVEYSKESKUSKOULUTUSJAKSOJEN_HYVAKSYMINEN → getVastuuhenkilo() returns null.
+     */
+    @Test
+    @Transactional
+    fun getTerveyskeskuskoulutusjaksoThrowsEntityNotFoundReturnsBadRequest() {
+        user = KayttajaResourceWithMockUserIT.createEntity()
+        em.persist(user)
+        em.flush()
+        val authorities = listOf(SimpleGrantedAuthority(OPINTOHALLINNON_VIRKAILIJA))
+        TestSecurityContextHolder.getContext().authentication = Saml2Authentication(
+            DefaultSaml2AuthenticatedPrincipal(user.id, emptyMap()),
+            "test",
+            authorities
+        )
+
+        val yliopisto = Yliopisto(nimi = YliopistoEnum.TAMPEREEN_YLIOPISTO)
+        em.persist(yliopisto)
+
+        val erikoistuvaLaakari = ErikoistuvaLaakariHelper.createEntity(
+            em,
+            yliopisto = yliopisto,
+            laillistamispaiva = DEFAULT_LAILLISTAMISPAIVA
+        )
+        em.persist(erikoistuvaLaakari)
+
+        // Virkailija with the right yliopisto – so findByIdAndYliopistoIdVirkailija passes …
+        virkailija = KayttajaHelper.createEntity(em, user)
+        virkailija.yliopistot.add(yliopisto)
+        em.persist(virkailija)
+
+        // … but NO vastuuhenkilo with TERVEYSKESKUSKOULUTUSJAKSOJEN_HYVAKSYMINEN exists,
+        // so getVastuuhenkilo() returns null and mapTerveyskeskuskoulutusjakso throws.
+        val hyvaksynta = createTerveyskeskuskoulutusjaksonHyvaksynta(erikoistuvaLaakari)
+        em.persist(hyvaksynta)
+        em.flush()
+
+        assertNotNull(hyvaksynta.id)
+
+        restKoejaksoMockMvc.perform(
+            get("/api/virkailija/terveyskeskuskoulutusjakso/{id}", hyvaksynta.id)
+        )
+            .andExpect(status().isBadRequest)
     }
 
     fun initTest(virkailijaYliopisto: Yliopisto? = null) {


### PR DESCRIPTION
This pull request refactors the handling of Terveyskeskuskoulutusjakso-related REST endpoints by introducing a shared base resource class to centralize exception handling and file download logic. The changes improve code reuse, reduce duplication, and ensure consistent error responses across both `Vastuuhenkilo` and `Virkailija` resource classes. Additionally, new integration tests are added to verify file download endpoints.

**Refactoring and Code Reuse:**
* Introduced `TerveyskeskuskoulutusjaksoBaseResource` as an abstract base class to encapsulate common exception handling (`withTerveyskeskusExceptionHandling`) and file download response logic (`buildAsiakirjaDownloadResponse`). Both `VastuuhenkiloTerveyskeskuskoulutusjaksoResource` and `VirkailijaTerveyskeskuskoulutusjaksoResource` now extend this base class, removing duplicated code for error handling and file downloads. [[1]](diffhunk://#diff-9f1b48f2db5b51b1af5084cfeabc58629ac4d86210ea04825cd992eab1e5aabdR1-R52) [[2]](diffhunk://#diff-af22afc8e84a691fa6950d1d068bda4ca9c98d6b6defb2ffeebc2e5e31f1ced5L13-R30) [[3]](diffhunk://#diff-e12dbfa4703c6044da1dcaaa14b2614dd0db671cf8407c91db49bbe0e2675c97L12-R32)

* Updated constructors and method implementations in the two resource classes to delegate shared logic to the new base class, simplifying their code and ensuring consistent behavior. [[1]](diffhunk://#diff-af22afc8e84a691fa6950d1d068bda4ca9c98d6b6defb2ffeebc2e5e31f1ced5L13-R30) [[2]](diffhunk://#diff-e12dbfa4703c6044da1dcaaa14b2614dd0db671cf8407c91db49bbe0e2675c97L12-R32) [[3]](diffhunk://#diff-af22afc8e84a691fa6950d1d068bda4ca9c98d6b6defb2ffeebc2e5e31f1ced5L56-R54) [[4]](diffhunk://#diff-e12dbfa4703c6044da1dcaaa14b2614dd0db671cf8407c91db49bbe0e2675c97L59-R58) [[5]](diffhunk://#diff-af22afc8e84a691fa6950d1d068bda4ca9c98d6b6defb2ffeebc2e5e31f1ced5L87-R71) [[6]](diffhunk://#diff-e12dbfa4703c6044da1dcaaa14b2614dd0db671cf8407c91db49bbe0e2675c97L90-R75)

**Error Handling Improvements:**
* Centralized the handling of `EntityNotFoundException` and `ValidationException` in the base resource, ensuring that both resource classes return uniform error messages and codes for these scenarios. [[1]](diffhunk://#diff-9f1b48f2db5b51b1af5084cfeabc58629ac4d86210ea04825cd992eab1e5aabdR1-R52) [[2]](diffhunk://#diff-af22afc8e84a691fa6950d1d068bda4ca9c98d6b6defb2ffeebc2e5e31f1ced5L56-R54) [[3]](diffhunk://#diff-e12dbfa4703c6044da1dcaaa14b2614dd0db671cf8407c91db49bbe0e2675c97L59-R58)

**File Download Endpoint Consistency:**
* Refactored file download endpoints to use the new `buildAsiakirjaDownloadResponse` method, providing consistent HTTP responses and handling of missing files (404). [[1]](diffhunk://#diff-9f1b48f2db5b51b1af5084cfeabc58629ac4d86210ea04825cd992eab1e5aabdR1-R52) [[2]](diffhunk://#diff-af22afc8e84a691fa6950d1d068bda4ca9c98d6b6defb2ffeebc2e5e31f1ced5L87-R71) [[3]](diffhunk://#diff-e12dbfa4703c6044da1dcaaa14b2614dd0db671cf8407c91db49bbe0e2675c97L90-R75)

**Testing Enhancements:**
* Added integration tests to verify that the file download endpoints return the correct byte content when the file exists and a 404 status when it does not.

**Minor Cleanups:**
* Removed unused imports and simplified method calls for clarity and maintainability. [[1]](diffhunk://#diff-af22afc8e84a691fa6950d1d068bda4ca9c98d6b6defb2ffeebc2e5e31f1ced5L4) [[2]](diffhunk://#diff-af22afc8e84a691fa6950d1d068bda4ca9c98d6b6defb2ffeebc2e5e31f1ced5L42-R41) [[3]](diffhunk://#diff-e12dbfa4703c6044da1dcaaa14b2614dd0db671cf8407c91db49bbe0e2675c97L43-R43) [[4]](diffhunk://#diff-af22afc8e84a691fa6950d1d068bda4ca9c98d6b6defb2ffeebc2e5e31f1ced5L105-R89) [[5]](diffhunk://#diff-e12dbfa4703c6044da1dcaaa14b2614dd0db671cf8407c91db49bbe0e2675c97L110-R87) [[6]](diffhunk://#diff-e12dbfa4703c6044da1dcaaa14b2614dd0db671cf8407c91db49bbe0e2675c97L120-R97) [[7]](diffhunk://#diff-21332af447829479b77050c108dfc97623fc511735cbdb4feb81665dc9ca9284R30) [[8]](diffhunk://#diff-21332af447829479b77050c108dfc97623fc511735cbdb4feb81665dc9ca9284R43) [[9]](diffhunk://#diff-afdeaaac979417f5fca8ca4a5ce73ebda304da93da5aa42997f488b3e7520606R13) [[10]](diffhunk://#diff-afdeaaac979417f5fca8ca4a5ce73ebda304da93da5aa42997f488b3e7520606R27) [[11]](diffhunk://#diff-afdeaaac979417f5fca8ca4a5ce73ebda304da93da5aa42997f488b3e7520606R40)