### PR TITLE
Enabled detekt UnusedImport rule

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -1,6 +1,8 @@
 style:
   MaxLineLength:
     maxLineLength: 180
+  UnusedImport:
+    active: true
   UnusedVariable:
     active: true
   UnusedPrivateProperty:

--- a/src/test/kotlin/fi/elsapalvelu/elsa/extensions/LocalDateExtensionsTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/extensions/LocalDateExtensionsTest.kt
@@ -1,9 +1,7 @@
 package fi.elsapalvelu.elsa.extensions
 
-import fi.elsapalvelu.elsa.ElsaBackendApp
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
 import java.time.LocalDate
 
 class LocalDateExtensionsTest {

--- a/src/test/kotlin/fi/elsapalvelu/elsa/extensions/LocalDateParseTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/extensions/LocalDateParseTest.kt
@@ -1,10 +1,8 @@
 package fi.elsapalvelu.elsa.extensions
 
-import fi.elsapalvelu.elsa.ElsaBackendApp
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.springframework.boot.test.context.SpringBootTest
 
 class LocalDateParseTest {
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/extensions/StringWildcardMatchTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/extensions/StringWildcardMatchTest.kt
@@ -1,10 +1,8 @@
 package fi.elsapalvelu.elsa.extensions
 
-import fi.elsapalvelu.elsa.ElsaBackendApp
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.springframework.boot.test.context.SpringBootTest
 
 class StringWildcardMatchTest {
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/arkistointi/tampere/TampereArkistointiExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/arkistointi/tampere/TampereArkistointiExternalIntegrationTests.kt
@@ -22,7 +22,6 @@ import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
 import fi.elsapalvelu.elsa.service.impl.kayttaja.AlertPublisherServiceImpl
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/OverlappingTyoskentelyjaksoValidationServiceTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/OverlappingTyoskentelyjaksoValidationServiceTest.kt
@@ -15,7 +15,6 @@ import fi.elsapalvelu.elsa.service.impl.tyoskentely.OverlappingTyoskentelyjaksoV
 import fi.elsapalvelu.elsa.service.impl.tyoskentely.TyoskentelyjaksonPituusCounterServiceImpl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.springframework.boot.test.context.SpringBootTest

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/common/KayttajaResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/common/KayttajaResourceIT.kt
@@ -34,15 +34,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal
-import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication
 import org.springframework.security.test.context.TestSecurityContextHolder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
-import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResourceIT.kt
@@ -13,7 +13,6 @@ import fi.elsapalvelu.elsa.web.rest.helpers.ErikoistuvaLaakariHelper
 import fi.elsapalvelu.elsa.web.rest.helpers.OpintooikeusHelper
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers
-import org.hibernate.engine.jdbc.BlobProxy
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoulutussuunnitelmaResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoulutussuunnitelmaResourceIT.kt
@@ -6,7 +6,6 @@ import fi.elsapalvelu.elsa.domain.kayttaja.User
 import fi.elsapalvelu.elsa.repository.koulutus.KoulutussuunnitelmaRepository
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI
 import fi.elsapalvelu.elsa.security.KOULUTTAJA
-import fi.elsapalvelu.elsa.service.mapper.koulutus.KoulutussuunnitelmaMapper
 import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
 import fi.elsapalvelu.elsa.web.rest.helpers.ErikoistuvaLaakariHelper
 import fi.elsapalvelu.elsa.web.rest.helpers.KoulutussuunnitelmaHelper
@@ -42,9 +41,7 @@ import org.mockito.MockitoAnnotations
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.http.MediaType
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal
@@ -56,7 +53,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.validation.Validator
 import jakarta.persistence.EntityManager
 import kotlin.test.assertNotNull
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSeurantakeskustelutResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSeurantakeskustelutResourceIT.kt
@@ -21,7 +21,6 @@ import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
 import fi.elsapalvelu.elsa.web.rest.convertObjectToJsonBytes
 import fi.elsapalvelu.elsa.web.rest.helpers.*
 import org.assertj.core.api.Assertions.assertThat
-import org.hamcrest.CoreMatchers.hasItem
 import org.hamcrest.collection.IsCollectionWithSize.hasSize
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/errors/ExceptionTranslatorTestController.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/errors/ExceptionTranslatorTestController.kt
@@ -6,13 +6,9 @@ import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import jakarta.validation.Valid
 import jakarta.validation.constraints.NotNull
 
 @RestController

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/ArvioitavanKokonaisuudenKategoriaHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/ArvioitavanKokonaisuudenKategoriaHelper.kt
@@ -3,8 +3,6 @@ package fi.elsapalvelu.elsa.web.rest.helpers
 import fi.elsapalvelu.elsa.domain.arviointi.ArvioitavanKokonaisuudenKategoria
 import fi.elsapalvelu.elsa.domain.perustiedot.Erikoisala
 import fi.elsapalvelu.elsa.web.rest.findAll
-import java.time.LocalDate
-import java.time.ZoneId
 import jakarta.persistence.EntityManager
 
 object ArvioitavanKokonaisuudenKategoriaHelper {

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaSeurantakeskustelutResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaSeurantakeskustelutResourceIT.kt
@@ -21,7 +21,6 @@ import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
 import fi.elsapalvelu.elsa.web.rest.convertObjectToJsonBytes
 import fi.elsapalvelu.elsa.web.rest.helpers.*
 import org.assertj.core.api.Assertions.assertThat
-import org.hamcrest.CoreMatchers.hasItem
 import org.hamcrest.collection.IsCollectionWithSize.hasSize
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloEtusivuResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloEtusivuResourceIT.kt
@@ -57,7 +57,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import jakarta.persistence.EntityManager
 
 @AutoConfigureMockMvc
 @SpringBootTest(classes = [ElsaBackendApp::class])


### PR DESCRIPTION
This pull request primarily cleans up the codebase by removing unused imports from various test files and updates the static analysis configuration to enforce better code quality. These changes help maintain a cleaner, more maintainable codebase and ensure that unnecessary dependencies are not included.

**Code quality improvements:**

* Enabled the `UnusedImport` rule in the `detekt-config.yml` file to automatically detect and flag unused imports in the codebase.

**Test code cleanup:**

* Removed unused import statements from multiple test files, including `LocalDateExtensionsTest.kt`, `LocalDateParseTest.kt`, `StringWildcardMatchTest.kt`, and several integration test files. This reduces clutter and potential confusion in the test code. [[1]](diffhunk://#diff-97c6e7b4dee4b85c8d1ddf9bb9c14bac49fe00049ce4d5e7bc0ace9be87b0c04L3-L6) [[2]](diffhunk://#diff-1b00dcfde37df8d6df0d5a6c9a889ffaed7c350cb730575b6694c8db09b62894L3-L7) [[3]](diffhunk://#diff-84539bea8de84df40b406a29dc1818040a17d366ebfef9f021a1a98939aa53beL3-L7) [[4]](diffhunk://#diff-ca2c401160341921f0e183081d1f897e0a56a42b5287eee6ef392b7e0b98f337L25) [[5]](diffhunk://#diff-415d079491b963a970b81e7b2073c0d496dcf2747e9cb64d9065acbf64310f5fL18) [[6]](diffhunk://#diff-5b7386564cfa6dbfded753d909225db05491336c8fbb99452afbf32aa99cbaedL37-L45) [[7]](diffhunk://#diff-377a2d7d3eb675c53f3f8aa9b8da4c04e1af4df0cb2029a9434457efbb422d3aL16) [[8]](diffhunk://#diff-1b848591213649a99191313e69a4fa44c01301bb3e98d48d69a9af86f1da6fb9L9) [[9]](diffhunk://#diff-1b848591213649a99191313e69a4fa44c01301bb3e98d48d69a9af86f1da6fb9L45-L47) [[10]](diffhunk://#diff-1b848591213649a99191313e69a4fa44c01301bb3e98d48d69a9af86f1da6fb9L59) [[11]](diffhunk://#diff-37e2a9de46072bc68ae339415bd3659198f46aaef123da532ccc33541a42de3cL24) [[12]](diffhunk://#diff-624346aaebbccbe3aa2dfcdd3f8b8d2ada79a1a5938ddd6c59e78decfbd83ffdL9-L15) [[13]](diffhunk://#diff-cc5a97a78adbfbe31e3cdf4e78df5c360b5ae8356fe473cce2a896b13be54d16L6-L7) [[14]](diffhunk://#diff-42d5fd6a5a9c742cc763969a4d423957ad3cf4f578b83b55810e2c770dc6724dL24) [[15]](diffhunk://#diff-6bae89f5ce70193d2de03c3452b27c66d46234fc3afe8cab2a003c39f4798838L60)