### PR TITLE
KoejaksoResourceSupport helper class

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KoejaksoResource.kt
@@ -20,7 +20,7 @@ import fi.elsapalvelu.elsa.service.dto.seuranta.*
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.*
 import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
-import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
+import fi.elsapalvelu.elsa.web.rest.common.KoejaksoResourceSupport
 import fi.elsapalvelu.elsa.web.rest.kouluttaja.*
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -37,7 +37,8 @@ open class KoejaksoResource(
     private val koejaksonAloituskeskusteluService: KoejaksonAloituskeskusteluService,
     private val koejaksonValiarviointiService: KoejaksonValiarviointiService,
     private val koejaksonKehittamistoimenpiteetService: KoejaksonKehittamistoimenpiteetService,
-    private val koejaksonLoppukeskusteluService: KoejaksonLoppukeskusteluService
+    private val koejaksonLoppukeskusteluService: KoejaksonLoppukeskusteluService,
+    private val koejaksoResourceSupport: KoejaksoResourceSupport
 ) {
 
     @PutMapping("/koejakso/aloituskeskustelu")
@@ -45,50 +46,30 @@ open class KoejaksoResource(
         @Valid @RequestBody aloituskeskusteluDTO: KoejaksonAloituskeskusteluDTO,
         principal: Principal?
     ): ResponseEntity<KoejaksonAloituskeskusteluDTO> {
-        validateId(aloituskeskusteluDTO.id, ENTITY_KOEJAKSON_ALOITUSKESKUSTELU)
+        koejaksoResourceSupport.validateId(aloituskeskusteluDTO.id, ENTITY_KOEJAKSON_ALOITUSKESKUSTELU)
         val user = userService.getAuthenticatedUser(principal)
 
-        var aloituskeskustelu =
-            koejaksonAloituskeskusteluService.findOneByIdAndLahikouluttajaUserId(
-                aloituskeskusteluDTO.id!!,
-                user.id!!
-            )
+        val aloituskeskustelu = koejaksoResourceSupport.findForUpdateByLahikouluttajaOrLahiesimies(
+            id = aloituskeskusteluDTO.id!!,
+            userId = user.id!!,
+            entity = ENTITY_KOEJAKSON_ALOITUSKESKUSTELU,
+            notFoundMessage = "Koejakson aloituskeskustelua ei löydy.",
+            notFoundErrorKey = "dataillegal.koejakson-aloituskeskustelua-ei-loydy",
+            lahiesimiesBeforeLahikouluttajaMessage = "Esihenkilö ei saa muokata aloituskeskustelua, " +
+                "jos kouluttaja ei ole hyväksynyt sitä",
+            lahiesimiesBeforeLahikouluttajaErrorKey = "dataillegal.esimies-ei-saa-muokata-aloituskeskustelua-jos-kouluttaja-ei-ole-hyvaksynyt-sita",
+            findByLahikouluttaja = koejaksonAloituskeskusteluService::findOneByIdAndLahikouluttajaUserId,
+            findByLahiesimies = koejaksonAloituskeskusteluService::findOneByIdAndLahiesimiesUserId,
+            lahikouluttajaSopimusHyvaksytty = { it.lahikouluttaja?.sopimusHyvaksytty }
+        )
 
-        if (!aloituskeskustelu.isPresent) {
-            aloituskeskustelu =
-                koejaksonAloituskeskusteluService.findOneByIdAndLahiesimiesUserId(
-                    aloituskeskusteluDTO.id!!,
-                    user.id!!
-                )
+        koejaksoResourceSupport.validateLahetetty(
+            aloituskeskustelu.lahetetty,
+            ENTITY_KOEJAKSON_ALOITUSKESKUSTELU
+        )
 
-            if (!aloituskeskustelu.isPresent) {
-                throw BadRequestAlertException(
-                    "Koejakson aloituskeskustelua ei löydy.",
-                    ENTITY_KOEJAKSON_ALOITUSKESKUSTELU,
-                    "dataillegal.koejakson-aloituskeskustelua-ei-loydy"
-                )
-            }
-
-            if (aloituskeskustelu.get().lahikouluttaja?.sopimusHyvaksytty != true) {
-                throw BadRequestAlertException(
-                    "Esihenkilö ei saa muokata aloituskeskustelua, " +
-                        "jos kouluttaja ei ole hyväksynyt sitä",
-                    ENTITY_KOEJAKSON_ALOITUSKESKUSTELU,
-                    "dataillegal.esimies-ei-saa-muokata-aloituskeskustelua-jos-kouluttaja-ei-ole-hyvaksynyt-sita"
-                )
-            }
-        }
-
-        if (aloituskeskustelu.get().lahetetty != true) {
-            throw BadRequestAlertException(
-                "Arviointia ei saa muokata, jos erikoistuva ei ole lähettänyt pyyntöä.",
-                ENTITY_KOEJAKSON_ALOITUSKESKUSTELU,
-                "dataillegal.arviointia-ei-saa-muokata-jos-erikoistuva-ei-ole-lahettanyt-pyyntoa"
-            )
-        }
-
-        validateArviointi(
-            aloituskeskustelu.get().lahiesimies?.sopimusHyvaksytty,
+        koejaksoResourceSupport.validateArviointi(
+            aloituskeskustelu.lahiesimies?.sopimusHyvaksytty,
             ENTITY_KOEJAKSON_ALOITUSKESKUSTELU
         )
 
@@ -101,42 +82,25 @@ open class KoejaksoResource(
         @Valid @RequestBody valiarviointiDTO: KoejaksonValiarviointiDTO,
         principal: Principal?
     ): ResponseEntity<KoejaksonValiarviointiDTO> {
-        validateId(valiarviointiDTO.id, ENTITY_KOEJAKSON_LOPPUKESKUSTELU)
+        koejaksoResourceSupport.validateId(valiarviointiDTO.id, ENTITY_KOEJAKSON_LOPPUKESKUSTELU)
         val user = userService.getAuthenticatedUser(principal)
 
-        var valiarviointi =
-            koejaksonValiarviointiService.findOneByIdAndLahikouluttajaUserId(
-                valiarviointiDTO.id!!,
-                user.id!!
-            )
+        val valiarviointi = koejaksoResourceSupport.findForUpdateByLahikouluttajaOrLahiesimies(
+            id = valiarviointiDTO.id!!,
+            userId = user.id!!,
+            entity = ENTITY_KOEJAKSON_VALIARVIOINTI,
+            notFoundMessage = "Koejakson väliarviointia ei löydy.",
+            notFoundErrorKey = "dataillegal.koejakson-valiarviointia-ei-loydy",
+            lahiesimiesBeforeLahikouluttajaMessage = "Esimies ei saa muokata väliarviointia, " +
+                "jos kouluttaja ei ole hyväksynyt sitä",
+            lahiesimiesBeforeLahikouluttajaErrorKey = "dataillegal.esimies-ei-saa-muoktata-valiarviointia-jos-kouluttaja-ei-ole-hyvaksynyt-sita",
+            findByLahikouluttaja = koejaksonValiarviointiService::findOneByIdAndLahikouluttajaUserId,
+            findByLahiesimies = koejaksonValiarviointiService::findOneByIdAndLahiesimiesUserId,
+            lahikouluttajaSopimusHyvaksytty = { it.lahikouluttaja?.sopimusHyvaksytty }
+        )
 
-        if (!valiarviointi.isPresent) {
-            valiarviointi =
-                koejaksonValiarviointiService.findOneByIdAndLahiesimiesUserId(
-                    valiarviointiDTO.id!!,
-                    user.id!!
-                )
-
-            if (!valiarviointi.isPresent) {
-                throw BadRequestAlertException(
-                    "Koejakson väliarviointia ei löydy.",
-                    ENTITY_KOEJAKSON_VALIARVIOINTI,
-                    "dataillegal.koejakson-valiarviointia-ei-loydy"
-                )
-            }
-
-            if (valiarviointi.get().lahikouluttaja?.sopimusHyvaksytty != true) {
-                throw BadRequestAlertException(
-                    "Esimies ei saa muokata väliarviointia, " +
-                        "jos kouluttaja ei ole hyväksynyt sitä",
-                    ENTITY_KOEJAKSON_VALIARVIOINTI,
-                    "dataillegal.esimies-ei-saa-muoktata-valiarviointia-jos-kouluttaja-ei-ole-hyvaksynyt-sita"
-                )
-            }
-        }
-
-        validateArviointi(
-            valiarviointi.get().lahiesimies?.sopimusHyvaksytty,
+        koejaksoResourceSupport.validateArviointi(
+            valiarviointi.lahiesimies?.sopimusHyvaksytty,
             ENTITY_KOEJAKSON_VALIARVIOINTI
         )
 
@@ -149,42 +113,25 @@ open class KoejaksoResource(
         @Valid @RequestBody kehittamistoimenpiteetDTO: KoejaksonKehittamistoimenpiteetDTO,
         principal: Principal?
     ): ResponseEntity<KoejaksonKehittamistoimenpiteetDTO> {
-        validateId(kehittamistoimenpiteetDTO.id, ENTITY_KOEJAKSON_KEHITTAMISTOIMENPITEET)
+        koejaksoResourceSupport.validateId(kehittamistoimenpiteetDTO.id, ENTITY_KOEJAKSON_KEHITTAMISTOIMENPITEET)
         val user = userService.getAuthenticatedUser(principal)
 
-        var kehittamistoimenpiteet =
-            koejaksonKehittamistoimenpiteetService.findOneByIdAndLahikouluttajaUserId(
-                kehittamistoimenpiteetDTO.id!!,
-                user.id!!
-            )
+        val kehittamistoimenpiteet = koejaksoResourceSupport.findForUpdateByLahikouluttajaOrLahiesimies(
+            id = kehittamistoimenpiteetDTO.id!!,
+            userId = user.id!!,
+            entity = ENTITY_KOEJAKSON_KEHITTAMISTOIMENPITEET,
+            notFoundMessage = "Koejakson kehittämistoimenpiteitä ei löydy.",
+            notFoundErrorKey = "dataillegal.koejakson-kehittamistoimenpiteita-ei-loydy",
+            lahiesimiesBeforeLahikouluttajaMessage = "Esimies ei saa muokata kehittämistoimenpiteitä, " +
+                "jos kouluttaja ei ole hyväksynyt niitä",
+            lahiesimiesBeforeLahikouluttajaErrorKey = "dataillegal.esimies-ei-saa-muokata-kehittamistoimenpiteita-jos-kouluttaja-ei-ole-hyvaksynyt-niita",
+            findByLahikouluttaja = koejaksonKehittamistoimenpiteetService::findOneByIdAndLahikouluttajaUserId,
+            findByLahiesimies = koejaksonKehittamistoimenpiteetService::findOneByIdAndLahiesimiesUserId,
+            lahikouluttajaSopimusHyvaksytty = { it.lahikouluttaja?.sopimusHyvaksytty }
+        )
 
-        if (!kehittamistoimenpiteet.isPresent) {
-            kehittamistoimenpiteet =
-                koejaksonKehittamistoimenpiteetService.findOneByIdAndLahiesimiesUserId(
-                    kehittamistoimenpiteetDTO.id!!,
-                    user.id!!
-                )
-
-            if (!kehittamistoimenpiteet.isPresent) {
-                throw BadRequestAlertException(
-                    "Koejakson kehittämistoimenpiteitä ei löydy.",
-                    ENTITY_KOEJAKSON_KEHITTAMISTOIMENPITEET,
-                    "dataillegal.koejakson-kehittamistoimenpiteita-ei-loydy"
-                )
-            }
-
-            if (kehittamistoimenpiteet.get().lahikouluttaja?.sopimusHyvaksytty != true) {
-                throw BadRequestAlertException(
-                    "Esimies ei saa muokata kehittämistoimenpiteitä, " +
-                        "jos kouluttaja ei ole hyväksynyt niitä",
-                    ENTITY_KOEJAKSON_KEHITTAMISTOIMENPITEET,
-                    "dataillegal.esimies-ei-saa-muokata-kehittamistoimenpiteita-jos-kouluttaja-ei-ole-hyvaksynyt-niita"
-                )
-            }
-        }
-
-        validateArviointi(
-            kehittamistoimenpiteet.get().lahiesimies?.sopimusHyvaksytty,
+        koejaksoResourceSupport.validateArviointi(
+            kehittamistoimenpiteet.lahiesimies?.sopimusHyvaksytty,
             ENTITY_KOEJAKSON_KEHITTAMISTOIMENPITEET
         )
 
@@ -198,42 +145,25 @@ open class KoejaksoResource(
         @Valid @RequestBody loppukeskusteluDTO: KoejaksonLoppukeskusteluDTO,
         principal: Principal?
     ): ResponseEntity<KoejaksonLoppukeskusteluDTO> {
-        validateId(loppukeskusteluDTO.id, ENTITY_KOEJAKSON_LOPPUKESKUSTELU)
+        koejaksoResourceSupport.validateId(loppukeskusteluDTO.id, ENTITY_KOEJAKSON_LOPPUKESKUSTELU)
         val user = userService.getAuthenticatedUser(principal)
 
-        var loppukeskustelu =
-            koejaksonLoppukeskusteluService.findOneByIdAndLahikouluttajaUserId(
-                loppukeskusteluDTO.id!!,
-                user.id!!
-            )
+        val loppukeskustelu = koejaksoResourceSupport.findForUpdateByLahikouluttajaOrLahiesimies(
+            id = loppukeskusteluDTO.id!!,
+            userId = user.id!!,
+            entity = ENTITY_KOEJAKSON_LOPPUKESKUSTELU,
+            notFoundMessage = "Koejakson loppukeskustelua ei löydy.",
+            notFoundErrorKey = "dataillegal.koejakson-loppukeskustelua-ei-loydy",
+            lahiesimiesBeforeLahikouluttajaMessage = "Esimies ei saa muokata loppukeskustelua, " +
+                "jos kouluttaja ei ole hyväksynyt niitä",
+            lahiesimiesBeforeLahikouluttajaErrorKey = "dataillegal.esimies-ei-saa-muokata-loppukeskustelua-jos-kouluttaja-ei-ole-hyvaksynyt-niita",
+            findByLahikouluttaja = koejaksonLoppukeskusteluService::findOneByIdAndLahikouluttajaUserId,
+            findByLahiesimies = koejaksonLoppukeskusteluService::findOneByIdAndLahiesimiesUserId,
+            lahikouluttajaSopimusHyvaksytty = { it.lahikouluttaja?.sopimusHyvaksytty }
+        )
 
-        if (!loppukeskustelu.isPresent) {
-            loppukeskustelu =
-                koejaksonLoppukeskusteluService.findOneByIdAndLahiesimiesUserId(
-                    loppukeskusteluDTO.id!!,
-                    user.id!!
-                )
-
-            if (!loppukeskustelu.isPresent) {
-                throw BadRequestAlertException(
-                    "Koejakson loppukeskustelua ei löydy.",
-                    ENTITY_KOEJAKSON_LOPPUKESKUSTELU,
-                    "dataillegal.koejakson-loppukeskustelua-ei-loydy"
-                )
-            }
-
-            if (loppukeskustelu.get().lahikouluttaja?.sopimusHyvaksytty != true) {
-                throw BadRequestAlertException(
-                    "Esimies ei saa muokata loppukeskustelua, " +
-                        "jos kouluttaja ei ole hyväksynyt niitä",
-                    ENTITY_KOEJAKSON_LOPPUKESKUSTELU,
-                    "dataillegal.esimies-ei-saa-muokata-loppukeskustelua-jos-kouluttaja-ei-ole-hyvaksynyt-niita"
-                )
-            }
-        }
-
-        validateArviointi(
-            loppukeskustelu.get().lahiesimies?.sopimusHyvaksytty,
+        koejaksoResourceSupport.validateArviointi(
+            loppukeskustelu.lahiesimies?.sopimusHyvaksytty,
             ENTITY_KOEJAKSON_LOPPUKESKUSTELU
         )
 
@@ -241,26 +171,4 @@ open class KoejaksoResource(
         return ResponseEntity.ok(result)
     }
 
-    private fun validateArviointi(
-        hyvaksytty: Boolean?,
-        entity: String
-    ) {
-        if (hyvaksytty == true) {
-            throw BadRequestAlertException(
-                "Hyväksyttyä arviointia ei saa muokata",
-                entity,
-                "dataillegal.hyvaksyttya-arviointia-ei-saa-muokata"
-            )
-        }
-    }
-
-    private fun validateId(id: Long?, entity: String) {
-        if (id == null) {
-            throw BadRequestAlertException(
-                "Virheellinen id",
-                entity,
-                "idnull"
-            )
-        }
-    }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/KoejaksoResourceSupport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/KoejaksoResourceSupport.kt
@@ -1,0 +1,92 @@
+package fi.elsapalvelu.elsa.web.rest.common
+
+import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
+import org.springframework.stereotype.Component
+import java.util.Optional
+
+@Component
+class KoejaksoResourceSupport {
+
+    fun <T> findByLahikouluttajaOrLahiesimies(
+        id: Long,
+        userId: String,
+        findByLahikouluttaja: (Long, String) -> Optional<T>,
+        findByLahiesimies: (Long, String) -> Optional<T>
+    ): Optional<T> {
+        val lahikouluttajaResult = findByLahikouluttaja(id, userId)
+        return if (lahikouluttajaResult.isPresent) {
+            lahikouluttajaResult
+        } else {
+            findByLahiesimies(id, userId)
+        }
+    }
+
+    fun <T> findForUpdateByLahikouluttajaOrLahiesimies(
+        id: Long,
+        userId: String,
+        entity: String,
+        notFoundMessage: String,
+        notFoundErrorKey: String,
+        lahiesimiesBeforeLahikouluttajaMessage: String,
+        lahiesimiesBeforeLahikouluttajaErrorKey: String,
+        findByLahikouluttaja: (Long, String) -> Optional<T>,
+        findByLahiesimies: (Long, String) -> Optional<T>,
+        lahikouluttajaSopimusHyvaksytty: (T) -> Boolean?
+    ): T {
+        var result = findByLahikouluttaja(id, userId)
+
+        if (!result.isPresent) {
+            result = findByLahiesimies(id, userId)
+
+            if (!result.isPresent) {
+                throw BadRequestAlertException(notFoundMessage, entity, notFoundErrorKey)
+            }
+
+            if (lahikouluttajaSopimusHyvaksytty(result.get()) != true) {
+                throw BadRequestAlertException(
+                    lahiesimiesBeforeLahikouluttajaMessage,
+                    entity,
+                    lahiesimiesBeforeLahikouluttajaErrorKey
+                )
+            }
+        }
+
+        return result.get()
+    }
+
+    fun validateArviointi(
+        hyvaksytty: Boolean?,
+        entity: String
+    ) {
+        if (hyvaksytty == true) {
+            throw BadRequestAlertException(
+                "Hyväksyttyä arviointia ei saa muokata",
+                entity,
+                "dataillegal.hyvaksyttya-arviointia-ei-saa-muokata"
+            )
+        }
+    }
+
+    fun validateLahetetty(
+        lahetetty: Boolean?,
+        entity: String
+    ) {
+        if (lahetetty != true) {
+            throw BadRequestAlertException(
+                "Arviointia ei saa muokata, jos erikoistuva ei ole lähettänyt pyyntöä.",
+                entity,
+                "dataillegal.arviointia-ei-saa-muokata-jos-erikoistuva-ei-ole-lahettanyt-pyyntoa"
+            )
+        }
+    }
+
+    fun validateId(id: Long?, entity: String) {
+        if (id == null) {
+            throw BadRequestAlertException(
+                "Virheellinen id",
+                entity,
+                "idnull"
+            )
+        }
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoCommonResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoCommonResource.kt
@@ -21,6 +21,7 @@ import fi.elsapalvelu.elsa.service.dto.valmistuminen.*
 import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.web.rest.KoejaksoResource
+import fi.elsapalvelu.elsa.web.rest.common.KoejaksoResourceSupport
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -30,11 +31,13 @@ class KouluttajaKoejaksoCommonResource(
     koejaksonAloituskeskusteluService: KoejaksonAloituskeskusteluService,
     koejaksonValiarviointiService: KoejaksonValiarviointiService,
     koejaksonKehittamistoimenpiteetService: KoejaksonKehittamistoimenpiteetService,
-    koejaksonLoppukeskusteluService: KoejaksonLoppukeskusteluService
+    koejaksonLoppukeskusteluService: KoejaksonLoppukeskusteluService,
+    koejaksoResourceSupport: KoejaksoResourceSupport
 ) : KoejaksoResource(
     userService,
     koejaksonAloituskeskusteluService,
     koejaksonValiarviointiService,
     koejaksonKehittamistoimenpiteetService,
-    koejaksonLoppukeskusteluService
+    koejaksonLoppukeskusteluService,
+    koejaksoResourceSupport
 )

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoResource.kt
@@ -21,6 +21,7 @@ import fi.elsapalvelu.elsa.service.dto.valmistuminen.*
 import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.web.rest.ENTITY_KOEJAKSON_SOPIMUS
+import fi.elsapalvelu.elsa.web.rest.common.KoejaksoResourceSupport
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -38,7 +39,8 @@ class KouluttajaKoejaksoResource(
     private val koejaksonValiarviointiService: KoejaksonValiarviointiService,
     private val koejaksonKehittamistoimenpiteetService: KoejaksonKehittamistoimenpiteetService,
     private val koejaksonLoppukeskusteluService: KoejaksonLoppukeskusteluService,
-    private val koejaksonVaiheetService: KoejaksonVaiheetService
+    private val koejaksonVaiheetService: KoejaksonVaiheetService,
+    private val koejaksoResourceSupport: KoejaksoResourceSupport
 ) {
 
     @GetMapping("/koejaksot")
@@ -95,13 +97,12 @@ class KouluttajaKoejaksoResource(
         principal: Principal?
     ): ResponseEntity<KoejaksonAloituskeskusteluDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        var aloituskeskusteluDTO =
-            koejaksonAloituskeskusteluService.findOneByIdAndLahikouluttajaUserId(id, user.id!!)
-
-        if (!aloituskeskusteluDTO.isPresent) {
-            aloituskeskusteluDTO =
-                koejaksonAloituskeskusteluService.findOneByIdAndLahiesimiesUserId(id, user.id!!)
-        }
+        val aloituskeskusteluDTO = koejaksoResourceSupport.findByLahikouluttajaOrLahiesimies(
+            id,
+            user.id!!,
+            koejaksonAloituskeskusteluService::findOneByIdAndLahikouluttajaUserId,
+            koejaksonAloituskeskusteluService::findOneByIdAndLahiesimiesUserId
+        )
         return ResponseUtil.wrapOrNotFound(aloituskeskusteluDTO)
     }
 
@@ -111,13 +112,12 @@ class KouluttajaKoejaksoResource(
         principal: Principal?
     ): ResponseEntity<KoejaksonValiarviointiDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        var valiarviointiDTO =
-            koejaksonValiarviointiService.findOneByIdAndLahikouluttajaUserId(id, user.id!!)
-
-        if (!valiarviointiDTO.isPresent) {
-            valiarviointiDTO =
-                koejaksonValiarviointiService.findOneByIdAndLahiesimiesUserId(id, user.id!!)
-        }
+        val valiarviointiDTO = koejaksoResourceSupport.findByLahikouluttajaOrLahiesimies(
+            id,
+            user.id!!,
+            koejaksonValiarviointiService::findOneByIdAndLahikouluttajaUserId,
+            koejaksonValiarviointiService::findOneByIdAndLahiesimiesUserId
+        )
         return ResponseUtil.wrapOrNotFound(valiarviointiDTO)
     }
 
@@ -127,16 +127,12 @@ class KouluttajaKoejaksoResource(
         principal: Principal?
     ): ResponseEntity<KoejaksonKehittamistoimenpiteetDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        var kehittamistoimenpiteetDTO =
-            koejaksonKehittamistoimenpiteetService.findOneByIdAndLahikouluttajaUserId(id, user.id!!)
-
-        if (!kehittamistoimenpiteetDTO.isPresent) {
-            kehittamistoimenpiteetDTO =
-                koejaksonKehittamistoimenpiteetService.findOneByIdAndLahiesimiesUserId(
-                    id,
-                    user.id!!
-                )
-        }
+        val kehittamistoimenpiteetDTO = koejaksoResourceSupport.findByLahikouluttajaOrLahiesimies(
+            id,
+            user.id!!,
+            koejaksonKehittamistoimenpiteetService::findOneByIdAndLahikouluttajaUserId,
+            koejaksonKehittamistoimenpiteetService::findOneByIdAndLahiesimiesUserId
+        )
         return ResponseUtil.wrapOrNotFound(kehittamistoimenpiteetDTO)
     }
 
@@ -146,16 +142,12 @@ class KouluttajaKoejaksoResource(
         principal: Principal?
     ): ResponseEntity<KoejaksonLoppukeskusteluDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        var loppukeskusteluDTO =
-            koejaksonLoppukeskusteluService.findOneByIdAndLahikouluttajaUserId(id, user.id!!)
-
-        if (!loppukeskusteluDTO.isPresent) {
-            loppukeskusteluDTO =
-                koejaksonLoppukeskusteluService.findOneByIdAndLahiesimiesUserId(
-                    id,
-                    user.id!!
-                )
-        }
+        val loppukeskusteluDTO = koejaksoResourceSupport.findByLahikouluttajaOrLahiesimies(
+            id,
+            user.id!!,
+            koejaksonLoppukeskusteluService::findOneByIdAndLahikouluttajaUserId,
+            koejaksonLoppukeskusteluService::findOneByIdAndLahiesimiesUserId
+        )
         return ResponseUtil.wrapOrNotFound(loppukeskusteluDTO)
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloKoejaksoCommonResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloKoejaksoCommonResource.kt
@@ -21,6 +21,7 @@ import fi.elsapalvelu.elsa.service.dto.valmistuminen.*
 import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.web.rest.KoejaksoResource
+import fi.elsapalvelu.elsa.web.rest.common.KoejaksoResourceSupport
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -30,11 +31,13 @@ class VastuuhenkiloKoejaksoCommonResource(
     koejaksonAloituskeskusteluService: KoejaksonAloituskeskusteluService,
     koejaksonValiarviointiService: KoejaksonValiarviointiService,
     koejaksonKehittamistoimenpiteetService: KoejaksonKehittamistoimenpiteetService,
-    koejaksonLoppukeskusteluService: KoejaksonLoppukeskusteluService
+    koejaksonLoppukeskusteluService: KoejaksonLoppukeskusteluService,
+    koejaksoResourceSupport: KoejaksoResourceSupport
 ) : KoejaksoResource(
     userService,
     koejaksonAloituskeskusteluService,
     koejaksonValiarviointiService,
     koejaksonKehittamistoimenpiteetService,
-    koejaksonLoppukeskusteluService
+    koejaksonLoppukeskusteluService,
+    koejaksoResourceSupport
 )

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoPolicyResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoPolicyResourceIT.kt
@@ -1,0 +1,209 @@
+package fi.elsapalvelu.elsa.web.rest.kouluttaja
+
+import fi.elsapalvelu.elsa.ElsaBackendApp
+import fi.elsapalvelu.elsa.domain.kayttaja.User
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonAloituskeskustelu
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonKehittamistoimenpiteet
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonKoulutussopimus
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonLoppukeskustelu
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonValiarviointi
+import fi.elsapalvelu.elsa.domain.perustiedot.Yliopisto
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.repository.koejakso.KoejaksonAloituskeskusteluRepository
+import fi.elsapalvelu.elsa.repository.koejakso.KoejaksonKehittamistoimenpiteetRepository
+import fi.elsapalvelu.elsa.repository.koejakso.KoejaksonKoulutussopimusRepository
+import fi.elsapalvelu.elsa.repository.koejakso.KoejaksonLoppukeskusteluRepository
+import fi.elsapalvelu.elsa.repository.koejakso.KoejaksonValiarviointiRepository
+import fi.elsapalvelu.elsa.security.KOULUTTAJA
+import fi.elsapalvelu.elsa.service.mapper.koejakso.KoejaksonAloituskeskusteluMapper
+import fi.elsapalvelu.elsa.service.mapper.koejakso.KoejaksonKehittamistoimenpiteetMapper
+import fi.elsapalvelu.elsa.service.mapper.koejakso.KoejaksonLoppukeskusteluMapper
+import fi.elsapalvelu.elsa.service.mapper.koejakso.KoejaksonValiarviointiMapper
+import fi.elsapalvelu.elsa.web.rest.ResourceIntegrationTestBase
+import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
+import fi.elsapalvelu.elsa.web.rest.convertObjectToJsonBytes
+import fi.elsapalvelu.elsa.web.rest.helpers.ErikoistuvaLaakariHelper
+import fi.elsapalvelu.elsa.web.rest.helpers.KayttajaHelper
+import fi.elsapalvelu.elsa.web.rest.helpers.KoejaksonVaiheetHelper
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import kotlin.test.assertNotNull
+
+@SpringBootTest(classes = [ElsaBackendApp::class])
+@Transactional
+class KouluttajaKoejaksoPolicyResourceIT : ResourceIntegrationTestBase() {
+
+    @Autowired private lateinit var koejaksonKoulutussopimusRepository: KoejaksonKoulutussopimusRepository
+    @Autowired private lateinit var koejaksonAloituskeskusteluRepository: KoejaksonAloituskeskusteluRepository
+    @Autowired private lateinit var koejaksonValiarviointiRepository: KoejaksonValiarviointiRepository
+    @Autowired private lateinit var koejaksonKehittamistoimenpiteetRepository: KoejaksonKehittamistoimenpiteetRepository
+    @Autowired private lateinit var koejaksonLoppukeskusteluRepository: KoejaksonLoppukeskusteluRepository
+    @Autowired private lateinit var koejaksonAloituskeskusteluMapper: KoejaksonAloituskeskusteluMapper
+    @Autowired private lateinit var koejaksonValiarviointiMapper: KoejaksonValiarviointiMapper
+    @Autowired private lateinit var koejaksonKehittamistoimenpiteetMapper: KoejaksonKehittamistoimenpiteetMapper
+    @Autowired private lateinit var koejaksonLoppukeskusteluMapper: KoejaksonLoppukeskusteluMapper
+
+    private lateinit var koejaksonKoulutussopimus: KoejaksonKoulutussopimus
+    private lateinit var koejaksonAloituskeskustelu: KoejaksonAloituskeskustelu
+    private lateinit var koejaksonValiarviointi: KoejaksonValiarviointi
+    private lateinit var koejaksonKehittamistoimenpiteet: KoejaksonKehittamistoimenpiteet
+    private lateinit var koejaksonLoppukeskustelu: KoejaksonLoppukeskustelu
+    private lateinit var user: User
+
+    @Test
+    fun getAloituskeskusteluAsEsimies() {
+        initTest()
+        assertNotNull(koejaksonAloituskeskustelu.id)
+
+        testMockMvc.perform(get("/api/kouluttaja/koejakso/aloituskeskustelu/{id}", koejaksonAloituskeskustelu.id))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.id").value(koejaksonAloituskeskustelu.id))
+            .andExpect(jsonPath("$.lahikouluttaja.id").value(koejaksonAloituskeskustelu.lahikouluttaja?.id))
+            .andExpect(jsonPath("$.lahiesimies.id").value(koejaksonAloituskeskustelu.lahiesimies?.id))
+    }
+
+    @Test
+    fun getValiarviointiAsEsimies() {
+        initTest()
+        assertNotNull(koejaksonValiarviointi.id)
+
+        testMockMvc.perform(get("/api/kouluttaja/koejakso/valiarviointi/{id}", koejaksonValiarviointi.id))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.id").value(koejaksonValiarviointi.id))
+            .andExpect(jsonPath("$.lahikouluttaja.id").value(koejaksonValiarviointi.lahikouluttaja?.id))
+            .andExpect(jsonPath("$.lahiesimies.id").value(koejaksonValiarviointi.lahiesimies?.id))
+    }
+
+    @Test
+    fun getKehittamistoimenpiteetAsEsimies() {
+        initTest()
+        assertNotNull(koejaksonKehittamistoimenpiteet.id)
+
+        testMockMvc.perform(get("/api/kouluttaja/koejakso/kehittamistoimenpiteet/{id}", koejaksonKehittamistoimenpiteet.id))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.id").value(koejaksonKehittamistoimenpiteet.id))
+            .andExpect(jsonPath("$.lahikouluttaja.id").value(koejaksonKehittamistoimenpiteet.lahikouluttaja?.id))
+            .andExpect(jsonPath("$.lahiesimies.id").value(koejaksonKehittamistoimenpiteet.lahiesimies?.id))
+    }
+
+    @Test
+    fun getLoppukeskusteluAsEsimies() {
+        initTest()
+        assertNotNull(koejaksonLoppukeskustelu.id)
+
+        testMockMvc.perform(get("/api/kouluttaja/koejakso/loppukeskustelu/{id}", koejaksonLoppukeskustelu.id))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.id").value(koejaksonLoppukeskustelu.id))
+            .andExpect(jsonPath("$.lahikouluttaja.id").value(koejaksonLoppukeskustelu.lahikouluttaja?.id))
+            .andExpect(jsonPath("$.lahiesimies.id").value(koejaksonLoppukeskustelu.lahiesimies?.id))
+    }
+
+    @Test
+    fun updateAloituskeskusteluAsEsimiesWithoutKouluttajaSopimusHyvaksytty() {
+        initTestWithKouluttajaSopimusNotHyvaksytty()
+        val updatedAloituskeskustelu = koejaksonAloituskeskusteluRepository.findById(koejaksonAloituskeskustelu.id!!).get()
+        em.detach(updatedAloituskeskustelu)
+        updatedAloituskeskustelu.lahiesimiesHyvaksynyt = true
+        updatedAloituskeskustelu.lahiesimiehenKuittausaika = KoejaksonVaiheetHelper.DEFAULT_MYONTAMISPAIVA
+        val aloituskeskusteluDTO = koejaksonAloituskeskusteluMapper.toDto(updatedAloituskeskustelu)
+
+        testMockMvc.perform(put("/api/kouluttaja/koejakso/aloituskeskustelu").contentType(MediaType.APPLICATION_JSON)
+            .content(convertObjectToJsonBytes(aloituskeskusteluDTO)).with(csrf()))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun updateValiarviointiAsEsimiesWithoutKouluttajaSopimusHyvaksytty() {
+        initTestWithKouluttajaSopimusNotHyvaksytty()
+        val updatedValiarviointi = koejaksonValiarviointiRepository.findById(koejaksonValiarviointi.id!!).get()
+        em.detach(updatedValiarviointi)
+        updatedValiarviointi.lahiesimiesHyvaksynyt = true
+        updatedValiarviointi.lahiesimiehenKuittausaika = KoejaksonVaiheetHelper.DEFAULT_MYONTAMISPAIVA
+        val valiarviointiDTO = koejaksonValiarviointiMapper.toDto(updatedValiarviointi)
+
+        testMockMvc.perform(put("/api/kouluttaja/koejakso/valiarviointi").contentType(MediaType.APPLICATION_JSON)
+            .content(convertObjectToJsonBytes(valiarviointiDTO)).with(csrf()))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun updateKehittamistoimenpiteetAsEsimiesWithoutKouluttajaSopimusHyvaksytty() {
+        initTestWithKouluttajaSopimusNotHyvaksytty()
+        val updatedKehittamistoimenpiteet = koejaksonKehittamistoimenpiteetRepository.findById(koejaksonKehittamistoimenpiteet.id!!).get()
+        em.detach(updatedKehittamistoimenpiteet)
+        updatedKehittamistoimenpiteet.lahiesimiesHyvaksynyt = true
+        updatedKehittamistoimenpiteet.lahiesimiehenKuittausaika = KoejaksonVaiheetHelper.DEFAULT_MYONTAMISPAIVA
+        val kehittamistoimenpiteetDTO = koejaksonKehittamistoimenpiteetMapper.toDto(updatedKehittamistoimenpiteet)
+
+        testMockMvc.perform(put("/api/kouluttaja/koejakso/kehittamistoimenpiteet").contentType(MediaType.APPLICATION_JSON)
+            .content(convertObjectToJsonBytes(kehittamistoimenpiteetDTO)).with(csrf()))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun updateLoppukeskusteluAsEsimiesWithoutKouluttajaSopimusHyvaksytty() {
+        initTestWithKouluttajaSopimusNotHyvaksytty()
+        val updatedLoppukeskustelu = koejaksonLoppukeskusteluRepository.findById(koejaksonLoppukeskustelu.id!!).get()
+        em.detach(updatedLoppukeskustelu)
+        updatedLoppukeskustelu.lahiesimiesHyvaksynyt = true
+        updatedLoppukeskustelu.lahiesimiehenKuittausaika = KoejaksonVaiheetHelper.DEFAULT_MYONTAMISPAIVA
+        val loppukeskusteluDTO = koejaksonLoppukeskusteluMapper.toDto(updatedLoppukeskustelu)
+
+        testMockMvc.perform(put("/api/kouluttaja/koejakso/loppukeskustelu").contentType(MediaType.APPLICATION_JSON)
+            .content(convertObjectToJsonBytes(loppukeskusteluDTO)).with(csrf()))
+            .andExpect(status().isBadRequest)
+    }
+
+    private fun initTestWithKouluttajaSopimusNotHyvaksytty() {
+        initTest()
+        koejaksonKoulutussopimus.kouluttajat?.forEach {
+            it.sopimusHyvaksytty = false
+            it.kuittausaika = null
+        }
+        koejaksonKoulutussopimusRepository.saveAndFlush(koejaksonKoulutussopimus)
+    }
+
+    private fun initTest() {
+        user = KayttajaResourceWithMockUserIT.createEntity()
+        em.persist(user)
+        em.flush()
+        setSecurityContext(user.id!!, KOULUTTAJA)
+        val erikoistuvaLaakari = ErikoistuvaLaakariHelper.createEntity(em)
+        em.persist(erikoistuvaLaakari)
+        val vastuuhenkilo = KayttajaHelper.createEntity(em)
+        em.persist(vastuuhenkilo)
+        val kouluttaja = KayttajaHelper.createEntity(em)
+        em.persist(kouluttaja)
+        val esimies = KayttajaHelper.createEntity(em, user)
+        em.persist(esimies)
+        val yliopisto = Yliopisto(nimi = YliopistoEnum.TAMPEREEN_YLIOPISTO)
+        em.persist(yliopisto)
+        val vaiheet = KoejaksonVaiheetHelper.persistKoejaksoVaiheet(
+            em,
+            erikoistuvaLaakari,
+            kouluttaja,
+            esimies,
+            vastuuhenkilo,
+            yliopisto
+        )
+        koejaksonKoulutussopimus = vaiheet.koulutussopimus
+        koejaksonAloituskeskustelu = vaiheet.aloituskeskustelu
+        koejaksonValiarviointi = vaiheet.valiarviointi
+        koejaksonKehittamistoimenpiteet = vaiheet.kehittamistoimenpiteet
+        koejaksonLoppukeskustelu = vaiheet.loppukeskustelu
+    }
+}
+


### PR DESCRIPTION
This pull request refactors the handling of validation and entity retrieval logic for "koejakso" (trial period) resources by introducing a new helper component, `KoejaksoResourceSupport`. The main goal is to remove duplicated code and centralize common validation and lookup routines, making the resource classes cleaner and easier to maintain.

The most important changes are:

### Introduction of Helper Component

* Added a new `KoejaksoResourceSupport` component in `web/rest/common`, which centralizes logic for finding entities by user role (lahikouluttaja or lahiesimies) and for common validations (such as ID and state checks).

### Refactoring Resource Classes to Use the Helper

* Refactored `KoejaksoResource`, `KouluttajaKoejaksoResource`, and `KouluttajaKoejaksoCommonResource` to inject and use `KoejaksoResourceSupport` for entity lookups and validations, replacing in-place logic with calls to the helper. This reduces code duplication and improves consistency. [[1]](diffhunk://#diff-e5e81d1e321778ba020e53477568d22cf22de4fc7c2846372f724713dfeed7b2L23-R23) [[2]](diffhunk://#diff-e5e81d1e321778ba020e53477568d22cf22de4fc7c2846372f724713dfeed7b2L40-R72) [[3]](diffhunk://#diff-bd15fc6215d806eb46986a9c24e2b4dbf904ad30167f0992bb42ab046e224b0bR24) [[4]](diffhunk://#diff-bd15fc6215d806eb46986a9c24e2b4dbf904ad30167f0992bb42ab046e224b0bL33-R42) [[5]](diffhunk://#diff-f6bf289d4cc4fbf066fc283c3a1e074bbba23a25399ec17fea24bf83f4892940R24) [[6]](diffhunk://#diff-f6bf289d4cc4fbf066fc283c3a1e074bbba23a25399ec17fea24bf83f4892940L41-R43)

### Centralization of Validation Logic

* Moved validation logic for ID presence, entity state (e.g., "lahetetty", "hyvaksytty"), and error handling for not found or unauthorized modifications into `KoejaksoResourceSupport`, removing private validation methods from the resource classes. [[1]](diffhunk://#diff-e5e81d1e321778ba020e53477568d22cf22de4fc7c2846372f724713dfeed7b2L201-L265) [[2]](diffhunk://#diff-82a48833ec8abb3e02d21d32a11a60459e06eab0a40be7ea54920fd0aedc1f8cR1-R92)

### Simplification of Entity Retrieval

* Replaced repeated patterns of finding entities by either lahikouluttaja or lahiesimies with a single method call, improving readability and reducing the risk of inconsistencies. [[1]](diffhunk://#diff-e5e81d1e321778ba020e53477568d22cf22de4fc7c2846372f724713dfeed7b2L40-R72) [[2]](diffhunk://#diff-e5e81d1e321778ba020e53477568d22cf22de4fc7c2846372f724713dfeed7b2L104-R103) [[3]](diffhunk://#diff-e5e81d1e321778ba020e53477568d22cf22de4fc7c2846372f724713dfeed7b2L152-R134) [[4]](diffhunk://#diff-e5e81d1e321778ba020e53477568d22cf22de4fc7c2846372f724713dfeed7b2L201-L265) [[5]](diffhunk://#diff-f6bf289d4cc4fbf066fc283c3a1e074bbba23a25399ec17fea24bf83f4892940L98-R105) [[6]](diffhunk://#diff-f6bf289d4cc4fbf066fc283c3a1e074bbba23a25399ec17fea24bf83f4892940L114-R120) [[7]](diffhunk://#diff-f6bf289d4cc4fbf066fc283c3a1e074bbba23a25399ec17fea24bf83f4892940L130-L139)

No business logic was changed; only the structure and maintainability of the code were improved.