### PR TITLE
yek-tyoskentelyjakso e2e test

### DIFF
--- a/e2e/cypress/e2e/tyoskentelyjaksot-yek/yek-tyoskentelyjakso.cy.ts
+++ b/e2e/cypress/e2e/tyoskentelyjaksot-yek/yek-tyoskentelyjakso.cy.ts
@@ -28,7 +28,11 @@ describe('YEK työskentelyjakso', () => {
     Cypress.session.clearAllSavedSessions()
     cy.task('db:cleanupErikoistuva', { email: E2E_ERIKOISTUVA_EMAIL })
     cy.loginAsErikoistuva()
-    cy.task('db:seedOpintooikeus', { email: E2E_ERIKOISTUVA_EMAIL, opintoOikeus: yekOpintooikeus })
+    cy.task('db:seedOpintooikeus', {
+      email: E2E_ERIKOISTUVA_EMAIL,
+      opintoOikeus: yekOpintooikeus,
+      updateCurrent: true
+    })
     cy.logout()
   })
 
@@ -52,6 +56,26 @@ describe('YEK työskentelyjakso', () => {
       new URL(Cypress.config('baseUrl') as string).origin
     )
 
+    cy.request('/api/kayttaja').then(({ body }) => {
+      if (body.activeAuthority === 'ROLE_YEK_KOULUTETTAVA') {
+        return
+      }
+
+      cy.getCookie('XSRF-TOKEN').then((cookie) => {
+        cy.request({
+          method: 'POST',
+          url: '/api/vaihda-rooli',
+          form: true,
+          body: { rooli: 'ROLE_YEK_KOULUTETTAVA' },
+          headers: { 'X-XSRF-TOKEN': cookie?.value ?? '' }
+        })
+      })
+    })
+
+    cy.request('/api/kayttaja')
+      .its('body.activeAuthority')
+      .should('eq', 'ROLE_YEK_KOULUTETTAVA')
+
     cy.visit('/yektyoskentelyjaksot')
     cy.contains('h1', 'Työskentelyjaksot').should('be.visible')
 
@@ -68,6 +92,8 @@ describe('YEK työskentelyjakso', () => {
       .blur()
 
     cy.get('input[type="file"]').first().selectFile('cypress/fixtures/test.pdf', { force: true })
+
+    cy.get('input[type="radio"][name="laakarikoulutus"]').first().click({ force: true })
 
     cy.get('input[type="radio"][name="tyoskentelyjakso-tyyppi"]').first().click({ force: true })
 

--- a/e2e/cypress/e2e/tyoskentelyjaksot-yek/yek-tyoskentelyjakso.cy.ts
+++ b/e2e/cypress/e2e/tyoskentelyjaksot-yek/yek-tyoskentelyjakso.cy.ts
@@ -1,0 +1,151 @@
+import { E2E_ERIKOISTUVA_EMAIL } from '../../support/commands'
+import { OpintoOikeus } from '../../plugins/db-tasks/opintooikeus'
+
+export {}
+
+describe('YEK työskentelyjakso', () => {
+  const yekOpintooikeus: OpintoOikeus = {
+    asetus_id: 5,
+    erikoisala_id: 61,
+    erikoistuva_laakari_id: 0,
+    kaytossa: true,
+    muokkausaika: '2021-01-04',
+    muokkausoikeudet_virkailijoilla: true,
+    myontamispaiva: '2021-01-04',
+    opintoopas_id: 17,
+    opiskelijatunnus: '',
+    osaamisen_arvioinnin_oppaan_pvm: '2022-09-07',
+    paattymispaiva: '2029-05-05',
+    terveyskeskuskoulutusjakso_suoritettu: false,
+    yliopisto_opintooikeus_id: 'e2e-yek-tyoskentelyjakso',
+    tila: 'AKTIIVINEN',
+    viimeinen_katselupaiva: '2029-11-05',
+    yliopisto_id: 5,
+    id: 610507
+  }
+
+  before(() => {
+    Cypress.session.clearAllSavedSessions()
+    cy.task('db:cleanupErikoistuva', { email: E2E_ERIKOISTUVA_EMAIL })
+    cy.loginAsErikoistuva()
+    cy.task('db:seedOpintooikeus', { email: E2E_ERIKOISTUVA_EMAIL, opintoOikeus: yekOpintooikeus })
+    cy.logout()
+  })
+
+  it('käyttäjä lisää YEK-työskentelyjakson ja poissaolon', () => {
+    cy.visit('/kirjautuminen')
+    cy.contains('Kirjaudu sisään (Suomi.fi)').click()
+
+    cy.origin('https://testi.apro.tunnistus.fi', () => {
+      cy.get('body').then(($body) => {
+        const exists = $body.find('[name="_eventId_proceed"]').length > 0
+        if (exists) {
+          cy.get('[name="_eventId_proceed"]').click()
+        } else {
+          cy.get('#continue-button').click()
+        }
+      })
+    })
+
+    cy.location('origin', { timeout: 60000 }).should(
+      'eq',
+      new URL(Cypress.config('baseUrl') as string).origin
+    )
+
+    cy.visit('/yektyoskentelyjaksot')
+    cy.contains('h1', 'Työskentelyjaksot').should('be.visible')
+
+    cy.visit('/yektyoskentelyjaksot/uusi')
+    cy.get('.lisaa-tyoskentelyjakso').should('be.visible')
+    cy.get('[role="status"]', { timeout: 10000 }).should('not.exist')
+
+    cy.contains('label', 'Valviran laillistamispäivä')
+      .parent()
+      .find('input.date-input')
+      .first()
+      .clear()
+      .type('01.01.2020')
+      .blur()
+
+    cy.get('input[type="file"]').first().selectFile('cypress/fixtures/test.pdf', { force: true })
+
+    cy.get('input[type="radio"][name="tyoskentelyjakso-tyyppi"]').first().click({ force: true })
+
+    cy.contains('label', 'Työskentelypaikka')
+      .parent()
+      .find('input[type="text"]')
+      .first()
+      .clear()
+      .type('E2E YEK Testisairaala')
+
+    cy.contains('label', 'Kunta').parent().as('kuntaGroup')
+    cy.selectFirstMultiselectOption(cy.get('@kuntaGroup'))
+
+    cy.contains('label', 'Alkamispäivä')
+      .parent()
+      .find('input.date-input')
+      .first()
+      .clear()
+      .type('01.02.2025')
+      .blur()
+
+    cy.contains('label', 'Päättymispäivä')
+      .parent()
+      .find('input.date-input')
+      .first()
+      .clear()
+      .type('30.06.2027')
+      .blur()
+
+    cy.get('input[type="number"]').first().clear().type('100')
+
+    cy.intercept('POST', '**/yek-koulutettava/tyoskentelyjaksot').as('yekTyoskentelyjaksoPost')
+    cy.contains('button', 'Lisää').click()
+    cy.wait('@yekTyoskentelyjaksoPost', { timeout: 15000 }).then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body?.id).to.be.a('number')
+      Cypress.env('yekTyoskentelyjaksoId', response?.body?.id)
+    })
+
+    cy.url().should('match', /\/yektyoskentelyjaksot\/\d+$/)
+    cy.contains('E2E YEK Testisairaala').should('be.visible')
+
+    cy.contains('Lisää poissaolo').click()
+    cy.url().should('include', '/yektyoskentelyjaksot/poissaolot/uusi')
+    cy.get('[role="status"]', { timeout: 10000 }).should('not.exist')
+
+    cy.contains('label', 'Poissaolon syy').parent().as('poissaolonSyy')
+    cy.selectFirstMultiselectOption(cy.get('@poissaolonSyy'))
+
+    cy.contains('label', 'Alkamispäivä')
+      .parent()
+      .find('input.date-input')
+      .first()
+      .clear()
+      .type('15.02.2025')
+      .blur()
+
+    cy.contains('label', 'Päättymispäivä')
+      .parent()
+      .find('input.date-input')
+      .first()
+      .clear()
+      .type('28.02.2025')
+      .blur()
+
+    cy.intercept('POST', '**/yek-koulutettava/tyoskentelyjaksot/poissaolot').as('yekPoissaoloPost')
+    cy.contains('button', 'Tallenna').click()
+    cy.wait('@yekPoissaoloPost', { timeout: 15000 }).then(({ response }) => {
+      expect(response?.statusCode).to.eq(201)
+      expect(response?.body?.id).to.be.a('number')
+    })
+
+    cy.url().should('match', /\/yektyoskentelyjaksot\/poissaolot\/\d+$/)
+    cy.contains(/15\.2\.2025|15\.02\.2025/i).should('be.visible')
+    cy.contains(/28\.2\.2025|28\.02\.2025/i).should('be.visible')
+
+    cy.visit('/yektyoskentelyjaksot')
+    cy.contains('E2E YEK Testisairaala').should('be.visible')
+  })
+})
+

--- a/e2e/cypress/plugins/db-tasks/opintooikeus.ts
+++ b/e2e/cypress/plugins/db-tasks/opintooikeus.ts
@@ -27,9 +27,11 @@ export const opintoOikeusTasks = {
   async 'db:seedOpintooikeus'({
     email,
     opintoOikeus,
+    updateCurrent = false,
   }: {
     email: string
     opintoOikeus: OpintoOikeus
+    updateCurrent?: boolean
   }): Promise<number> {
     return withDb(dbClient, async (client: Client) => {
       if (!opintoOikeus) {
@@ -50,6 +52,60 @@ export const opintoOikeusTasks = {
       console.log(opintoOikeus)
 
       opintoOikeus.erikoistuva_laakari_id = erikoistuva
+      if (updateCurrent) {
+        const currentOpintooikeus = await client.query(
+          `SELECT id FROM public.opintooikeus WHERE erikoistuva_laakari_id = $1 AND kaytossa = true LIMIT 1`,
+          [erikoistuva]
+        )
+        const currentId: number | undefined = currentOpintooikeus.rows[0]?.id
+        if (!currentId) {
+          throw new Error(`Could not find active opintooikeus for ${email}`)
+        }
+
+        await client.query(
+          `UPDATE public.opintooikeus
+           SET opintooikeuden_myontamispaiva = $2,
+               opintooikeuden_paattymispaiva = $3,
+               opiskelijatunnus = $4,
+               osaamisen_arvioinnin_oppaan_pvm = $5,
+               yliopisto_id = $6,
+               erikoisala_id = $7,
+               opintoopas_id = $8,
+               asetus_id = $9,
+               kaytossa = $10,
+               yliopisto_opintooikeus_id = $11,
+               tila = $12,
+               muokkausaika = $13,
+               terveyskeskuskoulutusjakso_suoritettu = $14,
+               muokkausoikeudet_virkailijoilla = $15,
+               viimeinen_katselupaiva = $16
+           WHERE id = $1`,
+          [
+            currentId,
+            opintoOikeus.myontamispaiva,
+            opintoOikeus.paattymispaiva,
+            opintoOikeus.opiskelijatunnus,
+            opintoOikeus.osaamisen_arvioinnin_oppaan_pvm,
+            opintoOikeus.yliopisto_id,
+            opintoOikeus.erikoisala_id,
+            opintoOikeus.opintoopas_id,
+            opintoOikeus.asetus_id,
+            opintoOikeus.kaytossa,
+            opintoOikeus.yliopisto_opintooikeus_id,
+            opintoOikeus.tila,
+            opintoOikeus.muokkausaika,
+            opintoOikeus.terveyskeskuskoulutusjakso_suoritettu,
+            opintoOikeus.muokkausoikeudet_virkailijoilla,
+            opintoOikeus.viimeinen_katselupaiva
+          ]
+        )
+        await client.query(
+          `UPDATE public.erikoistuva_laakari SET aktiivinen_opintooikeus = $1 WHERE id = $2`,
+          [currentId, erikoistuva]
+        )
+        return currentId
+      }
+
       if ( opintoOikeus.kaytossa ) {
         await client.query(`UPDATE public.opintooikeus SET kaytossa = false WHERE erikoistuva_laakari_id = $1`, [erikoistuva])
       }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonKoulutussopimusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonKoulutussopimusServiceImpl.kt
@@ -220,7 +220,7 @@ class KoejaksonKoulutussopimusServiceImpl(
 
         val erikoisala = opintooikeus?.erikoisala!!
         val yek = erikoisala.id == YEK_ERIKOISALA_ID
-        val erikoistujanNimi = opintooikeus?.erikoistuvaLaakari?.kayttaja?.user?.getName()
+        val erikoistujanNimi = opintooikeus.erikoistuvaLaakari?.kayttaja?.user?.getName()
         logger.info("Lahetetaan arkistopyynto: ${result.zipFilePath}")
         arkistointiService.laheta(
             yliopisto = yliopisto,

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TyoskentelyjaksoResourceSupport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TyoskentelyjaksoResourceSupport.kt
@@ -1,0 +1,192 @@
+package fi.elsapalvelu.elsa.web.rest.common
+
+import fi.elsapalvelu.elsa.extensions.mapAsiakirja
+import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
+import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
+import fi.elsapalvelu.elsa.service.dto.kayttaja.UserDTO
+import fi.elsapalvelu.elsa.service.dto.tyoskentely.KeskeytysaikaDTO
+import fi.elsapalvelu.elsa.service.dto.tyoskentely.TyoskentelyjaksoDTO
+import fi.elsapalvelu.elsa.service.kayttaja.ErikoistuvaLaakariService
+import fi.elsapalvelu.elsa.service.kayttaja.FileValidationService
+import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
+import fi.elsapalvelu.elsa.service.tyoskentely.OverlappingTyoskentelyjaksoValidationService
+import fi.elsapalvelu.elsa.service.tyoskentely.TyoskentelyjaksoService
+import fi.elsapalvelu.elsa.web.rest.TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME
+import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
+import jakarta.validation.ValidationException
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import java.security.Principal
+import java.time.LocalDate
+
+private const val TYOSKENTELYJAKSO_ENTITY_NAME = "tyoskentelyjakso"
+private const val KESKEYTYSAIKA_ENTITY_NAME = "keskeytysaika"
+private const val ASIAKIRJA_ENTITY_NAME = "asiakirja"
+private const val TYOSKENTELYPAIKKA_ENTITY_NAME = "tyoskentelypaikka"
+
+@Suppress("TooManyFunctions")
+@Component
+class TyoskentelyjaksoResourceSupport(
+    private val fileValidationService: FileValidationService,
+    private val overlappingTyoskentelyjaksoValidationService: OverlappingTyoskentelyjaksoValidationService,
+    private val tyoskentelyjaksoService: TyoskentelyjaksoService,
+    private val opintooikeusService: OpintooikeusService,
+    private val erikoistuvaLaakariService: ErikoistuvaLaakariService
+) {
+
+    fun getMappedFiles(
+        files: List<MultipartFile>?,
+        opintooikeusId: Long
+    ): MutableSet<AsiakirjaDTO>? {
+        files?.let {
+            if (!fileValidationService.validate(it, opintooikeusId)) {
+                throw BadRequestAlertException(
+                    "Tiedosto ei ole kelvollinen tai samanniminen tiedosto on jo olemassa.",
+                    ASIAKIRJA_ENTITY_NAME,
+                    "dataillegal.tiedosto-ei-ole-kelvollinen-tai-samanniminen-tiedosto-on-jo-olemassa"
+                )
+            }
+            return it.map { file -> file.mapAsiakirja() }.toMutableSet()
+        }
+
+        return null
+    }
+
+    fun validateLaillistamispaivaAndTodistus(
+        user: UserDTO,
+        laillistamispaiva: LocalDate?,
+        laillistamistodistus: MultipartFile?
+    ) {
+        if ((laillistamispaiva == null || laillistamistodistus == null) &&
+            !erikoistuvaLaakariService.laillistamispaivaAndTodistusExists(user.id!!)
+        ) {
+            throw BadRequestAlertException(
+                "Laillistamispaiva ja todistus vaaditaan",
+                TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME,
+                "dataillegal.laillistamispaiva-ja-todistus-vaaditaan"
+            )
+        }
+    }
+
+    fun validateNewTyoskentelyjaksoDTO(tyoskentelyjaksoDTO: TyoskentelyjaksoDTO) {
+        if (tyoskentelyjaksoDTO.id != null) {
+            throw BadRequestAlertException(
+                "Uusi tyoskentelyjakso ei saa sisältää ID:tä",
+                TYOSKENTELYJAKSO_ENTITY_NAME,
+                "idexists"
+            )
+        }
+        if (tyoskentelyjaksoDTO.tyoskentelypaikka == null || tyoskentelyjaksoDTO.tyoskentelypaikka!!.id != null) {
+            throw BadRequestAlertException(
+                "Uusi tyoskentelypaikka ei saa sisältää ID:tä",
+                TYOSKENTELYPAIKKA_ENTITY_NAME,
+                "idexists"
+            )
+        }
+    }
+
+    fun validateTyoskentelyaika(opintooikeusId: Long, tyoskentelyjaksoDTO: TyoskentelyjaksoDTO) {
+        if (!overlappingTyoskentelyjaksoValidationService.validateTyoskentelyjakso(opintooikeusId, tyoskentelyjaksoDTO)) {
+            throwOverlappingTyoskentelyjaksotException()
+        }
+    }
+
+    fun validateAlkamisJaPaattymispaiva(opintooikeusId: Long, tyoskentelyjaksoDTO: TyoskentelyjaksoDTO) {
+        tyoskentelyjaksoDTO.paattymispaiva?.isBefore(tyoskentelyjaksoDTO.alkamispaiva)?.let {
+            if (it) {
+                throw BadRequestAlertException(
+                    "Työskentelyjakson päättymispäivä ei saa olla ennen alkamisaikaa",
+                    TYOSKENTELYPAIKKA_ENTITY_NAME,
+                    "dataillegal.tyoskentelyjakson-paattymispaiva-ei-saa-olla-ennen-alkamisaikaa"
+                )
+            }
+        }
+
+        if (!tyoskentelyjaksoService.validateAlkamisJaPaattymispaiva(tyoskentelyjaksoDTO, opintooikeusId)) {
+            throw BadRequestAlertException(
+                "Työskentelyjakson alkamis- tai päättymispäivä ei ole kelvollinen.",
+                TYOSKENTELYJAKSO_ENTITY_NAME,
+                "dataillegal.tyoskentelyjakson-paattymispaiva-ei-ole-kelvollinen"
+            )
+        }
+    }
+
+    fun validateKeskeytysaikaDTO(keskeytysaikaDTO: KeskeytysaikaDTO) {
+        if (keskeytysaikaDTO.alkamispaiva == null || keskeytysaikaDTO.paattymispaiva == null) {
+            throw BadRequestAlertException(
+                "Keskeytysajan alkamis- ja päättymispäivä ovat pakollisia tietoja",
+                KESKEYTYSAIKA_ENTITY_NAME,
+                "dataillegal.keskeytysaika-alkamis-ja-paattymispaiva-ovat-pakollisia-tietoja"
+            )
+        }
+
+        if (keskeytysaikaDTO.alkamispaiva!!.isAfter(keskeytysaikaDTO.paattymispaiva)) {
+            throw BadRequestAlertException(
+                "Keskeytysajan päättymispäivä ei saa olla ennen alkamisaikaa",
+                KESKEYTYSAIKA_ENTITY_NAME,
+                "dataillegal.keskeytysajan-paattymispaiva-ei-saa-olla-ennen-alkamisaikaa"
+            )
+        }
+
+        if (keskeytysaikaDTO.alkamispaiva!!.isBefore(keskeytysaikaDTO.tyoskentelyjakso!!.alkamispaiva)) {
+            throw BadRequestAlertException(
+                "Keskeytysajan alkamispäivä ei voi olla ennen työskentelyjakson alkamispäivää",
+                KESKEYTYSAIKA_ENTITY_NAME,
+                "dataillegal.keskeytysajan-alkamispaiva-ei-voi-olla-ennen-tyoskentelyjakson-alkamispaivaa"
+            )
+        }
+
+        if (keskeytysaikaDTO.tyoskentelyjakso!!.paattymispaiva != null && keskeytysaikaDTO.paattymispaiva!!.isAfter(
+                keskeytysaikaDTO.tyoskentelyjakso!!.paattymispaiva
+            )
+        ) {
+            throw BadRequestAlertException(
+                "Keskeytysajan päättymispäivä ei voi olla työskentelyjakson päättymispäivän jälkeen",
+                KESKEYTYSAIKA_ENTITY_NAME,
+                "dataillegal.keskeytysajan-paattymispaiva-ei-voi-olla-tyoskentelyjakson-paattymispaivan-jalkeen"
+            )
+        }
+
+        if (keskeytysaikaDTO.tyoskentelyjakso == null) {
+            throw BadRequestAlertException(
+                "Keskeytysajan täytyy kohdistua työskentelyjaksoon",
+                KESKEYTYSAIKA_ENTITY_NAME,
+                "dataillegal.keskeytysajan-taytyy-kohdistua-tyoskentelyjaksoon"
+            )
+        }
+    }
+
+    fun validateMuokkausoikeudet(principal: Principal?, userId: String, entity: String, userDescription: String) {
+        if ((principal as Saml2Authentication).authorities.map(GrantedAuthority::getAuthority)
+                .contains(ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA)
+        ) {
+            val opintooikeus = opintooikeusService.findOneByKaytossaAndErikoistuvaLaakariKayttajaUserId(userId)
+            if (!opintooikeus.muokkausoikeudetVirkailijoilla) {
+                throw BadRequestAlertException(
+                    "Ei oikeuksia muokata $userDescription tietoja",
+                    entity,
+                    "dataillegal.ei-oikeuksia-muokata-erikoistujan-tietoja"
+                )
+            }
+        }
+    }
+
+    fun throwOverlappingTyoskentelyjaksotException() {
+        throw BadRequestAlertException(
+            "Päällekkäisten työskentelyjaksojen yhteenlaskettu työaika ei voi ylittää 100%:a",
+            TYOSKENTELYJAKSO_ENTITY_NAME,
+            "dataillegal.paallekkaisten-tyoskentelyjaksojen-yhteenlaskettu-aika-ylittyy"
+        )
+    }
+
+    fun liitettyTerveyskoulutusjaksoonException(e: ValidationException): BadRequestAlertException {
+        return BadRequestAlertException(
+            e.message ?: "Validaatiovirhe",
+            TYOSKENTELYJAKSO_ENTITY_NAME,
+            "dataillegal.terveyskeskuskoulutusjaksoon-liitettya-tyoskentelyjaksoa-ei-voi-paivittaa"
+        )
+    }
+}
+

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TyoskentelyjaksoResourceSupport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TyoskentelyjaksoResourceSupport.kt
@@ -26,7 +26,6 @@ private const val KESKEYTYSAIKA_ENTITY_NAME = "keskeytysaika"
 private const val ASIAKIRJA_ENTITY_NAME = "asiakirja"
 private const val TYOSKENTELYPAIKKA_ENTITY_NAME = "tyoskentelypaikka"
 
-@Suppress("TooManyFunctions")
 @Component
 class TyoskentelyjaksoResourceSupport(
     private val fileValidationService: FileValidationService,

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
@@ -46,7 +46,6 @@ private const val KESKEYTYSAIKA_ENTITY_NAME = "keskeytysaika"
 private const val ASIAKIRJA_ENTITY_NAME = "asiakirja"
 private const val TYOSKENTELYPAIKKA_ENTITY_NAME = "tyoskentelypaikka"
 
-@Suppress("TooManyFunctions")
 @RestController
 @RequestMapping("/api/erikoistuva-laakari")
 class ErikoistuvaLaakariTyoskentelyjaksoResource(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
@@ -3,8 +3,6 @@ package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
-import fi.elsapalvelu.elsa.extensions.mapAsiakirja
-import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*
@@ -27,6 +25,7 @@ import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.service.dto.enumeration.TerveyskeskuskoulutusjaksoTila
 import fi.elsapalvelu.elsa.web.rest.TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME
+import fi.elsapalvelu.elsa.web.rest.common.TyoskentelyjaksoResourceSupport
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.Valid
@@ -34,8 +33,6 @@ import jakarta.validation.ValidationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.GrantedAuthority
-import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
@@ -61,14 +58,14 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
     private val keskeytysaikaService: KeskeytysaikaService,
     private val asiakirjaService: AsiakirjaService,
     private val objectMapper: ObjectMapper,
-    private val fileValidationService: FileValidationService,
     private val overlappingTyoskentelyjaksoValidationService: OverlappingTyoskentelyjaksoValidationService,
     private val overlappingKeskeytysaikaValidationService: OverlappingKeskeytysaikaValidationService,
     private val opintooikeusService: OpintooikeusService,
     private val koulutusjaksoService: KoulutusjaksoService,
     private val erikoistuvaLaakariService: ErikoistuvaLaakariService,
     private val terveyskeskuskoulutusjaksonHyvaksyntaService: TerveyskeskuskoulutusjaksonHyvaksyntaService,
-    private val opintosuoritusService: OpintosuoritusService
+    private val opintosuoritusService: OpintosuoritusService,
+    private val tyoskentelyjaksoResourceSupport: TyoskentelyjaksoResourceSupport
 ) {
 
     @PostMapping("/tyoskentelyjaksot")
@@ -79,18 +76,18 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
     ): ResponseEntity<TyoskentelyjaksoDTO> {
         val user = userService.getAuthenticatedUser(principal)
 
-        validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "erikoistujan")
 
         tyoskentelyjaksoJson.let {
             objectMapper.readValue(it, TyoskentelyjaksoDTO::class.java)
         }?.let {
             val opintooikeusId =
                 opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
-            validateNewTyoskentelyjaksoDTO(it)
-            validateAlkamisJaPaattymispaiva(opintooikeusId, it)
-            validateTyoskentelyaika(opintooikeusId, it)
+            tyoskentelyjaksoResourceSupport.validateNewTyoskentelyjaksoDTO(it)
+            tyoskentelyjaksoResourceSupport.validateAlkamisJaPaattymispaiva(opintooikeusId, it)
+            tyoskentelyjaksoResourceSupport.validateTyoskentelyaika(opintooikeusId, it)
 
-            val asiakirjaDTOs = getMappedFiles(files, opintooikeusId) ?: mutableSetOf()
+            val asiakirjaDTOs = tyoskentelyjaksoResourceSupport.getMappedFiles(files, opintooikeusId) ?: mutableSetOf()
             tyoskentelyjaksoService.create(it, opintooikeusId, asiakirjaDTOs)?.let { result ->
                 return ResponseEntity
                     .created(URI("/api/tyoskentelyjaksot/${result.id}"))
@@ -112,7 +109,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
 
-        validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "erikoistujan")
 
         tyoskentelyjaksoJson.let {
             objectMapper.readValue(it, TyoskentelyjaksoDTO::class.java)
@@ -124,10 +121,10 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
                     "idnull"
                 )
             }
-            validateAlkamisJaPaattymispaiva(opintooikeusId, it)
-            validateTyoskentelyaika(opintooikeusId, it)
+            tyoskentelyjaksoResourceSupport.validateAlkamisJaPaattymispaiva(opintooikeusId, it)
+            tyoskentelyjaksoResourceSupport.validateTyoskentelyaika(opintooikeusId, it)
 
-            val newAsiakirjat = getMappedFiles(files, opintooikeusId) ?: mutableSetOf()
+            val newAsiakirjat = tyoskentelyjaksoResourceSupport.getMappedFiles(files, opintooikeusId) ?: mutableSetOf()
             val deletedAsiakirjaIds = deletedAsiakirjaIdsJson?.let { id ->
                 objectMapper.readValue(id, mutableSetOf<Int>()::class.java)
             }
@@ -142,7 +139,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
                         return ResponseEntity.ok(result)
                     }
             } catch (e: ValidationException) {
-                throw liitettyTerveyskoulutusjaksoonException(e)
+                throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
             }
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -241,18 +238,18 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
 
-        validateMuokkausoikeudet(principal, user.id!!, ASIAKIRJA_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, ASIAKIRJA_ENTITY_NAME, "erikoistujan")
 
         try {
             tyoskentelyjaksoService.updateAsiakirjat(
                 id,
-                getMappedFiles(addedFiles, opintooikeusId),
+                tyoskentelyjaksoResourceSupport.getMappedFiles(addedFiles, opintooikeusId),
                 deletedFiles?.toSet()
             )?.let {
                 return ResponseEntity.ok(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         } catch (e: ValidationException) {
-            throw liitettyTerveyskoulutusjaksoonException(e)
+            throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
         }
     }
 
@@ -263,7 +260,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
     ): ResponseEntity<Void> {
         val user = userService.getAuthenticatedUser(principal)
 
-        validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "erikoistujan")
 
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
@@ -332,8 +329,8 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
 
         val user = userService.getAuthenticatedUser(principal)
 
-        validateKeskeytysaikaDTO(keskeytysaikaDTO)
-        validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateKeskeytysaikaDTO(keskeytysaikaDTO)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME, "erikoistujan")
 
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
@@ -356,7 +353,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
                     .body(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         } catch (e: ValidationException) {
-            throw liitettyTerveyskoulutusjaksoonException(e)
+            throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
         }
     }
 
@@ -375,8 +372,8 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
 
         val user = userService.getAuthenticatedUser(principal)
 
-        validateKeskeytysaikaDTO(keskeytysaikaDTO)
-        validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateKeskeytysaikaDTO(keskeytysaikaDTO)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME, "erikoistujan")
 
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
@@ -397,7 +394,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
                 keskeytysaikaDTO
             )
         ) {
-            throwOverlappingTyoskentelyjaksotException()
+            tyoskentelyjaksoResourceSupport.throwOverlappingTyoskentelyjaksotException()
         }
 
         try {
@@ -405,7 +402,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
                 return ResponseEntity.ok(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         } catch (e: ValidationException) {
-            throw liitettyTerveyskoulutusjaksoonException(e)
+            throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
         }
     }
 
@@ -429,7 +426,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
     ): ResponseEntity<Void> {
         val user = userService.getAuthenticatedUser(principal)
 
-        validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME, "erikoistujan")
 
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
@@ -438,13 +435,13 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
                 id
             )
         ) {
-            throwOverlappingTyoskentelyjaksotException()
+            tyoskentelyjaksoResourceSupport.throwOverlappingTyoskentelyjaksotException()
         }
 
         try {
             keskeytysaikaService.delete(id, opintooikeusId)
         } catch (e: ValidationException) {
-            throw liitettyTerveyskoulutusjaksoonException(e)
+            throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
         }
         return ResponseEntity
             .noContent()
@@ -543,7 +540,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
             )
         }
 
-        validateLaillistamispaivaAndTodistus(user, laillistamispaiva, laillistamispaivanLiite)
+        tyoskentelyjaksoResourceSupport.validateLaillistamispaivaAndTodistus(user, laillistamispaiva, laillistamispaivanLiite)
         if (terveyskeskuskoulutusjaksonHyvaksyntaService.existsByOpintooikeusId(opintooikeusId)) {
             throw BadRequestAlertException(
                 "Terveyskeskuskoulutusjakson hyväksyntä on jo lähetetty",
@@ -604,118 +601,5 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
             }
     }
 
-    private fun getMappedFiles(
-        files: List<MultipartFile>?,
-        opintooikeusId: Long
-    ): MutableSet<AsiakirjaDTO>? {
-        files?.let {
-            if (!fileValidationService.validate(it, opintooikeusId)) {
-                throw BadRequestAlertException(
-                    "Tiedosto ei ole kelvollinen tai samanniminen tiedosto on jo olemassa.",
-                    ASIAKIRJA_ENTITY_NAME,
-                    "dataillegal.tiedosto-ei-ole-kelvollinen-tai-samanniminen-tiedosto-on-jo-olemassa"
-                )
-            }
-            return it.map { file -> file.mapAsiakirja() }.toMutableSet()
-        }
-
-        return null
-    }
-
-    private fun validateLaillistamispaivaAndTodistus(user: UserDTO, laillistamispaiva: LocalDate?, laillistamistodistus: MultipartFile?) {
-        if ((laillistamispaiva == null || laillistamistodistus == null) &&
-            !erikoistuvaLaakariService.laillistamispaivaAndTodistusExists(
-                user.id!!
-            )
-        ) {
-            throw BadRequestAlertException(
-                "Laillistamispaiva ja todistus vaaditaan",
-                TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME,
-                "dataillegal.laillistamispaiva-ja-todistus-vaaditaan"
-            )
-        }
-    }
-
-    private fun validateNewTyoskentelyjaksoDTO(it: TyoskentelyjaksoDTO) {
-        if (it.id != null) {
-            throw BadRequestAlertException("Uusi tyoskentelyjakso ei saa sisältää ID:tä", TYOSKENTELYJAKSO_ENTITY_NAME, "idexists")
-        }
-        if (it.tyoskentelypaikka == null || it.tyoskentelypaikka!!.id != null) {
-            throw BadRequestAlertException("Uusi tyoskentelypaikka ei saa sisältää ID:tä", TYOSKENTELYPAIKKA_ENTITY_NAME, "idexists")
-        }
-    }
-
-    private fun validateTyoskentelyaika(opintooikeusId: Long, tyoskentelyjaksoDTO: TyoskentelyjaksoDTO) {
-        if (!overlappingTyoskentelyjaksoValidationService.validateTyoskentelyjakso(opintooikeusId, tyoskentelyjaksoDTO)) {
-            throwOverlappingTyoskentelyjaksotException()
-        }
-    }
-
-    private fun validateAlkamisJaPaattymispaiva(opintooikeusId: Long, tyoskentelyjaksoDTO: TyoskentelyjaksoDTO) {
-        tyoskentelyjaksoDTO.paattymispaiva?.isBefore(tyoskentelyjaksoDTO.alkamispaiva)?.let {
-            if (it) {
-                throw BadRequestAlertException("Työskentelyjakson päättymispäivä ei saa olla ennen alkamisaikaa",
-                    TYOSKENTELYPAIKKA_ENTITY_NAME, "dataillegal.tyoskentelyjakson-paattymispaiva-ei-saa-olla-ennen-alkamisaikaa")
-            }
-        }
-
-        if (!tyoskentelyjaksoService.validateAlkamisJaPaattymispaiva(tyoskentelyjaksoDTO, opintooikeusId)
-        ) {
-            throw BadRequestAlertException("Työskentelyjakson alkamis- tai päättymispäivä ei ole kelvollinen.",
-                TYOSKENTELYJAKSO_ENTITY_NAME, "dataillegal.tyoskentelyjakson-paattymispaiva-ei-ole-kelvollinen")
-        }
-    }
-
-    private fun validateKeskeytysaikaDTO(keskeytysaikaDTO: KeskeytysaikaDTO) {
-        if (keskeytysaikaDTO.alkamispaiva == null || keskeytysaikaDTO.paattymispaiva == null) {
-            throw BadRequestAlertException("Keskeytysajan alkamis- ja päättymispäivä ovat pakollisia tietoja",
-                KESKEYTYSAIKA_ENTITY_NAME, "dataillegal.keskeytysaika-alkamis-ja-paattymispaiva-ovat-pakollisia-tietoja")
-        }
-
-        if (keskeytysaikaDTO.alkamispaiva!!.isAfter(keskeytysaikaDTO.paattymispaiva)) {
-            throw BadRequestAlertException("Keskeytysajan päättymispäivä ei saa olla ennen alkamisaikaa",
-                KESKEYTYSAIKA_ENTITY_NAME, "dataillegal.keskeytysajan-paattymispaiva-ei-saa-olla-ennen-alkamisaikaa")
-        }
-
-        if (keskeytysaikaDTO.alkamispaiva!!.isBefore(keskeytysaikaDTO.tyoskentelyjakso!!.alkamispaiva)) {
-            throw BadRequestAlertException("Keskeytysajan alkamispäivä ei voi olla ennen työskentelyjakson alkamispäivää",
-                KESKEYTYSAIKA_ENTITY_NAME, "dataillegal.keskeytysajan-alkamispaiva-ei-voi-olla-ennen-tyoskentelyjakson-alkamispaivaa")
-        }
-
-        if (keskeytysaikaDTO.tyoskentelyjakso!!.paattymispaiva != null && keskeytysaikaDTO.paattymispaiva!!.isAfter(
-                keskeytysaikaDTO.tyoskentelyjakso!!.paattymispaiva)
-        ) {
-            throw BadRequestAlertException(
-                "Keskeytysajan päättymispäivä ei voi olla työskentelyjakson päättymispäivän jälkeen",
-                KESKEYTYSAIKA_ENTITY_NAME, "dataillegal.keskeytysajan-paattymispaiva-ei-voi-olla-tyoskentelyjakson-paattymispaivan-jalkeen")
-        }
-
-        if (keskeytysaikaDTO.tyoskentelyjakso == null) {
-            throw BadRequestAlertException("Keskeytysajan täytyy kohdistua työskentelyjaksoon",
-                KESKEYTYSAIKA_ENTITY_NAME, "dataillegal.keskeytysajan-taytyy-kohdistua-tyoskentelyjaksoon")
-        }
-    }
-
-    private fun validateMuokkausoikeudet(principal: Principal?, userId: String, entity: String) {
-        if ((principal as Saml2Authentication).authorities.map(GrantedAuthority::getAuthority)
-                .contains(ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA)
-        ) {
-            val opintooikeus = opintooikeusService.findOneByKaytossaAndErikoistuvaLaakariKayttajaUserId(userId)
-            if (!opintooikeus.muokkausoikeudetVirkailijoilla) {
-                throw BadRequestAlertException("Ei oikeuksia muokata erikoistujan tietoja",
-                    entity, "dataillegal.ei-oikeuksia-muokata-erikoistujan-tietoja")
-            }
-        }
-    }
-
-    private fun throwOverlappingTyoskentelyjaksotException() {
-        throw BadRequestAlertException("Päällekkäisten työskentelyjaksojen yhteenlaskettu työaika ei voi ylittää 100%:a", TYOSKENTELYJAKSO_ENTITY_NAME,
-            "dataillegal.paallekkaisten-tyoskentelyjaksojen-yhteenlaskettu-aika-ylittyy")
-    }
-
-    private fun liitettyTerveyskoulutusjaksoonException(e: ValidationException): BadRequestAlertException {
-        return BadRequestAlertException(e.message ?: "Validaatiovirhe", TYOSKENTELYJAKSO_ENTITY_NAME,
-            "dataillegal.terveyskeskuskoulutusjaksoon-liitettya-tyoskentelyjaksoa-ei-voi-paivittaa")
-    }
 
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResource.kt
@@ -45,7 +45,6 @@ private const val KESKEYTYSAIKA_ENTITY_NAME = "keskeytysaika"
 private const val ASIAKIRJA_ENTITY_NAME = "asiakirja"
 private const val TYOSKENTELYPAIKKA_ENTITY_NAME = "tyoskentelypaikka"
 
-@Suppress("TooManyFunctions")
 @RestController
 @RequestMapping("/api/yek-koulutettava")
 class YekKoulutettavaTyoskentelyjaksoResource(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResource.kt
@@ -3,8 +3,6 @@ package fi.elsapalvelu.elsa.web.rest.yekkoulutettava
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
-import fi.elsapalvelu.elsa.extensions.mapAsiakirja
-import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*
@@ -27,6 +25,7 @@ import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.service.dto.enumeration.TerveyskeskuskoulutusjaksoTila
 import fi.elsapalvelu.elsa.web.rest.TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME
+import fi.elsapalvelu.elsa.web.rest.common.TyoskentelyjaksoResourceSupport
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.Valid
@@ -34,8 +33,6 @@ import jakarta.validation.ValidationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.GrantedAuthority
-import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
@@ -60,14 +57,14 @@ class YekKoulutettavaTyoskentelyjaksoResource(
     private val keskeytysaikaService: KeskeytysaikaService,
     private val asiakirjaService: AsiakirjaService,
     private val objectMapper: ObjectMapper,
-    private val fileValidationService: FileValidationService,
     private val overlappingTyoskentelyjaksoValidationService: OverlappingTyoskentelyjaksoValidationService,
     private val overlappingKeskeytysaikaValidationService: OverlappingKeskeytysaikaValidationService,
     private val opintooikeusService: OpintooikeusService,
     private val koulutusjaksoService: KoulutusjaksoService,
     private val erikoistuvaLaakariService: ErikoistuvaLaakariService,
     private val terveyskeskuskoulutusjaksonHyvaksyntaService: TerveyskeskuskoulutusjaksonHyvaksyntaService,
-    private val opintosuoritusService: OpintosuoritusService
+    private val opintosuoritusService: OpintosuoritusService,
+    private val tyoskentelyjaksoResourceSupport: TyoskentelyjaksoResourceSupport
 ) {
 
     @PostMapping("/tyoskentelyjaksot")
@@ -78,7 +75,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
     ): ResponseEntity<TyoskentelyjaksoDTO> {
         val user = userService.getAuthenticatedUser(principal)
 
-        validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "yek koulutettavan")
 
         tyoskentelyjaksoJson.let {
             objectMapper.readValue(it, TyoskentelyjaksoDTO::class.java)
@@ -86,11 +83,11 @@ class YekKoulutettavaTyoskentelyjaksoResource(
             it.kaytannonKoulutus = KaytannonKoulutusTyyppi.OMAN_ERIKOISALAN_KOULUTUS
             val opintooikeusId =
                 opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(user.id!!, YEK_ERIKOISALA_ID)
-            validateNewTyoskentelyjaksoDTO(it)
-            validateAlkamisJaPaattymispaiva(opintooikeusId, it)
-            validateTyoskentelyaika(opintooikeusId, it)
+            tyoskentelyjaksoResourceSupport.validateNewTyoskentelyjaksoDTO(it)
+            tyoskentelyjaksoResourceSupport.validateAlkamisJaPaattymispaiva(opintooikeusId, it)
+            tyoskentelyjaksoResourceSupport.validateTyoskentelyaika(opintooikeusId, it)
 
-            val asiakirjaDTOs = getMappedFiles(files, opintooikeusId) ?: mutableSetOf()
+            val asiakirjaDTOs = tyoskentelyjaksoResourceSupport.getMappedFiles(files, opintooikeusId) ?: mutableSetOf()
             tyoskentelyjaksoService.create(it, opintooikeusId, asiakirjaDTOs)?.let { result ->
                 return ResponseEntity
                     .created(URI("/api/yektyoskentelyjaksot/${result.id}"))
@@ -113,7 +110,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(user.id!!, YEK_ERIKOISALA_ID)
 
-        validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "yek koulutettavan")
 
         tyoskentelyjaksoJson.let {
             objectMapper.readValue(it, TyoskentelyjaksoDTO::class.java)
@@ -125,10 +122,10 @@ class YekKoulutettavaTyoskentelyjaksoResource(
                     "idnull"
                 )
             }
-            validateAlkamisJaPaattymispaiva(opintooikeusId, it)
-            validateTyoskentelyaika(opintooikeusId, it)
+            tyoskentelyjaksoResourceSupport.validateAlkamisJaPaattymispaiva(opintooikeusId, it)
+            tyoskentelyjaksoResourceSupport.validateTyoskentelyaika(opintooikeusId, it)
 
-            val newAsiakirjat = getMappedFiles(files, opintooikeusId) ?: mutableSetOf()
+            val newAsiakirjat = tyoskentelyjaksoResourceSupport.getMappedFiles(files, opintooikeusId) ?: mutableSetOf()
             val deletedAsiakirjaIds = deletedAsiakirjaIdsJson?.let { id ->
                 objectMapper.readValue(id, mutableSetOf<Int>()::class.java)
             }
@@ -143,7 +140,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
                         return ResponseEntity.ok(result)
                     }
             } catch (e: ValidationException) {
-                throw liitettyTerveyskoulutusjaksoonException(e)
+                throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
             }
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -223,18 +220,18 @@ class YekKoulutettavaTyoskentelyjaksoResource(
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(user.id!!, YEK_ERIKOISALA_ID)
 
-        validateMuokkausoikeudet(principal, user.id!!, ASIAKIRJA_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, ASIAKIRJA_ENTITY_NAME, "yek koulutettavan")
 
         try {
             tyoskentelyjaksoService.updateAsiakirjat(
                 id,
-                getMappedFiles(addedFiles, opintooikeusId),
+                tyoskentelyjaksoResourceSupport.getMappedFiles(addedFiles, opintooikeusId),
                 deletedFiles?.toSet()
             )?.let {
                 return ResponseEntity.ok(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         } catch (e: ValidationException) {
-            throw liitettyTerveyskoulutusjaksoonException(e)
+            throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
         }
     }
 
@@ -245,7 +242,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
     ): ResponseEntity<Void> {
         val user = userService.getAuthenticatedUser(principal)
 
-        validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "yek koulutettavan")
 
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(user.id!!, YEK_ERIKOISALA_ID)
@@ -314,8 +311,8 @@ class YekKoulutettavaTyoskentelyjaksoResource(
 
         val user = userService.getAuthenticatedUser(principal)
 
-        validateKeskeytysaikaDTO(keskeytysaikaDTO)
-        validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateKeskeytysaikaDTO(keskeytysaikaDTO)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME, "yek koulutettavan")
 
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(user.id!!, YEK_ERIKOISALA_ID)
@@ -338,7 +335,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
                     .body(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         } catch (e: ValidationException) {
-            throw liitettyTerveyskoulutusjaksoonException(e)
+            throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
         }
     }
 
@@ -357,8 +354,8 @@ class YekKoulutettavaTyoskentelyjaksoResource(
 
         val user = userService.getAuthenticatedUser(principal)
 
-        validateKeskeytysaikaDTO(keskeytysaikaDTO)
-        validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateKeskeytysaikaDTO(keskeytysaikaDTO)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME, "yek koulutettavan")
 
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(user.id!!, YEK_ERIKOISALA_ID)
@@ -379,7 +376,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
                 keskeytysaikaDTO
             )
         ) {
-            throwOverlappingTyoskentelyjaksotException()
+            tyoskentelyjaksoResourceSupport.throwOverlappingTyoskentelyjaksotException()
         }
 
         try {
@@ -387,7 +384,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
                 return ResponseEntity.ok(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         } catch (e: ValidationException) {
-            throw liitettyTerveyskoulutusjaksoonException(e)
+            throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
         }
     }
 
@@ -411,7 +408,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
     ): ResponseEntity<Void> {
         val user = userService.getAuthenticatedUser(principal)
 
-        validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME)
+        tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME, "yek koulutettavan")
 
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(user.id!!, YEK_ERIKOISALA_ID)
@@ -420,13 +417,13 @@ class YekKoulutettavaTyoskentelyjaksoResource(
                 id
             )
         ) {
-            throwOverlappingTyoskentelyjaksotException()
+            tyoskentelyjaksoResourceSupport.throwOverlappingTyoskentelyjaksotException()
         }
 
         try {
             keskeytysaikaService.delete(id, opintooikeusId)
         } catch (e: ValidationException) {
-            throw liitettyTerveyskoulutusjaksoonException(e)
+            throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
         }
         return ResponseEntity
             .noContent()
@@ -516,7 +513,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
             )
         }
 
-        validateLaillistamispaivaAndTodistus(user, laillistamispaiva, laillistamispaivanLiite)
+        tyoskentelyjaksoResourceSupport.validateLaillistamispaivaAndTodistus(user, laillistamispaiva, laillistamispaivanLiite)
         if (terveyskeskuskoulutusjaksonHyvaksyntaService.existsByOpintooikeusId(opintooikeusId)) {
             throw BadRequestAlertException(
                 "Terveyskeskuskoulutusjakson hyväksyntä on jo lähetetty",
@@ -599,125 +596,5 @@ class YekKoulutettavaTyoskentelyjaksoResource(
         }
     }
 
-    private fun getMappedFiles(
-        files: List<MultipartFile>?,
-        opintooikeusId: Long
-    ): MutableSet<AsiakirjaDTO>? {
-        files?.let {
-            if (!fileValidationService.validate(it, opintooikeusId)) {
-                throw BadRequestAlertException(
-                    "Tiedosto ei ole kelvollinen tai samanniminen tiedosto on jo olemassa.",
-                    ASIAKIRJA_ENTITY_NAME,
-                    "dataillegal.tiedosto-ei-ole-kelvollinen-tai-samanniminen-tiedosto-on-jo-olemassa"
-                )
-            }
-            return it.map { file -> file.mapAsiakirja() }.toMutableSet()
-        }
-
-        return null
-    }
-
-    private fun validateLaillistamispaivaAndTodistus(user: UserDTO, laillistamispaiva: LocalDate?, laillistamistodistus: MultipartFile?) {
-        if ((laillistamispaiva == null || laillistamistodistus == null) &&
-            !erikoistuvaLaakariService.laillistamispaivaAndTodistusExists(
-                user.id!!
-            )
-        ) {
-            throw BadRequestAlertException(
-                "Laillistamispaiva ja todistus vaaditaan",
-                TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME,
-                "dataillegal.laillistamispaiva-ja-todistus-vaaditaan"
-            )
-        }
-    }
-
-    private fun validateNewTyoskentelyjaksoDTO(it: TyoskentelyjaksoDTO) {
-        if (it.id != null) {
-            throw BadRequestAlertException(
-                "Uusi tyoskentelyjakso ei saa sisältää ID:tä",
-                TYOSKENTELYJAKSO_ENTITY_NAME,
-                "idexists"
-            )
-        }
-        if (it.tyoskentelypaikka == null || it.tyoskentelypaikka!!.id != null) {
-            throw BadRequestAlertException(
-                "Uusi tyoskentelypaikka ei saa sisältää ID:tä",
-                TYOSKENTELYPAIKKA_ENTITY_NAME,
-                "idexists"
-            )
-        }
-    }
-
-    private fun validateTyoskentelyaika(opintooikeusId: Long, tyoskentelyjaksoDTO: TyoskentelyjaksoDTO) {
-        if (!overlappingTyoskentelyjaksoValidationService.validateTyoskentelyjakso(opintooikeusId, tyoskentelyjaksoDTO)) {
-            throwOverlappingTyoskentelyjaksotException()
-        }
-    }
-
-    private fun validateAlkamisJaPaattymispaiva(opintooikeusId: Long, tyoskentelyjaksoDTO: TyoskentelyjaksoDTO) {
-        tyoskentelyjaksoDTO.paattymispaiva?.isBefore(tyoskentelyjaksoDTO.alkamispaiva)?.let {
-            if (it) {
-                throw BadRequestAlertException("Työskentelyjakson päättymispäivä ei saa olla ennen alkamisaikaa", TYOSKENTELYPAIKKA_ENTITY_NAME,
-                    "dataillegal.tyoskentelyjakson-paattymispaiva-ei-saa-olla-ennen-alkamisaikaa")
-            }
-        }
-
-        if (!tyoskentelyjaksoService.validateAlkamisJaPaattymispaiva(tyoskentelyjaksoDTO, opintooikeusId)) {
-            throw BadRequestAlertException("Työskentelyjakson alkamis- tai päättymispäivä ei ole kelvollinen.", TYOSKENTELYJAKSO_ENTITY_NAME,
-                "dataillegal.tyoskentelyjakson-paattymispaiva-ei-ole-kelvollinen")
-        }
-    }
-
-    private fun validateKeskeytysaikaDTO(keskeytysaikaDTO: KeskeytysaikaDTO) {
-        if (keskeytysaikaDTO.alkamispaiva == null || keskeytysaikaDTO.paattymispaiva == null) {
-            throw BadRequestAlertException("Keskeytysajan alkamis- ja päättymispäivä ovat pakollisia tietoja", KESKEYTYSAIKA_ENTITY_NAME,
-                "dataillegal.keskeytysaika-alkamis-ja-paattymispaiva-ovat-pakollisia-tietoja")
-        }
-
-        if (keskeytysaikaDTO.alkamispaiva!!.isAfter(keskeytysaikaDTO.paattymispaiva)) {
-            throw BadRequestAlertException("Keskeytysajan päättymispäivä ei saa olla ennen alkamisaikaa", KESKEYTYSAIKA_ENTITY_NAME,
-                "dataillegal.keskeytysajan-paattymispaiva-ei-saa-olla-ennen-alkamisaikaa")
-        }
-
-        if (keskeytysaikaDTO.alkamispaiva!!.isBefore(keskeytysaikaDTO.tyoskentelyjakso!!.alkamispaiva)) {
-            throw BadRequestAlertException("Keskeytysajan alkamispäivä ei voi olla ennen työskentelyjakson alkamispäivää",
-                KESKEYTYSAIKA_ENTITY_NAME, "dataillegal.keskeytysajan-alkamispaiva-ei-voi-olla-ennen-tyoskentelyjakson-alkamispaivaa")
-        }
-
-        if (keskeytysaikaDTO.tyoskentelyjakso!!.paattymispaiva != null && keskeytysaikaDTO.paattymispaiva!!.isAfter(
-                keskeytysaikaDTO.tyoskentelyjakso!!.paattymispaiva
-            )
-        ) {
-            throw BadRequestAlertException(
-                "Keskeytysajan päättymispäivä ei voi olla työskentelyjakson päättymispäivän jälkeen", KESKEYTYSAIKA_ENTITY_NAME,
-                "dataillegal.keskeytysajan-paattymispaiva-ei-voi-olla-tyoskentelyjakson-paattymispaivan-jalkeen")
-        }
-
-        if (keskeytysaikaDTO.tyoskentelyjakso == null) {
-            throw BadRequestAlertException("Keskeytysajan täytyy kohdistua työskentelyjaksoon", KESKEYTYSAIKA_ENTITY_NAME,
-                "dataillegal.keskeytysajan-taytyy-kohdistua-tyoskentelyjaksoon"
-            )
-        }
-    }
-
-    private fun validateMuokkausoikeudet(principal: Principal?, userId: String, entity: String) {
-        if ((principal as Saml2Authentication).authorities.map(GrantedAuthority::getAuthority).contains(ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA)) {
-            val opintooikeus = opintooikeusService.findOneByKaytossaAndErikoistuvaLaakariKayttajaUserId(userId)
-            if (!opintooikeus.muokkausoikeudetVirkailijoilla) {
-                throw BadRequestAlertException("Ei oikeuksia muokata yek koulutettavan tietoja",
-                    entity, "dataillegal.ei-oikeuksia-muokata-erikoistujan-tietoja")
-            }
-        }
-    }
-
-    private fun throwOverlappingTyoskentelyjaksotException() {
-        throw BadRequestAlertException("Päällekkäisten työskentelyjaksojen yhteenlaskettu työaika ei voi ylittää 100%:a",
-            TYOSKENTELYJAKSO_ENTITY_NAME, "dataillegal.paallekkaisten-tyoskentelyjaksojen-yhteenlaskettu-aika-ylittyy")
-    }
-
-    private fun liitettyTerveyskoulutusjaksoonException(e: ValidationException): BadRequestAlertException {
-        return BadRequestAlertException(e.message ?: "Validaatiovirhe", TYOSKENTELYJAKSO_ENTITY_NAME,
-            "dataillegal.terveyskeskuskoulutusjaksoon-liitettya-tyoskentelyjaksoa-ei-voi-paivittaa")
-    }
 
 }


### PR DESCRIPTION
This pull request introduces a significant refactoring and cleanup of the validation logic for YEK (general medical training) work periods and absences, mainly by extracting validation and file handling responsibilities into a new support class. It also enhances the E2E test coverage for YEK work periods and absences. The most important changes are grouped below:

**Backend Refactoring and Validation Improvements:**

* A new class, `TyoskentelyjaksoResourceSupport`, was introduced to encapsulate all validation and file mapping logic related to work periods and absences, reducing duplication and improving maintainability. This includes methods for file validation, date checks, and permission validation.
* The `ErikoistuvaLaakariTyoskentelyjaksoResource` controller was refactored to delegate validation and file handling to the new support class, removing direct validation logic and related imports. This makes the controller slimmer and easier to test. [[1]](diffhunk://#diff-be8694d2d51ca8a492e1227a3c1e0dec3742b5712a33afaeb91f61edc9b1c2aeL6-L7) [[2]](diffhunk://#diff-be8694d2d51ca8a492e1227a3c1e0dec3742b5712a33afaeb91f61edc9b1c2aeR28-L38) [[3]](diffhunk://#diff-be8694d2d51ca8a492e1227a3c1e0dec3742b5712a33afaeb91f61edc9b1c2aeL52) [[4]](diffhunk://#diff-be8694d2d51ca8a492e1227a3c1e0dec3742b5712a33afaeb91f61edc9b1c2aeL64-R67) [[5]](diffhunk://#diff-be8694d2d51ca8a492e1227a3c1e0dec3742b5712a33afaeb91f61edc9b1c2aeL82-R89) [[6]](diffhunk://#diff-be8694d2d51ca8a492e1227a3c1e0dec3742b5712a33afaeb91f61edc9b1c2aeL115-R111)
* Minor bug fix in `KoejaksonKoulutussopimusServiceImpl.kt` to avoid unnecessary null checks when accessing the resident’s name.

**Testing Improvements:**

* A comprehensive E2E Cypress test was added for creating a YEK work period and associated absence, including file upload and all form interactions. This ensures the new validation logic and file handling work as intended.

**Database Seeding Utility Enhancement:**

* The `db:seedOpintooikeus` Cypress plugin task was enhanced with an `updateCurrent` flag, allowing tests to update the current active study right instead of always inserting a new one. This enables more robust and flexible test setups. [[1]](diffhunk://#diff-490bf1c4b16f4635a273bc334301bb3e777bea8b305f96b1c76d73ace6e65a80R30-R34) [[2]](diffhunk://#diff-490bf1c4b16f4635a273bc334301bb3e777bea8b305f96b1c76d73ace6e65a80R55-R108)