### PR TITLE
Detekt fixes PR1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,9 +210,9 @@ detekt {
     config.setFrom(files("$rootDir/detekt-config.yml"))
 }
 
-//tasks.check {
-//    dependsOn(tasks.named("detektMain"))
-//}
+tasks.check {
+    dependsOn(tasks.named("detektMain"))
+}
 
 testlogger {
     theme = ThemeType.STANDARD

--- a/src/main/kotlin/fi/elsapalvelu/elsa/ElsaBackendApp.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/ElsaBackendApp.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.repository.koulutus.ErikoisalaSisuTutkintoohjelmaRepository
 import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaFetchingService
-import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaImportService
 import jakarta.annotation.PostConstruct
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/fi/elsapalvelu/elsa/ElsaBackendApp.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/ElsaBackendApp.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa
 
+import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaImportService
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.repository.koulutus.ErikoisalaSisuTutkintoohjelmaRepository
 import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaFetchingService

--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/CacheConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/CacheConfiguration.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.config
 
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonKoulutussopimus
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.ehcache.config.builders.CacheConfigurationBuilder
 import org.ehcache.config.builders.ExpiryPolicyBuilder
 import org.ehcache.config.builders.ResourcePoolsBuilder

--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/CoroutineConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/CoroutineConfiguration.kt
@@ -1,0 +1,14 @@
+package fi.elsapalvelu.elsa.config
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class CoroutineConfiguration {
+
+    @Bean(destroyMethod = "")
+    @Suppress("InjectDispatcher")
+    fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/LoggingConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/LoggingConfiguration.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.config
 
+import org.springframework.beans.factory.annotation.Value
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.spi.ILoggingEvent

--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/LoggingConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/LoggingConfiguration.kt
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.audit.AuditLoggingWrapper
 import fi.elsapalvelu.elsa.security.SecurityLoggingWrapper
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import tech.jhipster.config.JHipsterProperties
 import tech.jhipster.config.logging.LoggingUtils.addContextListener

--- a/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.config
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.audit.AuditLoggingWrapper
 import fi.elsapalvelu.elsa.domain.kayttaja.Authority
 import fi.elsapalvelu.elsa.domain.kayttaja.User
@@ -110,7 +111,8 @@ class SecurityConfiguration(
     private val userRepository: UserRepository,
     private val kouluttajavaltuutusRepository: KouluttajavaltuutusRepository,
     private val env: Environment,
-    private val applicationContext: ApplicationContext
+    private val applicationContext: ApplicationContext,
+    private val ioDispatcher: CoroutineDispatcher
 ) {
 
     private val log = LoggerFactory.getLogger(SecurityConfiguration::class.java)
@@ -540,7 +542,7 @@ class SecurityConfiguration(
     private suspend fun fetchOpintotietodata(hetu: String): List<OpintotietodataDTO> =
         supervisorScope {
             opintotietodataFetchingServices.map { service ->
-                async(Dispatchers.IO) {
+                async(ioDispatcher) {
                     fetchOpintotietodataForService(service, hetu)
                 }
             }.awaitAll().filterNotNull()
@@ -568,7 +570,7 @@ class SecurityConfiguration(
         }
 
     private fun fetchAndHandleOpintosuorituksetNonBlocking(userId: String, hetu: String) {
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
         opintosuorituksetFetchingService.filter { it.shouldFetchOpintosuoritukset() }
             .forEach { service ->
                 scope.launch {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/AbstractAuditingEntity.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/AbstractAuditingEntity.kt
@@ -18,7 +18,7 @@ import jakarta.persistence.MappedSuperclass
  */
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
-abstract class AbstractAuditingEntity(
+open class AbstractAuditingEntity(
 
     @CreatedBy
     @Column(name = "created_by", nullable = false, length = 50, updatable = false)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/arviointi/ArvioitavaKokonaisuus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/arviointi/ArvioitavaKokonaisuus.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.arviointi
 
+import java.time.LocalDate
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import java.io.Serializable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/arviointi/ArvioitavaKokonaisuus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/arviointi/ArvioitavaKokonaisuus.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.domain.arviointi
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/arviointi/Suoritusarviointi.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/arviointi/Suoritusarviointi.kt
@@ -10,7 +10,6 @@ import org.hibernate.envers.Audited
 import org.hibernate.envers.NotAudited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/arviointi/Suoritusarviointi.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/arviointi/Suoritusarviointi.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.arviointi
 
+import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Asiakirja.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Asiakirja.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.kayttaja
 
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Asiakirja.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Asiakirja.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.arviointi.Suoritusarviointi
-import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
 import fi.elsapalvelu.elsa.domain.koulutus.Teoriakoulutus
 import fi.elsapalvelu.elsa.domain.tyoskentely.Tyoskentelyjakso
 @Entity

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/ErikoistuvaLaakari.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/ErikoistuvaLaakari.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.kayttaja
 
+import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 import org.hibernate.annotations.Cache

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/ErikoistuvaLaakari.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/ErikoistuvaLaakari.kt
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotNull
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import java.io.Serializable
-import java.time.LocalDate
 
 @Entity
 @Table(name = "erikoistuva_laakari")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Kouluttajavaltuutus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Kouluttajavaltuutus.kt
@@ -6,7 +6,6 @@ import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
 import java.time.Instant
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Kouluttajavaltuutus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Kouluttajavaltuutus.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.kayttaja
 
+import java.time.LocalDate
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Opintooikeus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Opintooikeus.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.kayttaja
 
+import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 import org.hibernate.annotations.Cache

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Opintooikeus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/kayttaja/Opintooikeus.kt
@@ -9,7 +9,6 @@ import org.hibernate.envers.NotAudited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
 import java.time.Instant
-import java.time.LocalDate
 
 import fi.elsapalvelu.elsa.domain.koulutus.Koulutussuunnitelma
 import fi.elsapalvelu.elsa.domain.koulutus.Opintoopas

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonAloituskeskustelu.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonAloituskeskustelu.kt
@@ -5,13 +5,11 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 @Entity
 @Audited
 @Table(name = "koejakson_aloituskeskustelu")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonAloituskeskustelu.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonAloituskeskustelu.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.koejakso
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonKehittamistoimenpiteet.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonKehittamistoimenpiteet.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.koejakso
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonKehittamistoimenpiteet.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonKehittamistoimenpiteet.kt
@@ -5,13 +5,11 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 @Entity
 @Audited
 @Table(name = "koejakson_kehittamistoimenpiteet")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonKoulutussopimus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonKoulutussopimus.kt
@@ -5,13 +5,11 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 @Entity
 @Audited
 @Table(name = "koejakson_koulutussopimus")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonKoulutussopimus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonKoulutussopimus.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.koejakso
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonLoppukeskustelu.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonLoppukeskustelu.kt
@@ -5,13 +5,11 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 @Entity
 @Audited
 @Table(name = "koejakson_loppukeskustelu")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonLoppukeskustelu.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonLoppukeskustelu.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.koejakso
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonValiarviointi.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonValiarviointi.kt
@@ -5,13 +5,11 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 @Entity
 @Audited
 @Table(name = "koejakson_valiarviointi")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonValiarviointi.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonValiarviointi.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.koejakso
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonVastuuhenkilonArvio.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonVastuuhenkilonArvio.kt
@@ -7,12 +7,10 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import java.time.ZoneId
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 @Entity
 @Audited
 @Table(name = "koejakson_vastuuhenkilon_arvio")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonVastuuhenkilonArvio.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoejaksonVastuuhenkilonArvio.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.koejakso
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 import org.hibernate.annotations.Cache

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoulutussopimuksenKouluttaja.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoulutussopimuksenKouluttaja.kt
@@ -5,7 +5,6 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoulutussopimuksenKouluttaja.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koejakso/KoulutussopimuksenKouluttaja.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.koejakso
 
+import java.time.LocalDate
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Koulutusjakso.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Koulutusjakso.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.koulutus
 
+import java.time.LocalDate
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Koulutusjakso.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Koulutusjakso.kt
@@ -5,7 +5,6 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Koulutussuunnitelma.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Koulutussuunnitelma.kt
@@ -5,13 +5,11 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 @Entity
 @Audited
 @Table(name = "koulutussuunnitelma")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Koulutussuunnitelma.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Koulutussuunnitelma.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.koulutus
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Opintoopas.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Opintoopas.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.domain.koulutus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 import org.hibernate.envers.Audited
@@ -11,7 +10,6 @@ import org.hibernate.envers.NotAudited
 import org.hibernate.envers.RelationTargetAuditMode
 
 import fi.elsapalvelu.elsa.domain.arviointi.Arviointiasteikko
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.perustiedot.Erikoisala
 @Entity
 @Table(name = "opintoopas")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Opintoopas.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Opintoopas.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.koulutus
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import java.io.Serializable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Opintosuoritus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Opintosuoritus.kt
@@ -6,11 +6,9 @@ import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
 import java.time.Instant
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 @Entity
 @Audited
 @Table(name = "opintosuoritus")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Opintosuoritus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Opintosuoritus.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.koulutus
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/OpintosuoritusOsakokonaisuus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/OpintosuoritusOsakokonaisuus.kt
@@ -6,7 +6,6 @@ import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
 import java.time.Instant
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/OpintosuoritusOsakokonaisuus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/OpintosuoritusOsakokonaisuus.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.koulutus
 
+import java.time.LocalDate
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Teoriakoulutus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Teoriakoulutus.kt
@@ -5,13 +5,11 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 @Entity
 @Audited
 @Table(name = "teoriakoulutus")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Teoriakoulutus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/koulutus/Teoriakoulutus.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.koulutus
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/seuranta/Paivakirjamerkinta.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/seuranta/Paivakirjamerkinta.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.seuranta
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/seuranta/Paivakirjamerkinta.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/seuranta/Paivakirjamerkinta.kt
@@ -5,11 +5,9 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.koulutus.Teoriakoulutus
 @Entity
 @Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/seuranta/Seurantajakso.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/seuranta/Seurantajakso.kt
@@ -8,12 +8,10 @@ import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.koulutus.Koulutusjakso
 @Entity
 @Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/seuranta/Seurantajakso.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/seuranta/Seurantajakso.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.seuranta
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/suoritteet/Suorite.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/suoritteet/Suorite.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.suoritteet
 
+import java.time.LocalDate
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import java.io.Serializable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/suoritteet/Suorite.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/suoritteet/Suorite.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.domain.suoritteet
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/suoritteet/Suoritemerkinta.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/suoritteet/Suoritemerkinta.kt
@@ -5,7 +5,6 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/suoritteet/Suoritemerkinta.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/suoritteet/Suoritemerkinta.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.suoritteet
 
+import java.time.LocalDate
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/Keskeytysaika.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/Keskeytysaika.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.tyoskentely
 
+import java.time.LocalDate
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/Keskeytysaika.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/Keskeytysaika.kt
@@ -5,7 +5,6 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/PoissaolonSyy.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/PoissaolonSyy.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.tyoskentely
 
+import java.time.LocalDate
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/PoissaolonSyy.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/PoissaolonSyy.kt
@@ -5,7 +5,6 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/Tyoskentelyjakso.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/Tyoskentelyjakso.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.tyoskentely
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/Tyoskentelyjakso.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/tyoskentely/Tyoskentelyjakso.kt
@@ -7,7 +7,6 @@ import org.hibernate.envers.Audited
 import org.hibernate.envers.NotAudited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.persistence.*
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -15,7 +14,6 @@ import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.arviointi.Suoritusarviointi
 import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.koulutus.Koulutusjakso
 import fi.elsapalvelu.elsa.domain.perustiedot.Erikoisala
 import fi.elsapalvelu.elsa.domain.suoritteet.Suoritemerkinta

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksynta.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksynta.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.valmistuminen
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksynta.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksynta.kt
@@ -5,13 +5,11 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 @Entity
 @Table(name = "terveyskeskuskoulutusjakson_hyvaksynta")
 @Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/ValmistumispyynnonTarkistus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/ValmistumispyynnonTarkistus.kt
@@ -5,7 +5,6 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/ValmistumispyynnonTarkistus.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/ValmistumispyynnonTarkistus.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.domain.valmistuminen
 
+import java.time.LocalDate
 import org.hibernate.annotations.Cache
 import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/Valmistumispyynto.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/Valmistumispyynto.kt
@@ -7,14 +7,12 @@ import org.hibernate.annotations.CacheConcurrencyStrategy
 import org.hibernate.envers.Audited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.io.Serializable
-import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 @Entity
 @Audited
 @Table(name = "valmistumispyynto")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/Valmistumispyynto.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/domain/valmistuminen/Valmistumispyynto.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.domain.valmistuminen
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
 import org.hibernate.annotations.Cache

--- a/src/main/kotlin/fi/elsapalvelu/elsa/extensions/LocalDateExtensions.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/extensions/LocalDateExtensions.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.extensions
 
+import java.time.LocalDate
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.time.YearMonth

--- a/src/main/kotlin/fi/elsapalvelu/elsa/extensions/LocalDateExtensions.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/extensions/LocalDateExtensions.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.extensions
 
 import org.slf4j.LoggerFactory
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.temporal.ChronoUnit

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/ArvioitavaKokonaisuusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/ArvioitavaKokonaisuusRepository.kt
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.time.LocalDate
 
 @Repository
 interface ArvioitavaKokonaisuusRepository : JpaRepository<ArvioitavaKokonaisuus, Long> {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/ArvioitavaKokonaisuusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/ArvioitavaKokonaisuusRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.arviointi
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.arviointi.ArvioitavaKokonaisuus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/ArvioitavanKokonaisuudenKategoriaRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/ArvioitavanKokonaisuudenKategoriaRepository.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.domain.arviointi.ArvioitavanKokonaisuudenKategoria
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.time.LocalDate
 
 @Repository
 interface ArvioitavanKokonaisuudenKategoriaRepository :

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/ArvioitavanKokonaisuudenKategoriaRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/ArvioitavanKokonaisuudenKategoriaRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.arviointi
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.arviointi.ArvioitavanKokonaisuudenKategoria
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/SuoritusarviointiRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/SuoritusarviointiRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.arviointi
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.arviointi.Suoritusarviointi
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/SuoritusarviointiRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/arviointi/SuoritusarviointiRepository.kt
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.util.*
 
 @Repository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/kayttaja/KouluttajavaltuutusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/kayttaja/KouluttajavaltuutusRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.kayttaja
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.kayttaja.Kouluttajavaltuutus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/kayttaja/KouluttajavaltuutusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/kayttaja/KouluttajavaltuutusRepository.kt
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.util.*
 
 @Repository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/kayttaja/OpintooikeusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/kayttaja/OpintooikeusRepository.kt
@@ -1,11 +1,9 @@
 package fi.elsapalvelu.elsa.repository.kayttaja
 
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.time.LocalDate
 
 @Repository
 interface OpintooikeusRepository : JpaRepository<Opintooikeus, Long>,

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/kayttaja/OpintooikeusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/kayttaja/OpintooikeusRepository.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.repository.kayttaja
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/koejakso/KoejaksonKoulutussopimusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/koejakso/KoejaksonKoulutussopimusRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.koejakso
 
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonKoulutussopimus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/koejakso/KoejaksonKoulutussopimusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/koejakso/KoejaksonKoulutussopimusRepository.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.repository.koejakso
 
-import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonKoulutussopimus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/koejakso/KoejaksonVastuuhenkilonArvioRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/koejakso/KoejaksonVastuuhenkilonArvioRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.koejakso
 
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/koejakso/KoejaksonVastuuhenkilonArvioRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/koejakso/KoejaksonVastuuhenkilonArvioRepository.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.repository.koejakso
 
-import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/koulutus/OpintoopasRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/koulutus/OpintoopasRepository.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.domain.koulutus.Opintoopas
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.time.LocalDate
 
 
 @Repository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/koulutus/OpintoopasRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/koulutus/OpintoopasRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.koulutus
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.koulutus.Opintoopas
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/koulutus/TeoriakoulutusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/koulutus/TeoriakoulutusRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.koulutus
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.koulutus.Teoriakoulutus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/koulutus/TeoriakoulutusRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/koulutus/TeoriakoulutusRepository.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.domain.koulutus.Teoriakoulutus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.time.LocalDate
 
 
 @Repository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoriteRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoriteRepository.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.domain.suoritteet.Suorite
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.time.LocalDate
 
 @Repository
 interface SuoriteRepository : JpaRepository<Suorite, Long> {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoriteRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoriteRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.suoritteet
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.suoritteet.Suorite
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoritemerkintaRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoritemerkintaRepository.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.domain.suoritteet.Suoritemerkinta
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.time.LocalDate
 import java.util.*
 
 @Repository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoritemerkintaRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoritemerkintaRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.suoritteet
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.suoritteet.Suoritemerkinta
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoritteenKategoriaRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoritteenKategoriaRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.suoritteet
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.suoritteet.SuoritteenKategoria
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoritteenKategoriaRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/suoritteet/SuoritteenKategoriaRepository.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.domain.suoritteet.SuoritteenKategoria
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.time.LocalDate
 
 @Repository
 interface SuoritteenKategoriaRepository : JpaRepository<SuoritteenKategoria, Long> {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/tyoskentely/PoissaolonSyyRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/tyoskentely/PoissaolonSyyRepository.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.domain.tyoskentely.PoissaolonSyy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.time.LocalDate
 
 @Repository
 interface PoissaolonSyyRepository : JpaRepository<PoissaolonSyy, Long> {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/tyoskentely/PoissaolonSyyRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/tyoskentely/PoissaolonSyyRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.tyoskentely
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.tyoskentely.PoissaolonSyy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/tyoskentely/TyoskentelyjaksoRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/tyoskentely/TyoskentelyjaksoRepository.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.repository.tyoskentely
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.tyoskentely.Tyoskentelyjakso
 import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
 import fi.elsapalvelu.elsa.domain.tyoskentely.TyoskentelyjaksoTyyppi

--- a/src/main/kotlin/fi/elsapalvelu/elsa/repository/tyoskentely/TyoskentelyjaksoRepository.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/repository/tyoskentely/TyoskentelyjaksoRepository.kt
@@ -6,7 +6,6 @@ import fi.elsapalvelu.elsa.domain.tyoskentely.TyoskentelyjaksoTyyppi
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.time.LocalDate
 
 @Repository
 interface TyoskentelyjaksoRepository : JpaRepository<Tyoskentelyjakso, Long> {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledPaattyvaOpintooikeusHerate.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledPaattyvaOpintooikeusHerate.kt
@@ -1,6 +1,8 @@
 package fi.elsapalvelu.elsa.scheduler.jobs
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.kayttaja.ErikoistuvaLaakari
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeusHerate
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusHerateRepository
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledPaattyvaOpintooikeusHerate.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledPaattyvaOpintooikeusHerate.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.scheduler.jobs
 
 import fi.elsapalvelu.elsa.domain.kayttaja.ErikoistuvaLaakari
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeusHerate
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusHerateRepository
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Component
 import java.time.DayOfWeek
 import java.time.Duration
 import java.time.Instant
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class PaattyvaOikeus(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledSisuTutkintoohjelmaImport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledSisuTutkintoohjelmaImport.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.scheduler.jobs
 
 import fi.elsapalvelu.elsa.scheduler.AbstractTriggerableJob
 import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaFetchingService
-import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaImportService
 import kotlinx.coroutines.runBlocking
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.springframework.scheduling.annotation.Scheduled

--- a/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledSisuTutkintoohjelmaImport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/scheduler/jobs/ScheduledSisuTutkintoohjelmaImport.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.scheduler.jobs
 
+import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaImportService
 import fi.elsapalvelu.elsa.scheduler.AbstractTriggerableJob
 import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaFetchingService
 import kotlinx.coroutines.runBlocking

--- a/src/main/kotlin/fi/elsapalvelu/elsa/security/ElsaSwitchUserFilter.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/security/ElsaSwitchUserFilter.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.security
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.repository.kayttaja.KayttajaRepository
@@ -159,10 +161,10 @@ class ElsaSwitchUserFilter(
             userRepository.findByIdWithAuthorities(kirjautunutKayttaja.user?.id!!)
                 .get().authorities.map { it.name }
 
-        if (authorityNames.contains(VASTUUHENKILO) && kirjautunutKayttaja.yliopistotAndErikoisalat.find {
+        if (authorityNames.contains(VASTUUHENKILO) && kirjautunutKayttaja.yliopistotAndErikoisalat.any {
                 it.erikoisala?.id == opintooikeus.erikoisala?.id &&
                     it.yliopisto?.id == opintooikeus.yliopisto?.id
-            } != null) return ERIKOISTUVA_LAAKARI_IMPERSONATED
+            }) return ERIKOISTUVA_LAAKARI_IMPERSONATED
 
         if (authorityNames.contains(VASTUUHENKILO) && opintooikeus.erikoisala?.id == YEK_ERIKOISALA_ID
             && kirjautunutKayttaja.yliopistotAndErikoisalat.any {
@@ -170,9 +172,9 @@ class ElsaSwitchUserFilter(
                     && it.vastuuhenkilonTehtavat.map { t -> t.nimi }.contains(VastuuhenkilonTehtavatyyppiEnum.YEK_VALMISTUMINEN) })
             return ERIKOISTUVA_LAAKARI_IMPERSONATED
 
-        if (authorityNames.contains(OPINTOHALLINNON_VIRKAILIJA) && kirjautunutKayttaja.yliopistot.find {
+        if (authorityNames.contains(OPINTOHALLINNON_VIRKAILIJA) && kirjautunutKayttaja.yliopistot.any {
                 it.id == opintooikeus.yliopisto?.id
-            } != null) return ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
+            }) return ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
 
         if (kouluttajavaltuutusRepository.findByValtuuttajaOpintooikeusIdAndValtuutettuUserIdAndPaattymispaivaAfter(
                 opintooikeus.id!!,

--- a/src/main/kotlin/fi/elsapalvelu/elsa/security/ElsaSwitchUserFilter.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/security/ElsaSwitchUserFilter.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.security
 
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.repository.kayttaja.KayttajaRepository
 import fi.elsapalvelu.elsa.repository.kayttaja.KouluttajavaltuutusRepository
@@ -27,7 +26,6 @@ import org.springframework.security.web.authentication.switchuser.SwitchUserGran
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher
 import org.springframework.security.web.util.matcher.RequestMatcher
 import org.springframework.web.filter.OncePerRequestFilter
-import java.time.LocalDate
 import jakarta.persistence.EntityNotFoundException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiService.kt
@@ -1,11 +1,9 @@
 package fi.elsapalvelu.elsa.service.arkistointi
 
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.arkistointi.ArkistointiResult
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
-import java.time.LocalDate
 
 interface ArkistointiService {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiService.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.arkistointi
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.arkistointi.ArkistointiResult
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import fi.elsapalvelu.elsa.config.ApplicationProperties
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.service.kayttaja.AlertPublisherService
 import fi.elsapalvelu.elsa.service.dto.arkistointi.ArkistointiMetadata
@@ -23,7 +22,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.io.FileOutputStream
 import java.text.SimpleDateFormat
-import java.time.LocalDate
 import java.util.ResourceBundle
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.arkistointi
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/ErikoistujienSeurantaQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/ErikoistujienSeurantaQueryService.kt
@@ -23,7 +23,6 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/ErikoistujienSeurantaQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/ErikoistujienSeurantaQueryService.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.arviointi
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.koejakso.*
@@ -177,28 +179,28 @@ class ErikoistujienSeurantaQueryService(
         spec: Specification<Opintooikeus?>? = null
     ): Specification<Opintooikeus?> {
         var specification: Specification<Opintooikeus?> = spec ?: Specification.unrestricted()
-        criteria?.let {
-            it.asetusId?.let {
+        criteria?.let { seurantaCriteria ->
+            seurantaCriteria.asetusId?.let { asetusId ->
                 specification =
                     specification.and { root, _, cb ->
                         cb.equal(
                             root.join(Opintooikeus_.asetus, JoinType.INNER)
                                 .get(Asetus_.id),
-                            it.equals
+                            asetusId.equals
                         )
                     }
             }
-            it.erikoisalaId?.let {
+            seurantaCriteria.erikoisalaId?.let { erikoisalaId ->
                 specification =
                     specification.and { root, _, cb ->
                         cb.equal(
                             root.join(Opintooikeus_.erikoisala, JoinType.INNER)
                                 .get(Erikoisala_.id),
-                            it.equals
+                            erikoisalaId.equals
                         )
                     }
             }
-            if (it.naytaPaattyneet == null || it.naytaPaattyneet == false) {
+            if (seurantaCriteria.naytaPaattyneet == null || seurantaCriteria.naytaPaattyneet == false) {
                 specification =
                     specification.and { root, _, cb ->
                         cb.greaterThanOrEqualTo(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/SuoritusarviointiQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/SuoritusarviointiQueryService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.arviointi
 
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.koejakso.*
 import fi.elsapalvelu.elsa.domain.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/SuoritusarviointiService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/SuoritusarviointiService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.arviointi
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
 import fi.elsapalvelu.elsa.service.dto.arviointi.SuoritusarviointiDTO
 import java.util.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/SuoritusarviointiService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/SuoritusarviointiService.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.arviointi
 
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
 import fi.elsapalvelu.elsa.service.dto.arviointi.SuoritusarviointiDTO
-import java.time.LocalDate
 import java.util.*
 
 interface SuoritusarviointiService {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Action.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Action.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.arkistointi
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
-import java.time.LocalDate
 
 class Action {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Action.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Action.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arkistointi
 
+import java.time.LocalDate
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 
@@ -16,5 +17,5 @@ class Action {
 
     @JacksonXmlProperty(localName = "Record")
     @JacksonXmlElementWrapper(useWrapping = false)
-    var record: MutableList<Record> = mutableListOf()
+    val record: MutableList<Record> = mutableListOf()
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Authenticity.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Authenticity.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arkistointi
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
-import java.time.LocalDate
 
 class Authenticity {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Authenticity.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Authenticity.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arkistointi
 
+import java.time.LocalDate
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 
 class Authenticity {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/CaseFile.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/CaseFile.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arkistointi
 
+import java.time.LocalDate
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 
 class CaseFile {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/CaseFile.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/CaseFile.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arkistointi
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
-import java.time.LocalDate
 
 class CaseFile {
     @JacksonXmlProperty(localName = "Created")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Custom.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Custom.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arkistointi
 
+import java.time.LocalDate
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 
 class Custom {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Custom.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Custom.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arkistointi
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
-import java.time.LocalDate
 
 class Custom {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Person.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Person.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arkistointi
 
+import java.time.LocalDate
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 
 class Person {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Person.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Person.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arkistointi
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
-import java.time.LocalDate
 
 class Person {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Record.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Record.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arkistointi
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
-import java.time.LocalDate
 
 class Record {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Record.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arkistointi/Record.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arkistointi
 
+import java.time.LocalDate
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 
 class Record {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class ArvioitavaKokonaisuusDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusWithArvioinnitDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusWithArvioinnitDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusWithArvioinnitDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusWithArvioinnitDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class ArvioitavaKokonaisuusWithArvioinnitDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusWithErikoisalaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusWithErikoisalaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusWithErikoisalaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavaKokonaisuusWithErikoisalaDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class ArvioitavaKokonaisuusWithErikoisalaDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavanKokonaisuudenKategoriaSimpleDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavanKokonaisuudenKategoriaSimpleDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavanKokonaisuudenKategoriaSimpleDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/ArvioitavanKokonaisuudenKategoriaSimpleDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 class ArvioitavanKokonaisuudenKategoriaSimpleDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/EtusivuArviointipyyntoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/EtusivuArviointipyyntoDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
+import java.time.LocalDate
 import java.io.Serializable
 
 data class EtusivuArviointipyyntoDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/EtusivuArviointipyyntoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/EtusivuArviointipyyntoDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
 import java.io.Serializable
-import java.time.LocalDate
 
 data class EtusivuArviointipyyntoDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/SuoritusarviointiByKokonaisuusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/SuoritusarviointiByKokonaisuusDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/SuoritusarviointiByKokonaisuusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/SuoritusarviointiByKokonaisuusDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/SuoritusarviointiDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/SuoritusarviointiDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.arviointi
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.arviointi.ArvioinninPerustuminen
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/SuoritusarviointiDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/arviointi/SuoritusarviointiDTO.kt
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 import java.io.Serializable
-import java.time.LocalDate
 
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.KayttajaDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/enumeration/KoejaksoTila.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/enumeration/KoejaksoTila.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.dto.enumeration
 
-import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
 import fi.elsapalvelu.elsa.service.dto.*
 import fi.elsapalvelu.elsa.service.dto.koejakso.*
 import fi.elsapalvelu.elsa.service.dto.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/enumeration/KoejaksoTila.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/enumeration/KoejaksoTila.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.enumeration
 
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
 import fi.elsapalvelu.elsa.service.dto.*
 import fi.elsapalvelu.elsa.service.dto.koejakso.*
 import fi.elsapalvelu.elsa.service.dto.tyoskentely.*
@@ -34,7 +35,7 @@ enum class KoejaksoTila {
                     !koejaksonKoulutussopimusDTO.vastuuhenkilonKorjausehdotus.isNullOrBlank())) PALAUTETTU_KORJATTAVAKSI
             else if (koejaksonKoulutussopimusDTO.lahetetty == false) TALLENNETTU_KESKENERAISENA
             else if (koejaksonKoulutussopimusDTO.kouluttajat?.all { it.sopimusHyvaksytty == true } == true) {
-                if (koejaksonKoulutussopimusDTO.kouluttajat?.find { it.kayttajaId == kayttajaId } != null) ODOTTAA_VASTUUHENKILON_HYVAKSYNTAA
+                if (koejaksonKoulutussopimusDTO.kouluttajat?.any { it.kayttajaId == kayttajaId } == true) ODOTTAA_VASTUUHENKILON_HYVAKSYNTAA
                 else ODOTTAA_HYVAKSYNTAA
             } else if (koejaksonKoulutussopimusDTO.kouluttajat?.find { it.kayttajaId == kayttajaId }?.sopimusHyvaksytty == true) ODOTTAA_TOISEN_KOULUTTAJAN_HYVAKSYNTAA
             else ODOTTAA_HYVAKSYNTAA

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/AvoinAsiaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/AvoinAsiaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.kayttaja.AvoinAsiaTyyppiEnum
 import java.io.Serializable
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/AvoinAsiaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/AvoinAsiaDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.kayttaja
 
 import fi.elsapalvelu.elsa.domain.kayttaja.AvoinAsiaTyyppiEnum
 import java.io.Serializable
-import java.time.LocalDate
 
 data class AvoinAsiaDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistujanEteneminenDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistujanEteneminenDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.kayttaja
 
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import java.io.Serializable
-import java.time.LocalDate
 
 import fi.elsapalvelu.elsa.service.dto.tyoskentely.TyoskentelyjaksotTilastotDTO
 data class ErikoistujanEteneminenDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistujanEteneminenDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistujanEteneminenDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import java.io.Serializable
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistujanEteneminenVirkailijaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistujanEteneminenVirkailijaDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.kayttaja
 
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import java.io.Serializable
-import java.time.LocalDate
 import java.util.*
 
 import fi.elsapalvelu.elsa.service.dto.tyoskentely.TyoskentelyjaksotTilastotDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistujanEteneminenVirkailijaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistujanEteneminenVirkailijaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import java.io.Serializable
 import java.util.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistumisenEdistyminenDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistumisenEdistyminenDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.kayttaja
 
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import java.io.Serializable
-import java.time.LocalDate
 
 import fi.elsapalvelu.elsa.service.dto.arviointi.ArviointiasteikkoDTO
 import fi.elsapalvelu.elsa.service.dto.tyoskentely.TyoskentelyjaksotTilastotDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistumisenEdistyminenDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistumisenEdistyminenDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import java.io.Serializable
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistuvaLaakariDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistuvaLaakariDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class ErikoistuvaLaakariDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistuvaLaakariDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/ErikoistuvaLaakariDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KatseluoikeusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KatseluoikeusDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
 import java.io.Serializable
-import java.time.LocalDate
 
 data class KatseluoikeusDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KatseluoikeusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KatseluoikeusDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
+import java.time.LocalDate
 import java.io.Serializable
 
 data class KatseluoikeusDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KoulutettavanEteneminenDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KoulutettavanEteneminenDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
 import java.io.Serializable
-import java.time.LocalDate
 import java.util.*
 
 import fi.elsapalvelu.elsa.service.dto.tyoskentely.TyoskentelyjaksotTilastotDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KoulutettavanEteneminenDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KoulutettavanEteneminenDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
+import java.time.LocalDate
 import java.io.Serializable
 import java.util.*
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KouluttajavaltuutusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KouluttajavaltuutusDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KouluttajavaltuutusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/KouluttajavaltuutusDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class KouluttajavaltuutusDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/LaillistamispaivaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/LaillistamispaivaDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
 import java.io.Serializable
-import java.time.LocalDate
 
 data class LaillistamispaivaDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/LaillistamispaivaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/LaillistamispaivaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
+import java.time.LocalDate
 import java.io.Serializable
 
 data class LaillistamispaivaDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/OpintooikeusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/OpintooikeusDTO.kt
@@ -1,8 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
-import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.service.dto.perustiedot.AsetusDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/OpintooikeusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/OpintooikeusDTO.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.dto.kayttaja
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaErikoistujaJaKouluttajaListItemDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaErikoistujaJaKouluttajaListItemDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttajahallinta
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.kayttaja.KayttajatilinTila
 import fi.elsapalvelu.elsa.service.dto.kayttaja.KayttajahallintaYliopistoErikoisalaDTO
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaErikoistujaJaKouluttajaListItemDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaErikoistujaJaKouluttajaListItemDTO.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.domain.kayttaja.KayttajatilinTila
 import fi.elsapalvelu.elsa.service.dto.kayttaja.KayttajahallintaYliopistoErikoisalaDTO
 import jakarta.validation.constraints.NotNull
 import java.io.Serializable
-import java.time.LocalDate
 
 data class KayttajahallintaErikoistujaJaKouluttajaListItemDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaErikoistuvaLaakariDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaErikoistuvaLaakariDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttajahallinta
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotEmpty

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaErikoistuvaLaakariDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaErikoistuvaLaakariDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttajahallinta
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaKayttajaListItemDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaKayttajaListItemDTO.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.service.dto.kayttajahallinta
 import fi.elsapalvelu.elsa.domain.kayttaja.KayttajatilinTila
 import fi.elsapalvelu.elsa.service.dto.kayttaja.KayttajahallintaYliopistoErikoisalaDTO
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class KayttajahallintaKayttajaListItemDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaKayttajaListItemDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaKayttajaListItemDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttajahallinta
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.kayttaja.KayttajatilinTila
 import fi.elsapalvelu.elsa.service.dto.kayttaja.KayttajahallintaYliopistoErikoisalaDTO
 import java.io.Serializable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaOpintooikeusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaOpintooikeusDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttajahallinta
 
+import java.time.LocalDate
 import java.io.Serializable
 
 data class KayttajahallintaOpintooikeusDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaOpintooikeusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttajahallinta/KayttajahallintaOpintooikeusDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.kayttajahallinta
 
 import java.io.Serializable
-import java.time.LocalDate
 
 data class KayttajahallintaOpintooikeusDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/HyvaksyttyKoejaksonVaiheDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/HyvaksyttyKoejaksonVaiheDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.koejakso
 
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTyyppi
 import java.io.Serializable
-import java.time.LocalDate
 
 data class HyvaksyttyKoejaksonVaiheDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/HyvaksyttyKoejaksonVaiheDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/HyvaksyttyKoejaksonVaiheDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTyyppi
 import java.io.Serializable
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonAloituskeskusteluDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonAloituskeskusteluDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonAloituskeskusteluDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonAloituskeskusteluDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class KoejaksonAloituskeskusteluDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKehittamistoimenpiteetDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKehittamistoimenpiteetDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.koejakso
 
 import fi.elsapalvelu.elsa.domain.koejakso.KehittamistoimenpideKategoria
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class KoejaksonKehittamistoimenpiteetDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKehittamistoimenpiteetDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKehittamistoimenpiteetDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.koejakso.KehittamistoimenpideKategoria
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKouluttajaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKouluttajaDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
 import java.io.Serializable
-import java.time.LocalDate
 
 data class KoejaksonKouluttajaDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKouluttajaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKouluttajaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
+import java.time.LocalDate
 import java.io.Serializable
 
 data class KoejaksonKouluttajaDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKoulutussopimusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKoulutussopimusDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
 import java.io.Serializable
-import java.time.LocalDate
 
 data class KoejaksonKoulutussopimusDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKoulutussopimusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonKoulutussopimusDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
+import java.time.LocalDate
 import java.io.Serializable
 
 data class KoejaksonKoulutussopimusDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonLoppukeskusteluDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonLoppukeskusteluDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.koejakso
 
 import fi.elsapalvelu.elsa.domain.koejakso.KehittamistoimenpideKategoria
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class KoejaksonLoppukeskusteluDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonLoppukeskusteluDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonLoppukeskusteluDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.koejakso.KehittamistoimenpideKategoria
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonVaiheDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonVaiheDTO.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.service.dto.koejakso
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTyyppi
 import java.io.Serializable
-import java.time.LocalDate
 
 data class KoejaksonVaiheDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonVaiheDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonVaiheDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTyyppi
 import java.io.Serializable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonValiarviointiDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonValiarviointiDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.koejakso
 
 import fi.elsapalvelu.elsa.domain.koejakso.KehittamistoimenpideKategoria
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class KoejaksonValiarviointiDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonValiarviointiDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonValiarviointiDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.koejakso.KehittamistoimenpideKategoria
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonVastuuhenkilonArvioDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonVastuuhenkilonArvioDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import java.io.Serializable
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonVastuuhenkilonArvioDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoejaksonVastuuhenkilonArvioDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.koejakso
 
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import java.io.Serializable
-import java.time.LocalDate
 
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.OpintooikeusDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoulutussopimuksenKouluttajaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoulutussopimuksenKouluttajaDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
 import java.io.Serializable
-import java.time.LocalDate
 
 data class KoulutussopimuksenKouluttajaDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoulutussopimuksenKouluttajaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoulutussopimuksenKouluttajaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
+import java.time.LocalDate
 import java.io.Serializable
 
 data class KoulutussopimuksenKouluttajaDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoulutussopimuksenVastuuhenkiloDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoulutussopimuksenVastuuhenkiloDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
+import java.time.LocalDate
 import java.io.Serializable
 
 data class KoulutussopimuksenVastuuhenkiloDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoulutussopimuksenVastuuhenkiloDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koejakso/KoulutussopimuksenVastuuhenkiloDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koejakso
 
 import java.io.Serializable
-import java.time.LocalDate
 
 data class KoulutussopimuksenVastuuhenkiloDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/KoulutusjaksoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/KoulutusjaksoDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
+import java.time.LocalDate
 import java.io.Serializable
 import java.util.*
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/KoulutusjaksoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/KoulutusjaksoDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
 import java.io.Serializable
-import java.time.LocalDate
 import java.util.*
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/KoulutussuunnitelmaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/KoulutussuunnitelmaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/KoulutussuunnitelmaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/KoulutussuunnitelmaDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintoopasDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintoopasDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.koulutus
 
 import fi.elsapalvelu.elsa.domain.arviointi.ArviointiasteikkoTyyppi
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.service.dto.perustiedot.ErikoisalaDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintoopasDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintoopasDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.arviointi.ArviointiasteikkoTyyppi
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintoopasSimpleDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintoopasSimpleDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintoopasSimpleDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintoopasSimpleDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class OpintoopasSimpleDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintosuoritusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintosuoritusDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
+import java.time.LocalDate
 import java.io.Serializable
 
 import fi.elsapalvelu.elsa.service.dto.arviointi.SuoritusarviointiDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintosuoritusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintosuoritusDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
 import java.io.Serializable
-import java.time.LocalDate
 
 import fi.elsapalvelu.elsa.service.dto.arviointi.SuoritusarviointiDTO
 data class OpintosuoritusDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintosuoritusOsakokonaisuusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintosuoritusOsakokonaisuusDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
 import java.io.Serializable
-import java.time.LocalDate
 
 import fi.elsapalvelu.elsa.service.dto.arviointi.SuoritusarviointiDTO
 data class OpintosuoritusOsakokonaisuusDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintosuoritusOsakokonaisuusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintosuoritusOsakokonaisuusDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
+import java.time.LocalDate
 import java.io.Serializable
 
 import fi.elsapalvelu.elsa.service.dto.arviointi.SuoritusarviointiDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintotietoOpintooikeusDataDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintotietoOpintooikeusDataDTO.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import java.io.Serializable
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintotietoOpintooikeusDataDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintotietoOpintooikeusDataDTO.kt
@@ -1,9 +1,7 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
-import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import java.io.Serializable
-import java.time.LocalDate
 
 data class OpintotietoOpintooikeusDataDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintotietodataDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintotietodataDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
 import java.io.Serializable
-import java.time.LocalDate
 
 data class OpintotietodataDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintotietodataDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/OpintotietodataDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
+import java.time.LocalDate
 import java.io.Serializable
 
 data class OpintotietodataDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/TeoriakoulutusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/TeoriakoulutusDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
+import java.time.LocalDate
 import java.io.Serializable
 import java.util.*
 import jakarta.validation.constraints.Min

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/TeoriakoulutusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/koulutus/TeoriakoulutusDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.koulutus
 
 import java.io.Serializable
-import java.time.LocalDate
 import java.util.*
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/perustiedot/ErikoisalaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/perustiedot/ErikoisalaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.perustiedot
 
+import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/perustiedot/ErikoisalaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/perustiedot/ErikoisalaDTO.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.dto.perustiedot
 
-import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/EtusivuSeurantajaksoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/EtusivuSeurantajaksoDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.seuranta
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.enumeration.SeurantajaksoTila
 import java.io.Serializable
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/EtusivuSeurantajaksoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/EtusivuSeurantajaksoDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.seuranta
 
 import fi.elsapalvelu.elsa.service.dto.enumeration.SeurantajaksoTila
 import java.io.Serializable
-import java.time.LocalDate
 
 data class EtusivuSeurantajaksoDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/PaivakirjamerkintaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/PaivakirjamerkintaDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.seuranta
 
 import java.io.Serializable
-import java.time.LocalDate
 import java.util.*
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/PaivakirjamerkintaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/PaivakirjamerkintaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.seuranta
 
+import java.time.LocalDate
 import java.io.Serializable
 import java.util.*
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/SeurantajaksoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/SeurantajaksoDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.seuranta
 
 import fi.elsapalvelu.elsa.service.dto.enumeration.SeurantajaksoTila
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 import fi.elsapalvelu.elsa.service.dto.kayttaja.KayttajaDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/SeurantajaksoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/SeurantajaksoDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.seuranta
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.enumeration.SeurantajaksoTila
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/SeurantajaksonArviointiDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/SeurantajaksonArviointiDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.seuranta
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/SeurantajaksonArviointiDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/seuranta/SeurantajaksonArviointiDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.seuranta
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.suoritteet
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.suoritteet
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class SuoriteDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteWithErikoisalaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteWithErikoisalaDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.suoritteet
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class SuoriteWithErikoisalaDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteWithErikoisalaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteWithErikoisalaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.suoritteet
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteWithSuoritemerkinnatDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteWithSuoritemerkinnatDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.suoritteet
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteWithSuoritemerkinnatDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoriteWithSuoritemerkinnatDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.suoritteet
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class SuoriteWithSuoritemerkinnatDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoritemerkintaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoritemerkintaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.suoritteet
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoritemerkintaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoritemerkintaDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.suoritteet
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoritteenKategoriaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/SuoritteenKategoriaDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.suoritteet
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class SuoritteenKategoriaDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/UusiSuoritemerkintaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/UusiSuoritemerkintaDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.suoritteet
 
 import jakarta.validation.constraints.NotNull
 import java.io.Serializable
-import java.time.LocalDate
 
 import fi.elsapalvelu.elsa.service.dto.arviointi.ArviointiasteikkoDTO
 data class UusiSuoritemerkintaDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/UusiSuoritemerkintaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/suoritteet/UusiSuoritemerkintaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.suoritteet
 
+import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 import java.io.Serializable
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/KeskeytysaikaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/KeskeytysaikaDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.tyoskentely
 
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/KeskeytysaikaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/KeskeytysaikaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.tyoskentely
 
+import java.time.LocalDate
 import java.io.Serializable
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/PoissaolonSyyDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/PoissaolonSyyDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.tyoskentely
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.tyoskentely.PoissaolonSyyTyyppi
 import java.io.Serializable
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/PoissaolonSyyDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/PoissaolonSyyDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.tyoskentely
 
 import fi.elsapalvelu.elsa.domain.tyoskentely.PoissaolonSyyTyyppi
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.NotNull
 
 data class PoissaolonSyyDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/TyoskentelyjaksoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/TyoskentelyjaksoDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.tyoskentely
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
 import java.io.Serializable
 import jakarta.validation.constraints.Max

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/TyoskentelyjaksoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/TyoskentelyjaksoDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.tyoskentely
 
 import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
 import java.io.Serializable
-import java.time.LocalDate
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/TyoskentelyjaksotTableDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/TyoskentelyjaksotTableDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.tyoskentely
 
 import fi.elsapalvelu.elsa.service.dto.enumeration.TerveyskeskuskoulutusjaksoTila
 import java.io.Serializable
-import java.time.LocalDate
 
 class TyoskentelyjaksotTableDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/TyoskentelyjaksotTableDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/tyoskentely/TyoskentelyjaksotTableDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.tyoskentely
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.enumeration.TerveyskeskuskoulutusjaksoTila
 import java.io.Serializable
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/TerveyskeskuskoulutusjaksoSimpleDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/TerveyskeskuskoulutusjaksoSimpleDTO.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
 import fi.elsapalvelu.elsa.service.dto.enumeration.TerveyskeskuskoulutusjaksoTila
 import java.io.Serializable
-import java.time.LocalDate
 
 data class TerveyskeskuskoulutusjaksoSimpleDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/TerveyskeskuskoulutusjaksoSimpleDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/TerveyskeskuskoulutusjaksoSimpleDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.enumeration.TerveyskeskuskoulutusjaksoTila
 import java.io.Serializable
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.enumeration.TerveyskeskuskoulutusjaksoTila
 import java.io.Serializable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaDTO.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.service.dto.valmistuminen
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.enumeration.TerveyskeskuskoulutusjaksoTila
 import java.io.Serializable
-import java.time.LocalDate
 import java.util.*
 
 import fi.elsapalvelu.elsa.service.dto.tyoskentely.TyoskentelyjaksoDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/UusiValmistumispyyntoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/UusiValmistumispyyntoDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
+import java.time.LocalDate
 import java.io.Serializable
 
 data class UusiValmistumispyyntoDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/UusiValmistumispyyntoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/UusiValmistumispyyntoDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
 import java.io.Serializable
-import java.time.LocalDate
 
 data class UusiValmistumispyyntoDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyynnonTarkistusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyynnonTarkistusDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
 import java.io.Serializable
-import java.time.LocalDate
 
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuoritusDTO
 import fi.elsapalvelu.elsa.service.dto.tyoskentely.TyoskentelyjaksotKoulutustyypitDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyynnonTarkistusDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyynnonTarkistusDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
+import java.time.LocalDate
 import java.io.Serializable
 
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuoritusDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyynnonTarkistusUpdateDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyynnonTarkistusUpdateDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
+import java.time.LocalDate
 import java.io.Serializable
 
 data class ValmistumispyynnonTarkistusUpdateDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyynnonTarkistusUpdateDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyynnonTarkistusUpdateDTO.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
 import java.io.Serializable
-import java.time.LocalDate
 
 data class ValmistumispyynnonTarkistusUpdateDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoDTO.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.service.dto.valmistuminen
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
 import java.io.Serializable
-import java.time.LocalDate
 
 data class ValmistumispyyntoDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
 import java.io.Serializable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoListItemDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoListItemDTO.kt
@@ -1,9 +1,7 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
-import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonHyvaksyjaRole
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
 import java.io.Serializable
-import java.time.LocalDate
 
 data class ValmistumispyyntoListItemDTO(
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoListItemDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoListItemDTO.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
+import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonHyvaksyjaRole
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
 import java.io.Serializable
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoOsaamisenArviointiDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoOsaamisenArviointiDTO.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.service.dto.valmistuminen
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
 import java.io.Serializable
-import java.time.LocalDate
 
 data class ValmistumispyyntoOsaamisenArviointiDTO (
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoOsaamisenArviointiDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoOsaamisenArviointiDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
 import java.io.Serializable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoSuoritustenTilaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoSuoritustenTilaDTO.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
-import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
 import java.io.Serializable
 
 data class ValmistumispyyntoSuoritustenTilaDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoSuoritustenTilaDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/valmistuminen/ValmistumispyyntoSuoritustenTilaDTO.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.dto.valmistuminen
 
+import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
 import java.io.Serializable
 
 data class ValmistumispyyntoSuoritustenTilaDTO(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/PoissaolonSyyServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/PoissaolonSyyServiceImpl.kt
@@ -8,7 +8,6 @@ import fi.elsapalvelu.elsa.service.mapper.tyoskentely.PoissaolonSyyMapper
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 
 @Service
 @Transactional

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/PoissaolonSyyServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/PoissaolonSyyServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
 import fi.elsapalvelu.elsa.repository.tyoskentely.PoissaolonSyyRepository
 import fi.elsapalvelu.elsa.service.PoissaolonSyyService

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/ArviointityokaluServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/ArviointityokaluServiceImpl.kt
@@ -152,9 +152,8 @@ class ArviointityokaluServiceImpl(
             .map { arviointityokalu ->
                 arviointityokalu.kysymykset = arviointityokalu.kysymykset
                     .sortedBy { it.jarjestysnumero }
-                    .map { kysymys ->
+                    .onEach { kysymys ->
                         kysymys.vaihtoehdot = kysymys.vaihtoehdot.sortedBy { it.id }.toMutableList()
-                        kysymys
                     }.toMutableList()
                 arviointityokaluMapper.toDto(arviointityokalu)
             }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/ArvioitavaKokonaisuusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/ArvioitavaKokonaisuusServiceImpl.kt
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.util.*
 
 @Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/ArvioitavaKokonaisuusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/ArvioitavaKokonaisuusServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.arviointi
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.repository.arviointi.ArvioitavaKokonaisuusRepository
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
 import fi.elsapalvelu.elsa.repository.arviointi.SuoritusarviointiRepository
@@ -71,7 +72,7 @@ class ArvioitavaKokonaisuusServiceImpl(
             arvioitavaKokonaisuusRepository.findAllByErikoisalaIdAndValid(
                 it.erikoisala?.id, it.osaamisenArvioinninOppaanPvm ?: LocalDate.now()
             ).map(arvioitavaKokonaisuusMapper::toDto)
-        } ?: listOf()
+        }.orEmpty()
     }
 
     override fun findAllByErikoisalaIdPaged(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/ArvioitavanKokonaisuudenKategoriaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/ArvioitavanKokonaisuudenKategoriaServiceImpl.kt
@@ -12,7 +12,6 @@ import fi.elsapalvelu.elsa.service.mapper.arviointi.ArvioitavanKokonaisuudenKate
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.util.*
 
 @Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/ArvioitavanKokonaisuudenKategoriaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/ArvioitavanKokonaisuudenKategoriaServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.arviointi
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.repository.arviointi.ArvioitavanKokonaisuudenKategoriaRepository
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
 import fi.elsapalvelu.elsa.service.arviointi.ArvioitavanKokonaisuudenKategoriaService
@@ -51,7 +52,7 @@ class ArvioitavanKokonaisuudenKategoriaServiceImpl(
                 it.erikoisala?.id,
                 it.osaamisenArvioinninOppaanPvm ?: LocalDate.now()
             ).map(arvioitavanKokonaisuudenKategoriaMapper::toDto)
-        } ?: listOf()
+        }.orEmpty()
     }
 
     override fun findAllByErikoisalaId(erikoisalaId: Long): List<ArvioitavanKokonaisuudenKategoriaSimpleDTO> {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/SuoritusarviointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/SuoritusarviointiServiceImpl.kt
@@ -27,7 +27,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.util.ObjectUtils
 import java.io.ByteArrayInputStream
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/SuoritusarviointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/arviointi/SuoritusarviointiServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.arviointi
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.arviointi.SuoritusarvioinninArviointityokalunVastaus
 import fi.elsapalvelu.elsa.domain.arviointi.Suoritusarviointi
 import fi.elsapalvelu.elsa.repository.*
@@ -141,7 +142,7 @@ class SuoritusarviointiServiceImpl(
                         val result = suoritusarvioinninArvioitavaKokonaisuusMapper.toEntity(it)
                         result.suoritusarviointi = suoritusarviointi
                         result
-                    } ?: listOf()
+                    }.orEmpty()
             suoritusarviointi.arvioitavatKokonaisuudet.addAll(uudet)
         }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/ErikoistuvaLaakariQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/ErikoistuvaLaakariQueryService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.kayttaja
 
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.koejakso.*
 import fi.elsapalvelu.elsa.domain.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/ErikoistuvaLaakariServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/ErikoistuvaLaakariServiceImpl.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.service.impl.kayttaja
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.PAATTYNEEN_OPINTOOIKEUDEN_KATSELUAIKA_KUUKAUDET
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.koejakso.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/ErikoistuvaLaakariServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/ErikoistuvaLaakariServiceImpl.kt
@@ -12,7 +12,6 @@ import fi.elsapalvelu.elsa.domain.valmistuminen.*
 import fi.elsapalvelu.elsa.domain.kayttaja.*
 import fi.elsapalvelu.elsa.domain.perustiedot.*
 import fi.elsapalvelu.elsa.domain.kayttaja.KayttajatilinTila
-import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
 import fi.elsapalvelu.elsa.repository.*
 import fi.elsapalvelu.elsa.repository.koejakso.*
 import fi.elsapalvelu.elsa.repository.tyoskentely.*
@@ -50,7 +49,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
-import java.time.LocalDate
 import java.util.*
 
 @Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/EtusivuServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/EtusivuServiceImpl.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.service.impl.kayttaja
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.koejakso.*
@@ -95,15 +98,17 @@ class EtusivuServiceImpl(
         val seurantaDTO = ErikoistujienSeurantaDTO()
         kayttaja?.let {
             seurantaDTO.kayttajaYliopistoErikoisalat =
-                kayttaja.yliopistotAndErikoisalat.groupBy { it.yliopisto }.map {
+                kayttaja.yliopistotAndErikoisalat.groupBy { kayttajaYliopistoErikoisala ->
+                    kayttajaYliopistoErikoisala.yliopisto
+                }.map { yliopistoErikoisalat ->
                     KayttajaErikoisalatPerYliopistoDTO(
-                        yliopistoNimi = it.key?.nimi.toString(),
-                        erikoisalat = it.value.map { kayttajaYliopistoErikoisala -> kayttajaYliopistoErikoisala.erikoisala?.nimi!! }
+                        yliopistoNimi = yliopistoErikoisalat.key?.nimi.toString(),
+                        erikoisalat = yliopistoErikoisalat.value.map { kayttajaYliopistoErikoisala -> kayttajaYliopistoErikoisala.erikoisala?.nimi!! }
                             .sorted()
                     )
                 }
-            seurantaDTO.kayttajaYliopistoErikoisalat?.forEach {
-                seurantaDTO.erikoisalat?.addAll(it.erikoisalat!!)
+            seurantaDTO.kayttajaYliopistoErikoisalat?.forEach { yliopistoErikoisalat ->
+                seurantaDTO.erikoisalat?.addAll(yliopistoErikoisalat.erikoisalat!!)
             }
             seurantaDTO.erikoisalat = seurantaDTO.erikoisalat?.sorted()?.toMutableSet()
         }
@@ -141,15 +146,17 @@ class EtusivuServiceImpl(
         val seurantaDTO = ErikoistujienSeurantaDTO()
         kayttaja?.let {
             seurantaDTO.kayttajaYliopistoErikoisalat =
-                kayttaja.yliopistotAndErikoisalat.groupBy { it.yliopisto }.map {
+                kayttaja.yliopistotAndErikoisalat.groupBy { kayttajaYliopistoErikoisala ->
+                    kayttajaYliopistoErikoisala.yliopisto
+                }.map { yliopistoErikoisalat ->
                     KayttajaErikoisalatPerYliopistoDTO(
-                        yliopistoNimi = it.key?.nimi.toString(),
-                        erikoisalat = it.value.map { kayttajaYliopistoErikoisala -> kayttajaYliopistoErikoisala.erikoisala?.nimi!! }
+                        yliopistoNimi = yliopistoErikoisalat.key?.nimi.toString(),
+                        erikoisalat = yliopistoErikoisalat.value.map { kayttajaYliopistoErikoisala -> kayttajaYliopistoErikoisala.erikoisala?.nimi!! }
                             .sorted()
                     )
                 }
-            seurantaDTO.kayttajaYliopistoErikoisalat?.forEach {
-                seurantaDTO.erikoisalat?.addAll(it.erikoisalat!!)
+            seurantaDTO.kayttajaYliopistoErikoisalat?.forEach { yliopistoErikoisalat ->
+                seurantaDTO.erikoisalat?.addAll(yliopistoErikoisalat.erikoisalat!!)
             }
             seurantaDTO.erikoisalat = seurantaDTO.erikoisalat?.sorted()?.toMutableSet()
         }
@@ -195,7 +202,7 @@ class EtusivuServiceImpl(
         // Seurantajaksot
         val seurantajaksot = seurantajaksoRepository.findByOpintooikeusId(opintooikeus.id!!)
         eteneminen.seurantajaksotLkm = seurantajaksot.size
-        eteneminen.seurantajaksonHuoletLkm = seurantajaksot.filter { jakso -> jakso.huolenaiheet != null }.size
+        eteneminen.seurantajaksonHuoletLkm = seurantajaksot.count { jakso -> jakso.huolenaiheet != null }
 
         // Suoritemerkinnät
         val suoritemerkinnatMap = getSuoritemerkinnatMap(opintooikeus.id!!)
@@ -275,7 +282,9 @@ class EtusivuServiceImpl(
                 val suoritemerkinnat = suoritemerkinnatMap.values.flatten()
                 val opintosuoritukset = opintosuoritusRepository.findAllByOpintooikeusId(it.id!!).asSequence()
                 val yekSuoritukset = opintosuoritusRepository.findAllByErikoistuvaLaakariIdAndErikoisalaId(opintooikeus.erikoistuvaLaakari?.id!!, YEK_ERIKOISALA_ID)
-                val arviointiasteikko = it.opintoopas?.arviointiasteikko?.let { arviointiasteikkoMapper.toDto(it) }
+                val arviointiasteikko = it.opintoopas?.arviointiasteikko?.let { asteikko ->
+                    arviointiasteikkoMapper.toDto(asteikko)
+                }
 
                 ErikoistumisenEdistyminenDTO(
                     getArviointienKeskiarvo(suoritusarvioinnitMap),
@@ -390,13 +399,13 @@ class EtusivuServiceImpl(
             arvioitavanKokonaisuudenKategoriaRepository.findAllByErikoisalaIdAndValid(
                 opintooikeus.erikoisala?.id,
                 opintooikeus.osaamisenArvioinninOppaanPvm!!
-            ).map { it.arvioitavatKokonaisuudet }.flatten().filter {
+            ).map { it.arvioitavatKokonaisuudet }.flatten().count {
                 isValidByVoimassaDate(
                     it.voimassaoloAlkaa!!,
                     it.voimassaoloLoppuu,
                     opintooikeus.osaamisenArvioinninOppaanPvm!!
                 )
-            }.size
+            }
 
         // Lisätään arvioitava kokonaisuus mukaan kokonaismäärään voimassaolosta huolimatta, jos siihen kohdistuu arviointi.
         arvioitavatKokonaisuudetWithArviointi.forEach {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/EtusivuServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/EtusivuServiceImpl.kt
@@ -12,7 +12,6 @@ import fi.elsapalvelu.elsa.domain.valmistuminen.*
 import fi.elsapalvelu.elsa.domain.kayttaja.*
 import fi.elsapalvelu.elsa.domain.perustiedot.*
 import fi.elsapalvelu.elsa.domain.kayttaja.AvoinAsiaTyyppiEnum
-import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
 import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusTyyppiEnum
 import fi.elsapalvelu.elsa.extensions.pattern
 import fi.elsapalvelu.elsa.repository.*
@@ -56,7 +55,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.*
 import kotlin.jvm.optionals.getOrNull

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KayttajaQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KayttajaQueryService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.kayttaja
 
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.koejakso.*
 import fi.elsapalvelu.elsa.domain.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KayttajaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KayttajaServiceImpl.kt
@@ -150,13 +150,13 @@ class KayttajaServiceImpl(
 
     @Transactional(readOnly = true)
     override fun findKouluttajatFromSameErikoisala(userId: String): List<KayttajaDTO> {
-        erikoistuvaLaakariRepository.findOneByKayttajaUserId(userId)?.let {
+        return erikoistuvaLaakariRepository.findOneByKayttajaUserId(userId)?.let {
             val opintooikeus = it.getOpintooikeusKaytossa()
-            return kayttajaRepository.findAllByAuthoritiesAndErikoisala(
+            kayttajaRepository.findAllByAuthoritiesAndErikoisala(
                 listOf(KOULUTTAJA),
                 opintooikeus?.erikoisala?.id
             ).map(kayttajaMapper::toDto)
-        } ?: return listOf()
+        }.orEmpty()
     }
 
     @Transactional(readOnly = true)
@@ -187,7 +187,7 @@ class KayttajaServiceImpl(
 
     @Transactional(readOnly = true)
     override fun findKouluttajatAndVastuuhenkilotFromSameYliopisto(userId: String): List<KayttajaDTO> {
-        erikoistuvaLaakariRepository.findOneByKayttajaUserId(userId)?.let {
+        return erikoistuvaLaakariRepository.findOneByKayttajaUserId(userId)?.let {
             val opintooikeus = it.getOpintooikeusKaytossa()
             val result = kayttajaRepository.findAllByAuthoritiesAndErikoisala(
                 listOf(KOULUTTAJA),
@@ -198,8 +198,8 @@ class KayttajaServiceImpl(
                     listOf(VASTUUHENKILO), opintooikeus?.yliopisto?.id, opintooikeus?.erikoisala?.id
                 )
             )
-            return result.map(kayttajaMapper::toDto)
-        } ?: return listOf()
+            result.map(kayttajaMapper::toDto)
+        }.orEmpty()
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KayttajahallintaValidationServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KayttajahallintaValidationServiceImpl.kt
@@ -252,17 +252,17 @@ class KayttajahallintaValidationServiceImpl(
         tehtavaId: Long?,
         reassignedTyyppi: ReassignedVastuuhenkilonTehtavaTyyppi
     ): Boolean {
-        return reassignedTehtavat.find {
+        return reassignedTehtavat.any {
             it.kayttajaYliopistoErikoisala?.erikoisala?.id == erikoisalaId &&
                 it.tehtavaId == tehtavaId &&
                 it.tyyppi == reassignedTyyppi
-        } != null
+        }
     }
 
     private fun getAllTehtavatForErikoisala(erikoisalaId: Long): Set<VastuuhenkilonTehtavatyyppi> =
         erikoisalaRepository.findById(erikoisalaId)
             .orElseThrow { EntityNotFoundException("Erikoisalaa ei löydy") }.vastuuhenkilonTehtavatyypit?.toSet()
-            ?: setOf()
+            .orEmpty()
 
     private fun getAssignedTehtavatForErikoisala(
         kayttajaYliopistoErikoisalaDTO: KayttajaYliopistoErikoisalaDTO,
@@ -272,8 +272,8 @@ class KayttajahallintaValidationServiceImpl(
             kayttajaYliopistoErikoisalaDTO.yliopisto?.id!!,
             kayttajaYliopistoErikoisalaDTO.erikoisala?.id!!
         )
-        excludedId?.let {
-            kayttajaYliopistoErikoisalatList = kayttajaYliopistoErikoisalatList.filter { it.id != excludedId }
+        excludedId?.let { id ->
+            kayttajaYliopistoErikoisalatList = kayttajaYliopistoErikoisalatList.filter { it.id != id }
         }
         return kayttajaYliopistoErikoisalatList.map { it.vastuuhenkilonTehtavat }.flatten().toSet()
     }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KouluttajavaltuutusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KouluttajavaltuutusServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.kayttaja
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.repository.kayttaja.ErikoistuvaLaakariRepository
 import fi.elsapalvelu.elsa.repository.kayttaja.KayttajaRepository
 import fi.elsapalvelu.elsa.repository.kayttaja.KouluttajavaltuutusRepository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KouluttajavaltuutusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KouluttajavaltuutusServiceImpl.kt
@@ -13,7 +13,6 @@ import fi.elsapalvelu.elsa.service.mapper.kayttaja.KouluttajavaltuutusMapper
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.*
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/OpintooikeusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/OpintooikeusServiceImpl.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.service.impl.kayttaja
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.kayttaja.Authority
 import fi.elsapalvelu.elsa.domain.kayttaja.User
@@ -210,7 +213,7 @@ class OpintooikeusServiceImpl(
 
     private fun updateRoles(validOikeudet: List<Opintooikeus>, user: User) {
         val yekOikeus = validOikeudet.map { it.erikoisala?.id }.contains(YEK_ERIKOISALA_ID)
-        val elOikeus = validOikeudet.filter { it.erikoisala?.id != YEK_ERIKOISALA_ID }.isNotEmpty()
+        val elOikeus = validOikeudet.any { it.erikoisala?.id != YEK_ERIKOISALA_ID }
         val authorities = user.authorities
 
         val elAuthority = authorities.find { it.name == ERIKOISTUVA_LAAKARI }
@@ -233,10 +236,10 @@ class OpintooikeusServiceImpl(
 
         val elOikeudet = validOikeudet.filter { it.erikoisala?.id != YEK_ERIKOISALA_ID }
 
-        erikoistuvaLaakariRepository.findOneByKayttajaUserId(user.id!!)?.let {
-            if (elOikeus && !elOikeudet.map { it.id }.contains(it.aktiivinenOpintooikeus)) {
-                it.aktiivinenOpintooikeus = elOikeudet.first().id
-                erikoistuvaLaakariRepository.save(it)
+        erikoistuvaLaakariRepository.findOneByKayttajaUserId(user.id!!)?.let { erikoistuvaLaakari ->
+            if (elOikeus && elOikeudet.none { it.id == erikoistuvaLaakari.aktiivinenOpintooikeus }) {
+                erikoistuvaLaakari.aktiivinenOpintooikeus = elOikeudet.first().id
+                erikoistuvaLaakariRepository.save(erikoistuvaLaakari)
             }
         }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/OpintooikeusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/OpintooikeusServiceImpl.kt
@@ -2,9 +2,7 @@ package fi.elsapalvelu.elsa.service.impl.kayttaja
 
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.kayttaja.Authority
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.kayttaja.User
-import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
 import fi.elsapalvelu.elsa.repository.kayttaja.ErikoistuvaLaakariRepository
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
 import fi.elsapalvelu.elsa.repository.koulutus.OpintoopasRepository
@@ -25,7 +23,6 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2A
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
-import java.time.LocalDate
 import javax.xml.bind.ValidationException
 
 @Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/UserServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/UserServiceImpl.kt
@@ -23,7 +23,6 @@ import fi.elsapalvelu.elsa.repository.seuranta.*
 import fi.elsapalvelu.elsa.repository.valmistuminen.*
 import fi.elsapalvelu.elsa.repository.kayttaja.*
 import fi.elsapalvelu.elsa.repository.perustiedot.*
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.constants.KAYTTAJA_NOT_FOUND_ERROR
 import fi.elsapalvelu.elsa.service.dto.kayttaja.OmatTiedotDTO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.UserDTO
@@ -40,7 +39,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
-import java.security.Principal
 import java.util.*
 import javax.crypto.Cipher
 import javax.crypto.SecretKey

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/UserServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/UserServiceImpl.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.impl.kayttaja
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.config.ANONYMOUS_USER
 import fi.elsapalvelu.elsa.config.LoginException
 import fi.elsapalvelu.elsa.domain.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonAloituskeskusteluServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonAloituskeskusteluServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.koejakso
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonAloituskeskustelu
 import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.repository.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonAloituskeskusteluServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonAloituskeskusteluServiceImpl.kt
@@ -29,7 +29,6 @@ import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.time.ZoneId
 import java.util.*
 import jakarta.persistence.EntityNotFoundException

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonKehittamistoimenpiteetServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonKehittamistoimenpiteetServiceImpl.kt
@@ -18,7 +18,6 @@ import fi.elsapalvelu.elsa.service.mapper.koejakso.KoejaksonKehittamistoimenpite
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.time.ZoneId
 import java.util.*
 import jakarta.persistence.EntityNotFoundException

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonKehittamistoimenpiteetServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonKehittamistoimenpiteetServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.koejakso
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonKehittamistoimenpiteet

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonKoulutussopimusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonKoulutussopimusServiceImpl.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.service.impl.koejakso
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonKoulutussopimus
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.koejakso.*
@@ -90,7 +93,7 @@ class KoejaksonKoulutussopimusServiceImpl(
                     paikka.yliopisto = null
                 }
             }
-            koulutussopimus.kouluttajat?.forEach { it.koulutussopimus = koulutussopimus }
+            koulutussopimus.kouluttajat?.forEach { kouluttaja -> kouluttaja.koulutussopimus = koulutussopimus }
             if (koulutussopimus.lahetetty) koulutussopimus.erikoistuvanAllekirjoitusaika =
                 LocalDate.now()
             koulutussopimus.korjausehdotus = null
@@ -148,14 +151,7 @@ class KoejaksonKoulutussopimusServiceImpl(
             koulutussopimus.kouluttajat?.toTypedArray()?.forEach {
                 if (it.kouluttaja?.user?.id == userId) {
                     koulutussopimus = handleKouluttaja(koulutussopimus, it, updatedKoulutussopimus)
-                    val kayttaja = it.kouluttaja!!
-                    val user = it.kouluttaja?.user!!
-                    val kouluttaja = koulutussopimusDTO.kouluttajat?.first { it.kayttajaUserId == userId }
-                    user.phoneNumber = kouluttaja?.puhelin
-                    user.email = kouluttaja?.sahkoposti?.lowercase()
-                    kayttaja.nimike = kouluttaja?.nimike
-                    userRepository.save(user)
-                    kayttajaRepository.save(kayttaja)
+                    updateKouluttajaContact(it, koulutussopimusDTO, userId)
                 }
             }
 
@@ -195,6 +191,23 @@ class KoejaksonKoulutussopimusServiceImpl(
             logger.error("Virhe koulutussopimuksen päivityksessä: ${e.message}", e)
             throw e
         }
+    }
+
+    private fun updateKouluttajaContact(
+        kouluttajaEntity: KoulutussopimuksenKouluttaja,
+        koulutussopimusDTO: KoejaksonKoulutussopimusDTO,
+        userId: String
+    ) {
+        val kayttaja = kouluttajaEntity.kouluttaja!!
+        val user = kouluttajaEntity.kouluttaja?.user!!
+        val kouluttaja = koulutussopimusDTO.kouluttajat?.first { kouluttajaDTO ->
+            kouluttajaDTO.kayttajaUserId == userId
+        }
+        user.phoneNumber = kouluttaja?.puhelin
+        user.email = kouluttaja?.sahkoposti?.lowercase()
+        kayttaja.nimike = kouluttaja?.nimike
+        userRepository.save(user)
+        kayttajaRepository.save(kayttaja)
     }
 
     private fun arkistoiKoulutussopimus(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonKoulutussopimusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonKoulutussopimusServiceImpl.kt
@@ -48,7 +48,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.thymeleaf.context.Context
 import java.io.ByteArrayOutputStream
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonLoppukeskusteluServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonLoppukeskusteluServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.koejakso
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonLoppukeskustelu
 import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.repository.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonLoppukeskusteluServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonLoppukeskusteluServiceImpl.kt
@@ -29,7 +29,6 @@ import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.time.ZoneId
 import java.util.*
 import jakarta.persistence.EntityNotFoundException

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonVaiheetServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonVaiheetServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.koejakso
 
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
 import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.repository.*
@@ -229,7 +230,7 @@ class KoejaksonVaiheetServiceImpl(
                 }
             }
 
-            resultMap[opintooikeusId]!!.add(result)
+            resultMap.getValue(opintooikeusId).add(result)
         }
     }
 
@@ -279,7 +280,7 @@ class KoejaksonVaiheetServiceImpl(
                 }
             }
 
-            resultMap[opintooikeusId]!!.add(result)
+            resultMap.getValue(opintooikeusId).add(result)
 
         }
     }
@@ -322,7 +323,7 @@ class KoejaksonVaiheetServiceImpl(
                 }
             }
 
-            resultMap[opintooikeusId]!!.add(result)
+            resultMap.getValue(opintooikeusId).add(result)
         }
     }
 
@@ -352,12 +353,10 @@ class KoejaksonVaiheetServiceImpl(
                 val mappedAloituskeskusteluHyvaksytty =
                     applyAloituskeskustelu(opintooikeusId)
 
-                result.apply {
-                    hyvaksytytVaiheet.add(mappedAloituskeskusteluHyvaksytty)
-                }
+                result.hyvaksytytVaiheet.add(mappedAloituskeskusteluHyvaksytty)
             }
 
-            resultMap[opintooikeusId]!!.add(result)
+            resultMap.getValue(opintooikeusId).add(result)
         }
     }
 
@@ -383,7 +382,7 @@ class KoejaksonVaiheetServiceImpl(
                 return@forEach
             }
             resultMap[opintooikeusId] = mutableListOf()
-            resultMap[opintooikeusId]!!.add(
+            resultMap.getValue(opintooikeusId).add(
                 mapAloituskeskustelu(it.value, kayttajaId)
             )
         }
@@ -408,7 +407,7 @@ class KoejaksonVaiheetServiceImpl(
         }.forEach {
             val opintooikeusId = it.key
             resultMap.putIfAbsent(opintooikeusId, mutableListOf())
-            resultMap[opintooikeusId]!!.add(mapKoulutussopimus(it.value, false, kayttajaId))
+            resultMap.getValue(opintooikeusId).add(mapKoulutussopimus(it.value, false, kayttajaId))
         }
     }
 
@@ -441,7 +440,7 @@ class KoejaksonVaiheetServiceImpl(
         }.forEach {
             val opintooikeusId = it.key
             resultMap.putIfAbsent(opintooikeusId, mutableListOf())
-            resultMap[opintooikeusId]!!.add(mapKoulutussopimus(it.value, true))
+            resultMap.getValue(opintooikeusId).add(mapKoulutussopimus(it.value, true))
         }
     }
 
@@ -471,9 +470,7 @@ class KoejaksonVaiheetServiceImpl(
                 .map(valiarviointiMapper::toDto).get()
         val mappedValiarviointi = mapValiarviointi(valiarviointiDTO, kayttajaId)
         val mappedValiarviointiHyvaksytty = mapValiarviointiHyvaksytty(valiarviointiDTO)
-        mappedValiarviointi.apply {
-            hyvaksytytVaiheet.add(mappedAloituskeskusteluHyvaksytty)
-        }
+        mappedValiarviointi.hyvaksytytVaiheet.add(mappedAloituskeskusteluHyvaksytty)
         return mappedValiarviointiHyvaksytty
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonVaiheetServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonVaiheetServiceImpl.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.koejakso
 
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.repository.*
 import fi.elsapalvelu.elsa.repository.koejakso.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonValiarviointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonValiarviointiServiceImpl.kt
@@ -23,7 +23,6 @@ import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.time.ZoneId
 import java.util.*
 import jakarta.persistence.EntityNotFoundException

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonValiarviointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonValiarviointiServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.koejakso
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonValiarviointi
 import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.repository.kayttaja.KayttajaRepository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonVastuuhenkilonArvioServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonVastuuhenkilonArvioServiceImpl.kt
@@ -54,7 +54,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.thymeleaf.context.Context
 import java.io.ByteArrayOutputStream
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Period
 import java.time.ZoneId

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonVastuuhenkilonArvioServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonVastuuhenkilonArvioServiceImpl.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.impl.koejakso
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/KoulutussuunnitelmaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/KoulutussuunnitelmaServiceImpl.kt
@@ -62,13 +62,11 @@ class KoulutussuunnitelmaServiceImpl(
     }
 
     override fun findOneByOpintooikeusId(opintooikeusId: Long): KoulutussuunnitelmaDTO? {
-        koulutussuunnitelmaRepository.findOneByOpintooikeusId(opintooikeusId)?.let {
-            return koulutussuunnitelmaMapper.toDto(it)
-        } ?: run {
-            return opintooikeusRepository.findByIdOrNull(opintooikeusId)?.let {
+        return koulutussuunnitelmaRepository.findOneByOpintooikeusId(opintooikeusId)?.let {
+            koulutussuunnitelmaMapper.toDto(it)
+        } ?: opintooikeusRepository.findByIdOrNull(opintooikeusId)?.let {
                 val koulutussuunnitelma = koulutussuunnitelmaRepository.save(Koulutussuunnitelma(opintooikeus = it))
-                return koulutussuunnitelmaMapper.toDto(koulutussuunnitelma)
-            }
+                koulutussuunnitelmaMapper.toDto(koulutussuunnitelma)
         }
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/KoulutussuunnitelmaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/KoulutussuunnitelmaServiceImpl.kt
@@ -6,7 +6,6 @@ import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
 import fi.elsapalvelu.elsa.service.koulutus.KoulutussuunnitelmaService
 import fi.elsapalvelu.elsa.service.dto.koulutus.KoulutussuunnitelmaDTO
 import fi.elsapalvelu.elsa.service.mapper.koulutus.KoulutussuunnitelmaMapper
-import org.hibernate.engine.jdbc.BlobProxy
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintosuorituksetPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintosuorituksetPersistenceServiceImpl.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.impl.koulutus
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.kayttaja.ErikoistuvaLaakari
 import fi.elsapalvelu.elsa.domain.koulutus.Opintosuoritus
 import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusOsakokonaisuus

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintosuorituksetPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintosuorituksetPersistenceServiceImpl.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.koulutus
 
 import fi.elsapalvelu.elsa.domain.kayttaja.ErikoistuvaLaakari
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.koulutus.Opintosuoritus
 import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusOsakokonaisuus
 import fi.elsapalvelu.elsa.extensions.match
@@ -20,7 +19,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
-import java.time.LocalDate
 
 @Service
 @Transactional

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintosuoritusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintosuoritusServiceImpl.kt
@@ -9,7 +9,6 @@ import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuorituksetDTO
 import fi.elsapalvelu.elsa.service.mapper.koulutus.OpintosuoritusMapper
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 
 @Service
 class OpintosuoritusServiceImpl(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintosuoritusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintosuoritusServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.koulutus
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusTyyppiEnum
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintotietodataPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintotietodataPersistenceServiceImpl.kt
@@ -14,9 +14,7 @@ import fi.elsapalvelu.elsa.domain.seuranta.*
 import fi.elsapalvelu.elsa.domain.valmistuminen.*
 import fi.elsapalvelu.elsa.domain.kayttaja.*
 import fi.elsapalvelu.elsa.domain.perustiedot.*
-import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
 import fi.elsapalvelu.elsa.domain.kayttaja.KayttajatilinTila
-import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.*
 import fi.elsapalvelu.elsa.repository.koejakso.*
@@ -33,7 +31,6 @@ import fi.elsapalvelu.elsa.security.YEK_KOULUTETTAVA
 import fi.elsapalvelu.elsa.service.kayttaja.MailProperty
 import fi.elsapalvelu.elsa.service.kayttaja.MailService
 import fi.elsapalvelu.elsa.service.koulutus.OpintotietodataPersistenceService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintotietoOpintooikeusDataDTO
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintotietodataDTO
 import jakarta.persistence.EntityNotFoundException
@@ -45,7 +42,6 @@ import org.springframework.stereotype.Service
 import tech.jhipster.config.JHipsterConstants.SPRING_PROFILE_DEVELOPMENT
 import java.time.Clock
 import java.time.Instant
-import java.time.LocalDate
 import java.time.ZoneId
 import javax.crypto.Cipher
 import javax.crypto.SecretKey

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintotietodataPersistenceServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/OpintotietodataPersistenceServiceImpl.kt
@@ -1,5 +1,9 @@
 package fi.elsapalvelu.elsa.service.impl.koulutus
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.config.LoginException
 import fi.elsapalvelu.elsa.config.PAATTYNEEN_OPINTOOIKEUDEN_KATSELUAIKA_KUUKAUDET
@@ -79,7 +83,7 @@ class OpintotietodataPersistenceServiceImpl(
     ) {
         val filteredOpintotietodataOpintooikeudet =
             filterOpintooikeudetByVoimassaDate(opintotietodataDTOs.map {
-                it.opintooikeudet ?: listOf()
+                it.opintooikeudet.orEmpty()
             }.flatten())
 
         if (filteredOpintotietodataOpintooikeudet.isEmpty()) {
@@ -133,7 +137,7 @@ class OpintotietodataPersistenceServiceImpl(
         var erikoistuvaLaakari = erikoistuvaLaakariRepository.findOneByKayttajaUserId(userId)
 
         val opintotietodataOpintooikeudet =
-            opintotietodataDTOs.map { it.opintooikeudet ?: listOf() }.flatten()
+            opintotietodataDTOs.map { it.opintooikeudet.orEmpty() }.flatten()
 
         if (filterOpintooikeudetByVoimassaDate(opintotietodataOpintooikeudet).isEmpty()) {
             if (erikoistuvaLaakari == null)
@@ -269,7 +273,7 @@ class OpintotietodataPersistenceServiceImpl(
             mailService.sendEmailFromTemplate(
                 user,
                 // Ei lähetetä Helsingin yliopiston virkailijoille: https://jira.eduuni.fi/browse/UOELSA-1156
-                getOpintohallintoEmailAddresses(yliopistot.filter { it != YliopistoEnum.HELSINGIN_YLIOPISTO }
+                getOpintohallintoEmailAddresses(yliopistot.filter { yliopisto -> yliopisto != YliopistoEnum.HELSINGIN_YLIOPISTO }
                     .toSet()),
                 "useaOpintooikeus.html",
                 "useaopintooikeus.title",
@@ -282,7 +286,7 @@ class OpintotietodataPersistenceServiceImpl(
                 erikoistuvaLaakari = erikoistuvaLaakari
             ).apply {
                 useaVoimassaolevaHerateLahetetty = Instant.now()
-            }.let { opintooikeusHerateRepository.save(it) }
+            }.let { herate -> opintooikeusHerateRepository.save(herate) }
         }
     }
 
@@ -521,14 +525,14 @@ class OpintotietodataPersistenceServiceImpl(
         alkamispaiva: LocalDate?, yliopisto: YliopistoEnum, userId: String
     ): LocalDate? = alkamispaiva?.let {
         if (LocalDate.now(clock) >= alkamispaiva) {
-            return alkamispaiva
+            alkamispaiva
         } else {
             log.warn("$yliopisto, user id: $userId. Opinto-oikeus ei ole vielä alkanut.")
-            return null
+            null
         }
     } ?: run {
         log.error("$yliopisto, user id: $userId. Opinto-oikeuden alkamispäivää ei ole asetettu.")
-        return null
+        null
     }
 
     private fun checkOpintooikeudenPaattymispaivaValidDateExistsOrLogError(
@@ -637,7 +641,7 @@ class OpintotietodataPersistenceServiceImpl(
             log.error(
                 "Erikoistuja: $etunimi $sukunimi. Kelvollista syntymäaikaa ei löytynyt yhdestäkään " +
                     "opintotietojärjestelmästä, jossa erikoistujalla on opinto-oikeus. Yliopisto(t): ${
-                        opintotietodataDTOs.map { it.opintooikeudet ?: listOf() }.flatten()
+                        opintotietodataDTOs.map { it.opintooikeudet.orEmpty() }.flatten()
                             .joinToString { it.yliopisto.toString() }
                     })"
             )

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/TeoriakoulutusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/TeoriakoulutusServiceImpl.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.impl.koulutus
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.koulutus.Teoriakoulutus
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
 import fi.elsapalvelu.elsa.repository.seuranta.PaivakirjamerkintaRepository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/TeoriakoulutusServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koulutus/TeoriakoulutusServiceImpl.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.impl.koulutus
 
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.koulutus.Teoriakoulutus
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
 import fi.elsapalvelu.elsa.repository.seuranta.PaivakirjamerkintaRepository
@@ -13,7 +12,6 @@ import fi.elsapalvelu.elsa.service.mapper.koulutus.TeoriakoulutusMapper
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/seuranta/SeurantajaksoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/seuranta/SeurantajaksoServiceImpl.kt
@@ -37,7 +37,6 @@ import fi.elsapalvelu.elsa.service.mapper.seuranta.SeurantajaksoMapper
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import jakarta.persistence.EntityNotFoundException
 
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/seuranta/SeurantajaksoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/seuranta/SeurantajaksoServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.seuranta
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.seuranta.Seurantajakso
 import fi.elsapalvelu.elsa.repository.*
 import fi.elsapalvelu.elsa.repository.koejakso.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoriteServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoriteServiceImpl.kt
@@ -12,7 +12,6 @@ import fi.elsapalvelu.elsa.service.mapper.suoritteet.SuoritteenKategoriaWithErik
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.util.*
 
 @Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoriteServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoriteServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.suoritteet
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
 import fi.elsapalvelu.elsa.repository.suoritteet.SuoriteRepository
 import fi.elsapalvelu.elsa.repository.suoritteet.SuoritemerkintaRepository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoritemerkintaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoritemerkintaServiceImpl.kt
@@ -10,7 +10,6 @@ import fi.elsapalvelu.elsa.service.mapper.suoritteet.SuoritemerkintaMapper
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 
 @Service
 @Transactional

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoritemerkintaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoritemerkintaServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.suoritteet
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.repository.kayttaja.ErikoistuvaLaakariRepository
 import fi.elsapalvelu.elsa.repository.suoritteet.SuoritemerkintaRepository
 import fi.elsapalvelu.elsa.repository.tyoskentely.TyoskentelyjaksoRepository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoritteenKategoriaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoritteenKategoriaServiceImpl.kt
@@ -12,7 +12,6 @@ import fi.elsapalvelu.elsa.service.mapper.suoritteet.SuoritteenKategoriaWithErik
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.util.*
 
 @Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoritteenKategoriaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/suoritteet/SuoritteenKategoriaServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.suoritteet
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
 import fi.elsapalvelu.elsa.repository.suoritteet.SuoritteenKategoriaRepository
 import fi.elsapalvelu.elsa.service.suoritteet.SuoritteenKategoriaService
@@ -40,7 +41,7 @@ class SuoritteenKategoriaServiceImpl(
                 it.erikoisala?.id,
                 it.osaamisenArvioinninOppaanPvm ?: LocalDate.now()
             ).map(suoritteenKategoriaMapper::toDto)
-        } ?: listOf()
+        }.orEmpty()
     }
 
     override fun findAllExpiredByOpintooikeusId(opintooikeusId: Long): List<SuoritteenKategoriaDTO> {
@@ -49,7 +50,7 @@ class SuoritteenKategoriaServiceImpl(
                 it.erikoisala?.id,
                 it.osaamisenArvioinninOppaanPvm ?: LocalDate.now()
             ).map(suoritteenKategoriaMapper::toDto)
-        } ?: listOf()
+        }.orEmpty()
     }
 
     override fun findAllByErikoisalaId(erikoisalaId: Long): List<SuoritteenKategoriaSimpleDTO> {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/OverlappingTyoskentelyjaksoValidationServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/OverlappingTyoskentelyjaksoValidationServiceImpl.kt
@@ -14,7 +14,6 @@ import fi.elsapalvelu.elsa.service.dto.tyoskentely.KeskeytysaikaDTO
 import fi.elsapalvelu.elsa.service.dto.tyoskentely.TyoskentelyjaksoDTO
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
-import java.time.LocalDate
 import java.time.ZoneId
 import kotlin.math.abs
 import kotlin.math.max

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/OverlappingTyoskentelyjaksoValidationServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/OverlappingTyoskentelyjaksoValidationServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.tyoskentely
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.tyoskentely.PoissaolonSyy
 import fi.elsapalvelu.elsa.domain.tyoskentely.Tyoskentelyjakso
 import fi.elsapalvelu.elsa.domain.tyoskentely.PoissaolonSyyTyyppi
@@ -108,9 +109,12 @@ class OverlappingTyoskentelyjaksoValidationServiceImpl(
     private fun validateTyoskentelyaika(existingTyoskentelyjaksoId: Long?, tyoskentelyjaksoStartDate: LocalDate, tyoskentelyjaksoEndDate: LocalDate,
         tyoskentelyjaksot: List<Tyoskentelyjakso>, osaaikaProsentti: Double? = null): Boolean {
         var hyvaksiluettavatCounterData: HyvaksiluettavatCounterData? = null
-        fun getHyvaksiluettavatCounterData(tyoskentelyjaksot: List<Tyoskentelyjakso>, calculateUntilDate: LocalDate): HyvaksiluettavatCounterData {
+        fun getHyvaksiluettavatCounterData(
+            counterTyoskentelyjaksot: List<Tyoskentelyjakso>,
+            calculateUntilDate: LocalDate
+        ): HyvaksiluettavatCounterData {
             if (hyvaksiluettavatCounterData == null) {
-                hyvaksiluettavatCounterData = tyoskentelyjaksonPituusCounterService.calculateHyvaksiluettavatDaysLeft(tyoskentelyjaksot, calculateUntilDate)
+                hyvaksiluettavatCounterData = tyoskentelyjaksonPituusCounterService.calculateHyvaksiluettavatDaysLeft(counterTyoskentelyjaksot, calculateUntilDate)
             }
             return hyvaksiluettavatCounterData
         }
@@ -160,18 +164,18 @@ class OverlappingTyoskentelyjaksoValidationServiceImpl(
                             // poissaolokohtaisesta määrästä. Hyväksiluetaan näistä niin paljon kuin
                             // pystytään ja päivitetään molemmat laskurit.
                             val hyvaksiluettavaFactor = if (vahennetaanKerran) min(
-                                counterData.hyvaksiluettavatPerYearMap[date.year]!!,
-                                counterData.hyvaksiluettavatDays[it.poissaolonSyy]!!
-                            ) else counterData.hyvaksiluettavatPerYearMap[date.year]!!
+                                counterData.hyvaksiluettavatPerYearMap.getValue(date.year),
+                                counterData.hyvaksiluettavatDays.getValue(it.poissaolonSyy!!)
+                            ) else counterData.hyvaksiluettavatPerYearMap.getValue(date.year)
                             val reducedFactor = hyvaksiluettavaFactor - keskeytysaikaFactor
                             if (reducedFactor < 0) overallTyoskentelyaikaFactorForCurrentDate -= abs(
                                 reducedFactor
                             )
                             counterData.hyvaksiluettavatPerYearMap[date.year] =
-                                max(0.0, counterData.hyvaksiluettavatPerYearMap[date.year]!! - keskeytysaikaFactor)
+                                max(0.0, counterData.hyvaksiluettavatPerYearMap.getValue(date.year) - keskeytysaikaFactor)
                             if (vahennetaanKerran) {
                                 counterData.hyvaksiluettavatDays[it.poissaolonSyy!!] =
-                                    max(0.0, counterData.hyvaksiluettavatDays[it.poissaolonSyy!!]!! - keskeytysaikaFactor)
+                                    max(0.0, counterData.hyvaksiluettavatDays.getValue(it.poissaolonSyy!!) - keskeytysaikaFactor)
                             }
                         }
                         else -> {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/TyoskentelyjaksoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/TyoskentelyjaksoServiceImpl.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.impl.tyoskentely
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.koulutus.Opintoopas
 import fi.elsapalvelu.elsa.domain.tyoskentely.Tyoskentelyjakso
@@ -53,26 +55,26 @@ class TyoskentelyjaksoServiceImpl(
         opintooikeusId: Long,
         newAsiakirjat: MutableSet<AsiakirjaDTO>
     ): TyoskentelyjaksoDTO? {
-        opintooikeusRepository.findByIdOrNull(opintooikeusId)?.let {
+        opintooikeusRepository.findByIdOrNull(opintooikeusId)?.let { opintooikeus ->
             tyoskentelyjaksoMapper.toEntity(tyoskentelyjaksoDTO).apply {
-                opintooikeus = it
+                this.opintooikeus = opintooikeus
                 tyoskentelypaikka?.kunta =
-                    tyoskentelyjaksoDTO.tyoskentelypaikka!!.kuntaId?.let { kuntaRepository.findByIdOrNull(it) }
+                    tyoskentelyjaksoDTO.tyoskentelypaikka!!.kuntaId?.let { kuntaId -> kuntaRepository.findByIdOrNull(kuntaId) }
                 omaaErikoisalaaTukeva =
                     tyoskentelyjaksoDTO.omaaErikoisalaaTukeva.takeIf {
                         kaytannonKoulutus == OMAA_ERIKOISALAA_TUKEVA_KOULUTUS
-                    }?.let {
-                        it.id?.let { id -> erikoisalaRepository.findByIdOrNull(id) }
+                    }?.let { erikoisala ->
+                        erikoisala.id?.let { id -> erikoisalaRepository.findByIdOrNull(id) }
                     }
             }.takeIf { isValidTyoskentelyjakso(it) }?.let { tyoskentelyjakso ->
                 mapAsiakirjat(
                     tyoskentelyjakso,
                     newAsiakirjat,
                     null,
-                    it
+                    opintooikeus
                 )
-            }?.let {
-                tyoskentelyjaksoRepository.save(it).let { saved ->
+            }?.let { tyoskentelyjakso ->
+                tyoskentelyjaksoRepository.save(tyoskentelyjakso).let { saved ->
                     return tyoskentelyjaksoMapper.toDto(saved)
                 }
             }
@@ -322,7 +324,7 @@ class TyoskentelyjaksoServiceImpl(
                 yhteensaSuoritettu = arvioErikoistumiseenHyvaksyttavista
             ),
             kaytannonKoulutus = KaytannonKoulutusTyyppi.entries.map {
-                TyoskentelyjaksotTilastotKaytannonKoulutusDTO(kaytannonKoulutus = it, suoritettu = kaytannonKoulutusSuoritettuMap[it]!!)
+                TyoskentelyjaksotTilastotKaytannonKoulutusDTO(kaytannonKoulutus = it, suoritettu = kaytannonKoulutusSuoritettuMap.getValue(it))
             }
                 .toMutableSet(),
             tyoskentelyjaksot = tyoskentelyjaksotSuoritettu
@@ -411,17 +413,20 @@ class TyoskentelyjaksoServiceImpl(
             // Summataan suoritettu aika käytännön koulutuksettain
             when (tyoskentelyjakso.kaytannonKoulutus!!) {
                 OMAN_ERIKOISALAN_KOULUTUS ->
-                    kaytannonKoulutusSuoritettuMap[OMAN_ERIKOISALAN_KOULUTUS] = kaytannonKoulutusSuoritettuMap[OMAN_ERIKOISALAN_KOULUTUS]!! + tyoskentelyjaksonPituus
+                    kaytannonKoulutusSuoritettuMap[OMAN_ERIKOISALAN_KOULUTUS] =
+                        kaytannonKoulutusSuoritettuMap.getValue(OMAN_ERIKOISALAN_KOULUTUS) + tyoskentelyjaksonPituus
 
                 OMAA_ERIKOISALAA_TUKEVA_KOULUTUS ->
                     kaytannonKoulutusSuoritettuMap[OMAA_ERIKOISALAA_TUKEVA_KOULUTUS] =
-                        kaytannonKoulutusSuoritettuMap[OMAA_ERIKOISALAA_TUKEVA_KOULUTUS]!! + tyoskentelyjaksonPituus
+                        kaytannonKoulutusSuoritettuMap.getValue(OMAA_ERIKOISALAA_TUKEVA_KOULUTUS) + tyoskentelyjaksonPituus
 
                 TUTKIMUSTYO ->
-                    kaytannonKoulutusSuoritettuMap[TUTKIMUSTYO] = kaytannonKoulutusSuoritettuMap[TUTKIMUSTYO]!! + tyoskentelyjaksonPituus
+                    kaytannonKoulutusSuoritettuMap[TUTKIMUSTYO] =
+                        kaytannonKoulutusSuoritettuMap.getValue(TUTKIMUSTYO) + tyoskentelyjaksonPituus
 
                 TERVEYSKESKUSTYO ->
-                    kaytannonKoulutusSuoritettuMap[TERVEYSKESKUSTYO] = kaytannonKoulutusSuoritettuMap[TERVEYSKESKUSTYO]!! + tyoskentelyjaksonPituus
+                    kaytannonKoulutusSuoritettuMap[TERVEYSKESKUSTYO] =
+                        kaytannonKoulutusSuoritettuMap.getValue(TERVEYSKESKUSTYO) + tyoskentelyjaksonPituus
             }
 
             // Summataan nykyiselle tai hyväksytylle erikoisalalle
@@ -462,7 +467,7 @@ class TyoskentelyjaksoServiceImpl(
                     )
                 result.putIfAbsent(it.tyoskentelyjakso!!.id!!, 0.0)
                 result[it.tyoskentelyjakso!!.id!!] =
-                    result[it.tyoskentelyjakso!!.id!!]!! + amountOfReducedDays
+                    result.getValue(it.tyoskentelyjakso!!.id!!) + amountOfReducedDays
             }
         return result
     }
@@ -474,38 +479,38 @@ class TyoskentelyjaksoServiceImpl(
         val alkamispaiva = tyoskentelyjaksoDTO.alkamispaiva
         val paattymispaiva = tyoskentelyjaksoDTO.paattymispaiva
 
-        tyoskentelyjaksoDTO.id?.let { tyoskentelyjaksoId ->
+        val tyoskentelyjakso = tyoskentelyjaksoDTO.id?.let { tyoskentelyjaksoId ->
             tyoskentelyjaksoRepository.findOneByIdAndOpintooikeusId(
                 tyoskentelyjaksoId,
                 opintooikeusId
             )
-        }?.let { tyoskentelyjakso ->
-            for (suoritemerkinta in tyoskentelyjakso.suoritemerkinnat) {
-                if (alkamispaiva?.isAfter(suoritemerkinta.suorituspaiva) == true
-                    || paattymispaiva?.isBefore(suoritemerkinta.suorituspaiva) == true
-                ) {
-                    return false
-                }
-            }
-
-            for (keskeytys in tyoskentelyjakso.keskeytykset) {
-                if (alkamispaiva?.isAfter(keskeytys.paattymispaiva) == true
-                    || paattymispaiva?.isBefore(keskeytys.paattymispaiva) == true
-                ) {
-                    return false
-                }
-            }
-
-            for (suoritusarviointi in tyoskentelyjakso.suoritusarvioinnit) {
-                if (alkamispaiva?.isAfter(suoritusarviointi.tapahtumanAjankohta) == true
-                    || paattymispaiva?.isBefore(suoritusarviointi.tapahtumanAjankohta) == true
-                ) {
-                    return false
-                }
-            }
-
-            return true
         } ?: return true
+
+        for (suoritemerkinta in tyoskentelyjakso.suoritemerkinnat) {
+            if (alkamispaiva?.isAfter(suoritemerkinta.suorituspaiva) == true
+                || paattymispaiva?.isBefore(suoritemerkinta.suorituspaiva) == true
+            ) {
+                return false
+            }
+        }
+
+        for (keskeytys in tyoskentelyjakso.keskeytykset) {
+            if (alkamispaiva?.isAfter(keskeytys.paattymispaiva) == true
+                || paattymispaiva?.isBefore(keskeytys.paattymispaiva) == true
+            ) {
+                return false
+            }
+        }
+
+        for (suoritusarviointi in tyoskentelyjakso.suoritusarvioinnit) {
+            if (alkamispaiva?.isAfter(suoritusarviointi.tapahtumanAjankohta) == true
+                || paattymispaiva?.isBefore(suoritusarviointi.tapahtumanAjankohta) == true
+            ) {
+                return false
+            }
+        }
+
+        return true
     }
 
     override fun updateAsiakirjat(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/TyoskentelyjaksoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/TyoskentelyjaksoServiceImpl.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.tyoskentely
 
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.koulutus.Opintoopas
 import fi.elsapalvelu.elsa.domain.tyoskentely.Tyoskentelyjakso
 import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
@@ -30,7 +29,6 @@ import jakarta.validation.ValidationException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.math.max
 import kotlin.math.min

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/TyoskentelyjaksonPituusCounterServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/TyoskentelyjaksonPituusCounterServiceImpl.kt
@@ -13,7 +13,6 @@ import fi.elsapalvelu.elsa.service.dto.tyoskentely.HyvaksiluettavatCounterData
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
-import java.time.LocalDate
 import java.time.ZoneId
 import kotlin.math.max
 import kotlin.math.min

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/TyoskentelyjaksonPituusCounterServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/tyoskentely/TyoskentelyjaksonPituusCounterServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.tyoskentely
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.tyoskentely.Keskeytysaika
 import fi.elsapalvelu.elsa.domain.tyoskentely.Tyoskentelyjakso
 import fi.elsapalvelu.elsa.domain.tyoskentely.PoissaolonSyyTyyppi.*
@@ -145,9 +146,9 @@ class TyoskentelyjaksonPituusCounterServiceImpl : TyoskentelyjaksonPituusCounter
                     // poissaolokohtaisesta määrästä. Hyväksiluetaan näistä niin paljon kuin
                     // pystytään ja päivitetään molemmat laskurit.
                     val hyvaksiLuettavatLeft = if (vahennetaanKerran) min(
-                        hyvaksiluettavatCounterData.hyvaksiluettavatPerYearMap[it.key]!!,
-                        hyvaksiluettavatCounterData.hyvaksiluettavatDays[keskeytysaika.poissaolonSyy]!!
-                    ) else hyvaksiluettavatCounterData.hyvaksiluettavatPerYearMap[it.key]!!
+                        hyvaksiluettavatCounterData.hyvaksiluettavatPerYearMap.getValue(it.key),
+                        hyvaksiluettavatCounterData.hyvaksiluettavatDays.getValue(keskeytysaika.poissaolonSyy!!)
+                    ) else hyvaksiluettavatCounterData.hyvaksiluettavatPerYearMap.getValue(it.key)
                     val (amountOfReducedDays, hyvaksiluettavatUsed) = getAmountOfReducedDaysAndHyvaksiluettavatUsed(
                         it.value,
                         hyvaksiLuettavatLeft
@@ -156,13 +157,13 @@ class TyoskentelyjaksonPituusCounterServiceImpl : TyoskentelyjaksonPituusCounter
                         hyvaksiluettavatCounterData.hyvaksiluettavatDays[keskeytysaika.poissaolonSyy!!] =
                             max(
                                 0.0,
-                                hyvaksiluettavatCounterData.hyvaksiluettavatDays[keskeytysaika.poissaolonSyy!!]!! - hyvaksiluettavatUsed
+                                hyvaksiluettavatCounterData.hyvaksiluettavatDays.getValue(keskeytysaika.poissaolonSyy!!) - hyvaksiluettavatUsed
                             )
                     }
                     hyvaksiluettavatCounterData.hyvaksiluettavatPerYearMap[it.key] =
                         max(
                             0.0,
-                            hyvaksiluettavatCounterData.hyvaksiluettavatPerYearMap[it.key]!! - hyvaksiluettavatUsed
+                            hyvaksiluettavatCounterData.hyvaksiluettavatPerYearMap.getValue(it.key) - hyvaksiluettavatUsed
                         )
                     reducedDaysTotal += amountOfReducedDays
                 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/PdfServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/PdfServiceImpl.kt
@@ -20,7 +20,6 @@ import fi.elsapalvelu.elsa.service.metrics.PdfGenerationMetricsService.Companion
 import fi.elsapalvelu.elsa.service.metrics.PdfGenerationMetricsService.Companion.OP_YHDISTA_PDF
 import org.apache.pdfbox.Loader
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.io.Resource
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/PdfServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/PdfServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.impl.valmistuminen
 
+import org.springframework.beans.factory.annotation.Value
 import com.itextpdf.html2pdf.ConverterProperties
 import com.itextpdf.html2pdf.HtmlConverter
 import com.itextpdf.io.exceptions.IOException

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaServiceImpl.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.impl.valmistuminen
 
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaServiceImpl.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.service.impl.valmistuminen
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.valmistuminen.TerveyskeskuskoulutusjaksonHyvaksynta
 import fi.elsapalvelu.elsa.domain.tyoskentely.Tyoskentelyjakso
 import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
@@ -37,7 +36,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.ValidationException
 import org.springframework.web.multipart.MultipartFile

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoQueryService.kt
@@ -15,7 +15,6 @@ import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.extensions.toNimiPredicate
 import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyyntoRepository
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
-import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonHyvaksyjaRole
 import jakarta.persistence.criteria.*
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoQueryService.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.impl.valmistuminen
 
+import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonHyvaksyjaRole
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.koejakso.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoServiceImpl.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.service.impl.valmistuminen
 
+import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonHyvaksyjaRole
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.*
@@ -815,12 +818,12 @@ class ValmistumispyyntoServiceImpl(
 
         if (!yek && kayttaja.yliopistotAndErikoisalat.none {
                 it.erikoisala?.id == valmistumispyynto.opintooikeus?.erikoisala?.id
-                    && it.vastuuhenkilonTehtavat.map { tehtava -> tehtava.nimi }
+                    && it.vastuuhenkilonTehtavat.map { vastuuhenkilonTehtava -> vastuuhenkilonTehtava.nimi }
                     .contains(tehtava)
             }) {
             throw getValmistumispyyntoNotFoundException()
         } else if (yek && kayttaja.yliopistotAndErikoisalat.none {
-                it.vastuuhenkilonTehtavat.map { tehtava -> tehtava.nimi }
+                it.vastuuhenkilonTehtavat.map { vastuuhenkilonTehtava -> vastuuhenkilonTehtava.nimi }
                     .contains(VastuuhenkilonTehtavatyyppiEnum.YEK_VALMISTUMINEN)
             }) {
             throw getValmistumispyyntoNotFoundException()
@@ -1513,7 +1516,7 @@ class ValmistumispyyntoServiceImpl(
                                 voimassaolonPaattymispaiva = s.voimassaolonPaattymispaiva,
                                 vaadittulkm = s.vaadittulkm,
                                 suoritemerkinnat = suoritemerkinnat[s.id]?.sortedByDescending { m -> m.suorituspaiva }
-                                    ?.map(suoritemerkintaMapper::toDto) ?: listOf()
+                                    ?.map(suoritemerkintaMapper::toDto).orEmpty()
                             )
                         },
                         jarjestysnumero = it.jarjestysnumero

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoServiceImpl.kt
@@ -70,7 +70,6 @@ import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType.*
-import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonHyvaksyjaRole
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
 import fi.elsapalvelu.elsa.service.mail.TransactionalMailService
 import fi.elsapalvelu.elsa.service.mapper.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintosuorituksetFetchingServiceImpl.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.service.integration.LocalizedString
-import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintosuorituksetFetchingServiceImpl.kt
@@ -2,14 +2,12 @@ package fi.elsapalvelu.elsa.service.integration.peppi
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.service.integration.LocalizedString
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
-import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuorituksetPersistenceDTO
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuoritusDTO
 import okhttp3.OkHttpClient
@@ -66,9 +64,6 @@ class PeppiCommonOpintosuorituksetFetchingServiceImpl(
         } catch (e: JsonProcessingException) {
             log.error("$JSON_DATA_PROSESSING_ERROR: $endpointUrl ${e.message}", e)
             throw e
-        } catch (e: JsonMappingException) {
-            log.error("$JSON_MAPPING_ERROR: $endpointUrl ${e.message}", e)
-            throw e
         } catch (e: IOException) {
             log.error("$JSON_FETCHING_ERROR: $endpointUrl ${e.message}", e)
             throw e
@@ -87,4 +82,3 @@ data class StudyAccomplishment(
     val hyvaksytty: Boolean?,
     val arvio: LocalizedString?
 )
-

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintotietodataFetchingServiceImpl.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.integration.peppi
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.ERIKOISTUVA_HAMMASLAAKARI_PEPPI_KOULUTUS
 import fi.elsapalvelu.elsa.config.ERIKOISTUVA_LAAKARI_PEPPI_KOULUTUS
@@ -12,7 +11,6 @@ import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
-import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintotietoOpintooikeusDataDTO
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintotietodataDTO
 import fi.elsapalvelu.elsa.service.dto.enumeration.PeppiOpintooikeudenTila
@@ -74,9 +72,6 @@ class PeppiCommonOpintotietodataFetchingServiceImpl(
         } catch (e: JsonProcessingException) {
             log.error("$JSON_DATA_PROSESSING_ERROR: $endpointUrl ${e.message}", e)
             throw e
-        } catch (e: JsonMappingException) {
-            log.error("$JSON_MAPPING_ERROR: $endpointUrl ${e.message}", e)
-            throw e
         } catch (e: IOException) {
             log.error("$JSON_FETCHING_ERROR: $endpointUrl ${e.message}", e)
             throw e
@@ -116,4 +111,3 @@ data class Entitlement(
 data class ErikoisalaPeppiTurku(
     val avain: String
 )
-

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/PeppiCommonOpintotietodataFetchingServiceImpl.kt
@@ -7,11 +7,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.ERIKOISTUVA_HAMMASLAAKARI_PEPPI_KOULUTUS
 import fi.elsapalvelu.elsa.config.ERIKOISTUVA_LAAKARI_PEPPI_KOULUTUS
 import fi.elsapalvelu.elsa.config.YEK_KOULUTETTAVA_PEPPI_VIRTAKOODI
-import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
 import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila.Companion.fromPeppiOpintooikeudenTila
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate
-import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintotietodataFetchingService
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintotietodataFetchingServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.integration.peppi.oulu
 
+import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
 import fi.elsapalvelu.elsa.OpintotietodataPeppiOuluQuery
 import fi.elsapalvelu.elsa.config.ERIKOISTUVA_HAMMASLAAKARI_PEPPI_KOULUTUS
 import fi.elsapalvelu.elsa.config.ERIKOISTUVA_LAAKARI_PEPPI_KOULUTUS

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/oulu/PeppiOuluOpintotietodataFetchingServiceImpl.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.OpintotietodataPeppiOuluQuery
 import fi.elsapalvelu.elsa.config.ERIKOISTUVA_HAMMASLAAKARI_PEPPI_KOULUTUS
 import fi.elsapalvelu.elsa.config.ERIKOISTUVA_LAAKARI_PEPPI_KOULUTUS
 import fi.elsapalvelu.elsa.config.YEK_KOULUTETTAVA_PEPPI_VIRTAKOODI
-import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.extensions.checkErrors
 import fi.elsapalvelu.elsa.extensions.tryParseToLocalDate

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintosuorituksetFetchingServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.integration.peppi.turku
 
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.perustiedot.YliopistoRepository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/turku/PeppiTurkuOpintosuorituksetFetchingServiceImpl.kt
@@ -5,7 +5,6 @@ import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.perustiedot.YliopistoRepository
 import fi.elsapalvelu.elsa.service.integration.AbstractOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuorituksetPersistenceDTO
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintosuorituksetFetchingServiceImpl.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.integration.peppi.uef
 
+import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.perustiedot.YliopistoRepository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/peppi/uef/PeppiUefOpintosuorituksetFetchingServiceImpl.kt
@@ -5,7 +5,6 @@ import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.perustiedot.YliopistoRepository
 import fi.elsapalvelu.elsa.service.integration.AbstractOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
-import fi.elsapalvelu.elsa.service.integration.peppi.PeppiCommonOpintosuorituksetFetchingService
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuorituksetPersistenceDTO
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaFetchingServiceImpl.kt
@@ -1,13 +1,11 @@
 package fi.elsapalvelu.elsa.service.integration.sisu
 
 import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.service.integration.GraphQLClientBuilder
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
-import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR
 import okhttp3.Request
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -41,10 +39,6 @@ class SisuTutkintoohjelmaFetchingServiceImpl(
         } catch (e: JsonProcessingException) {
             log.error(
                 "$JSON_DATA_PROSESSING_ERROR: $endpointUrl ${e.message}"
-            )
-        } catch (e: JsonMappingException) {
-            log.error(
-                "$JSON_MAPPING_ERROR: $endpointUrl ${e.message} "
             )
         } catch (e: IOException) {
             log.error(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaImportService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaImportService.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.integration.sisu
 
-import fi.elsapalvelu.elsa.service.integration.sisu.Qualifications
 
 interface SisuTutkintoohjelmaImportService {
     fun import(qualifications: Qualifications)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaImportServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaImportServiceImpl.kt
@@ -17,13 +17,13 @@ class SisuTutkintoohjelmaImportServiceImpl(
             ?.mapValues { it.value }
             ?.forEach {
                 it.value
-                    .flatMap { e -> e.requirementCollections ?: listOf() }
-                    .flatMap { r -> r.degreeProgrammeGroupIds?.toSet() ?: listOf() }
+                    .flatMap { e -> e.requirementCollections.orEmpty() }
+                    .flatMap { r -> r.degreeProgrammeGroupIds?.toSet().orEmpty() }
                     .toSet().let { ids ->
                         erikoisalaRepository.findOneByVirtaPatevyyskoodi(it.key!!)?.let { erikoisala ->
                             erikoisala.sisuTutkintoohjelmat.removeIf { s -> s.tutkintoohjelmaId !in ids }
                             ids.map { id ->
-                                if (erikoisala.sisuTutkintoohjelmat.find { s -> s.tutkintoohjelmaId == id } == null) {
+                                if (erikoisala.sisuTutkintoohjelmat.none { s -> s.tutkintoohjelmaId == id }) {
                                     val erikoisalaSisuTutkintoohjelma = ErikoisalaSisuTutkintoohjelma(
                                         tutkintoohjelmaId = id,
                                         erikoisala = erikoisala

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaImportServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/SisuTutkintoohjelmaImportServiceImpl.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.integration.sisu
 
 import fi.elsapalvelu.elsa.domain.koulutus.ErikoisalaSisuTutkintoohjelma
 import fi.elsapalvelu.elsa.repository.perustiedot.ErikoisalaRepository
-import fi.elsapalvelu.elsa.service.integration.sisu.SisuTutkintoohjelmaImportService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreAuthenticationTokenServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreAuthenticationTokenServiceImpl.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.integration.sisu.tampere
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.security.AuthenticationToken
@@ -11,7 +10,6 @@ import fi.elsapalvelu.elsa.service.kayttaja.AuthenticationTokenService
 import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
-import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR
 import okhttp3.FormBody
 import okhttp3.Request
 import org.slf4j.LoggerFactory
@@ -82,10 +80,6 @@ class SisuTreAuthenticationTokenServiceImpl(
         } catch (e: JsonProcessingException) {
             log.error(
                 "$JSON_DATA_PROSESSING_ERROR: $endpointUrl ${e.message}"
-            )
-        } catch (e: JsonMappingException) {
-            log.error(
-                "$JSON_MAPPING_ERROR: $endpointUrl ${e.message} "
             )
         } catch (e: IOException) {
             log.error(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintosuorituksetFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintosuorituksetFetchingServiceImpl.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.integration.sisu.tampere
 
 import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
@@ -12,7 +11,6 @@ import fi.elsapalvelu.elsa.service.integration.LocalizedString
 import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
-import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuorituksetPersistenceDTO
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuoritusDTO
 import okhttp3.Request
@@ -45,10 +43,10 @@ class SisuTreOpintosuorituksetFetchingServiceImpl(
                 }
                 response.body?.string().let { body ->
                     objectMapper.readValue(body, AttainmentsResponse::class.java)
-                        ?.let { response ->
+                        ?.let { attainmentsResponse ->
                             OpintosuorituksetPersistenceDTO(
                                 yliopisto = YliopistoEnum.TAMPEREEN_YLIOPISTO,
-                                items = response.attainments.map {
+                                items = attainmentsResponse.attainments.map {
                                     OpintosuoritusDTO(
                                         suorituspaiva = it.attainmentDate?.tryParseToLocalDate(),
                                         opintopisteet = it.credits,
@@ -68,9 +66,6 @@ class SisuTreOpintosuorituksetFetchingServiceImpl(
             }
         } catch (e: JsonProcessingException) {
             log.error("$JSON_DATA_PROSESSING_ERROR: $endpointUrl ${e.message}", e)
-            throw e
-        } catch (e: JsonMappingException) {
-            log.error("$JSON_MAPPING_ERROR: $endpointUrl ${e.message}", e)
             throw e
         } catch (e: IOException) {
             log.error("$JSON_FETCHING_ERROR: $endpointUrl ${e.message}", e)
@@ -102,4 +97,3 @@ data class Grade(
     val name: LocalizedString?,
     val passed: Boolean
 )
-

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintotietodataFetchingServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/integration/sisu/tampere/SisuTreOpintotietodataFetchingServiceImpl.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.integration.sisu.tampere
 
 import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.*
 import fi.elsapalvelu.elsa.domain.kayttaja.OpintooikeudenTila.Companion.fromSisuOpintooikeudenTila
@@ -12,7 +11,6 @@ import fi.elsapalvelu.elsa.service.integration.AbstractOpintotietodataFetchingSe
 import fi.elsapalvelu.elsa.service.integration.OkHttpClientBuilder
 import fi.elsapalvelu.elsa.service.constants.JSON_DATA_PROSESSING_ERROR
 import fi.elsapalvelu.elsa.service.constants.JSON_FETCHING_ERROR
-import fi.elsapalvelu.elsa.service.constants.JSON_MAPPING_ERROR
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintotietoOpintooikeusDataDTO
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintotietodataDTO
 import fi.elsapalvelu.elsa.service.dto.enumeration.SisuOpintooikeudenTila
@@ -69,9 +67,6 @@ class SisuTreOpintotietodataFetchingServiceImpl(
             }
         } catch (e: JsonProcessingException) {
             log.error("$JSON_DATA_PROSESSING_ERROR: $endpointUrl ${e.message}", e)
-            throw e
-        } catch (e: JsonMappingException) {
-            log.error("$JSON_MAPPING_ERROR: $endpointUrl ${e.message}", e)
             throw e
         } catch (e: IOException) {
             log.error("$JSON_FETCHING_ERROR: $endpointUrl ${e.message}", e)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/ErikoistuvaLaakariService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/ErikoistuvaLaakariService.kt
@@ -7,7 +7,6 @@ import fi.elsapalvelu.elsa.service.dto.kayttajahallinta.KayttajahallintaErikoist
 import fi.elsapalvelu.elsa.service.dto.kayttajahallinta.KayttajahallintaKayttajaListItemDTO
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import java.time.LocalDate
 import java.util.*
 
 interface ErikoistuvaLaakariService {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/ErikoistuvaLaakariService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/ErikoistuvaLaakariService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.kayttaja
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.criteria.KayttajahallintaCriteria
 import fi.elsapalvelu.elsa.service.dto.kayttaja.ErikoistuvaLaakariDTO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.LaillistamispaivaDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/MailService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/MailService.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.service.kayttaja
 import fi.elsapalvelu.elsa.domain.kayttaja.User
 import org.slf4j.LoggerFactory
 import org.springframework.context.MessageSource
-import org.springframework.mail.MailException
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.scheduling.annotation.Async
@@ -13,7 +12,6 @@ import org.thymeleaf.spring6.SpringTemplateEngine
 import tech.jhipster.config.JHipsterProperties
 import java.nio.charset.StandardCharsets
 import java.util.*
-import jakarta.mail.MessagingException
 
 enum class MailProperty(val property: String) {
     USER("user"),

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/OpintooikeusService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/OpintooikeusService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.kayttaja
 
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.kayttaja.User
 import fi.elsapalvelu.elsa.service.dto.kayttaja.OpintooikeusDTO
 import fi.elsapalvelu.elsa.service.dto.kayttajahallinta.KayttajahallintaOpintooikeusDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/OpintooikeusService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/OpintooikeusService.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.kayttaja
 
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.kayttaja.User
 import fi.elsapalvelu.elsa.service.dto.kayttaja.OpintooikeusDTO
 import fi.elsapalvelu.elsa.service.dto.kayttajahallinta.KayttajahallintaOpintooikeusDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/UserService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/UserService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.kayttaja
 
+import java.security.Principal
 import fi.elsapalvelu.elsa.domain.kayttaja.User
 import fi.elsapalvelu.elsa.domain.kayttaja.VerificationToken
 import fi.elsapalvelu.elsa.service.dto.kayttaja.OmatTiedotDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/UserService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/kayttaja/UserService.kt
@@ -7,7 +7,6 @@ import fi.elsapalvelu.elsa.service.dto.kayttaja.UserDTO
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication
-import java.security.Principal
 import javax.crypto.Cipher
 import javax.crypto.SecretKey
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/koejakso/KoejaksonKoulutussopimusService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/koejakso/KoejaksonKoulutussopimusService.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.koejakso
 
-import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonKoulutussopimus
 import fi.elsapalvelu.elsa.service.dto.koejakso.KoejaksonKoulutussopimusDTO
 import java.util.*
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/koejakso/KoejaksonVastuuhenkilonArvioQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/koejakso/KoejaksonVastuuhenkilonArvioQueryService.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.service.koejakso
 
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.koejakso.*
 import fi.elsapalvelu.elsa.domain.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/koejakso/KoejaksonVastuuhenkilonArvioService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/koejakso/KoejaksonVastuuhenkilonArvioService.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.koejakso
 
-import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
 import fi.elsapalvelu.elsa.service.dto.koejakso.KoejaksonVastuuhenkilonArvioDTO
 import java.util.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/koulutus/OpintosuoritusService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/koulutus/OpintosuoritusService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.koulutus
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusTyyppiEnum
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuorituksetDTO
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/koulutus/OpintosuoritusService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/koulutus/OpintosuoritusService.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.koulutus
 
 import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusTyyppiEnum
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuorituksetDTO
-import java.time.LocalDate
 
 interface OpintosuoritusService {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/koulutus/TeoriakoulutusService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/koulutus/TeoriakoulutusService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.koulutus
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
 import fi.elsapalvelu.elsa.service.dto.koulutus.TeoriakoulutusDTO
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/koulutus/TeoriakoulutusService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/koulutus/TeoriakoulutusService.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.koulutus
 
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
 import fi.elsapalvelu.elsa.service.dto.koulutus.TeoriakoulutusDTO
-import java.time.LocalDate
 
 interface TeoriakoulutusService {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/kayttaja/OpintooikeusMapper.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/kayttaja/OpintooikeusMapper.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.mapper.kayttaja
 
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.service.dto.kayttaja.OpintooikeusDTO
 import org.mapstruct.*
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/kayttaja/OpintooikeusMapper.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/kayttaja/OpintooikeusMapper.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.mapper.kayttaja
 
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.service.dto.kayttaja.OpintooikeusDTO
 import org.mapstruct.*
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/koejakso/KoejaksonKoulutussopimusMapper.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/koejakso/KoejaksonKoulutussopimusMapper.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.mapper.koejakso
 
-import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonKoulutussopimus
 import fi.elsapalvelu.elsa.service.dto.koejakso.KoejaksonKoulutussopimusDTO
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/koejakso/KoejaksonKoulutussopimusMapper.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/koejakso/KoejaksonKoulutussopimusMapper.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.mapper.koejakso
 
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonKoulutussopimus
 import fi.elsapalvelu.elsa.service.dto.koejakso.KoejaksonKoulutussopimusDTO
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/koejakso/KoejaksonVastuuhenkilonArvioMapper.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/koejakso/KoejaksonVastuuhenkilonArvioMapper.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.service.mapper.koejakso
 
 import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonLoppukeskustelu
-import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
 import fi.elsapalvelu.elsa.service.dto.koejakso.KoejaksonVastuuhenkilonArvioDTO
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/koejakso/KoejaksonVastuuhenkilonArvioMapper.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/mapper/koejakso/KoejaksonVastuuhenkilonArvioMapper.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.mapper.koejakso
 
+import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonVastuuhenkilonArvio
 import fi.elsapalvelu.elsa.domain.koejakso.KoejaksonLoppukeskustelu
 import fi.elsapalvelu.elsa.service.dto.koejakso.KoejaksonVastuuhenkilonArvioDTO
 import org.mapstruct.Mapper

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/ElsaMetricsService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/metrics/ElsaMetricsService.kt
@@ -5,7 +5,7 @@ import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import java.util.concurrent.atomic.AtomicInteger
 
-abstract class ElsaMetricsService(protected val registry: MeterRegistry) {
+open class ElsaMetricsService(protected val registry: MeterRegistry) {
 
     protected fun atomicGauge(name: String, description: String): AtomicInteger {
         val value = AtomicInteger(0)
@@ -23,4 +23,3 @@ abstract class ElsaMetricsService(protected val registry: MeterRegistry) {
         return Counter.builder(name).description(description).tags(*tags).register(registry)
     }
 }
-

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/seuranta/PaivakirjamerkintaQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/seuranta/PaivakirjamerkintaQueryService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.seuranta
 
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.koejakso.*
 import fi.elsapalvelu.elsa.domain.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/seuranta/SeurantajaksoService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/seuranta/SeurantajaksoService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.seuranta
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.seuranta.EtusivuSeurantajaksoDTO
 import fi.elsapalvelu.elsa.service.dto.seuranta.SeurantajaksoDTO
 import fi.elsapalvelu.elsa.service.dto.seuranta.SeurantajaksonTiedotDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/seuranta/SeurantajaksoService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/seuranta/SeurantajaksoService.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.service.seuranta
 import fi.elsapalvelu.elsa.service.dto.seuranta.EtusivuSeurantajaksoDTO
 import fi.elsapalvelu.elsa.service.dto.seuranta.SeurantajaksoDTO
 import fi.elsapalvelu.elsa.service.dto.seuranta.SeurantajaksonTiedotDTO
-import java.time.LocalDate
 
 interface SeurantajaksoService {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/suoritteet/SuoritemerkintaService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/suoritteet/SuoritemerkintaService.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.service.suoritteet
 
 import fi.elsapalvelu.elsa.service.dto.suoritteet.SuoritemerkintaDTO
 import fi.elsapalvelu.elsa.service.dto.suoritteet.UusiSuoritemerkintaDTO
-import java.time.LocalDate
 
 interface SuoritemerkintaService {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/suoritteet/SuoritemerkintaService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/suoritteet/SuoritemerkintaService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.suoritteet
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.dto.suoritteet.SuoritemerkintaDTO
 import fi.elsapalvelu.elsa.service.dto.suoritteet.UusiSuoritemerkintaDTO
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/tyoskentely/TyoskentelyjaksoService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/tyoskentely/TyoskentelyjaksoService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.tyoskentely
 
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.tyoskentely.Tyoskentelyjakso
 import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/tyoskentely/TyoskentelyjaksoService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/tyoskentely/TyoskentelyjaksoService.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.tyoskentely
 
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.tyoskentely.Tyoskentelyjakso
 import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/tyoskentely/TyoskentelyjaksonPituusCounterService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/tyoskentely/TyoskentelyjaksonPituusCounterService.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.service.tyoskentely
 import fi.elsapalvelu.elsa.domain.tyoskentely.Keskeytysaika
 import fi.elsapalvelu.elsa.domain.tyoskentely.Tyoskentelyjakso
 import fi.elsapalvelu.elsa.service.dto.tyoskentely.HyvaksiluettavatCounterData
-import java.time.LocalDate
 
 interface TyoskentelyjaksonPituusCounterService {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/tyoskentely/TyoskentelyjaksonPituusCounterService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/tyoskentely/TyoskentelyjaksonPituusCounterService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.tyoskentely
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.tyoskentely.Keskeytysaika
 import fi.elsapalvelu.elsa.domain.tyoskentely.Tyoskentelyjakso
 import fi.elsapalvelu.elsa.service.dto.tyoskentely.HyvaksiluettavatCounterData

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaQueryService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.valmistuminen
 
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.*
 import fi.elsapalvelu.elsa.domain.koejakso.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaService.kt
@@ -1,13 +1,11 @@
 package fi.elsapalvelu.elsa.service.valmistuminen
 
-import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.TerveyskeskuskoulutusjaksoSimpleDTO
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.TerveyskeskuskoulutusjaksonHyvaksyntaDTO
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.web.multipart.MultipartFile
-import java.time.LocalDate
 
 interface TerveyskeskuskoulutusjaksonHyvaksyntaService {
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/TerveyskeskuskoulutusjaksonHyvaksyntaService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.valmistuminen
 
+import java.time.LocalDate
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.TerveyskeskuskoulutusjaksoSimpleDTO
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.TerveyskeskuskoulutusjaksonHyvaksyntaDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/ValmistumispyyntoService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/ValmistumispyyntoService.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.service.valmistuminen
 
+import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.*
 import fi.elsapalvelu.elsa.service.dto.koejakso.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/ValmistumispyyntoService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/ValmistumispyyntoService.kt
@@ -1,6 +1,5 @@
 package fi.elsapalvelu.elsa.service.valmistuminen
 
-import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.*
 import fi.elsapalvelu.elsa.service.dto.koejakso.*
@@ -12,7 +11,6 @@ import fi.elsapalvelu.elsa.service.dto.seuranta.*
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.*
 import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
-import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonHyvaksyjaRole
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.web.multipart.MultipartFile

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KayttajaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KayttajaResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.security.*
@@ -123,14 +126,15 @@ class KayttajaResource(
 
         val kayttajanYliopistotDTO: List<KayttajaYliopistoErikoisalatDTO> =
             kayttajanYliopistotJaErikoisalat?.let {
+                @Suppress("UNCHECKED_CAST")
                 objectMapper.readValue(
                     kayttajanYliopistotJaErikoisalat,
                     objectMapper.typeFactory.constructCollectionType(
                         List::class.java,
                         KayttajaYliopistoErikoisalatDTO::class.java
                     )
-                )
-            } ?: listOf()
+                ) as List<KayttajaYliopistoErikoisalatDTO>
+            }.orEmpty()
 
         if (user.authorities?.contains(KOULUTTAJA) == true) {
             kayttajaService.updateKayttaja(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KayttajaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KayttajaResource.kt
@@ -29,7 +29,6 @@ import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication
 import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority
 import org.springframework.web.bind.annotation.*
-import java.security.Principal
 import jakarta.validation.Valid
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal
 
@@ -156,7 +155,7 @@ class KayttajaResource(
     fun vaihdaRooli(
         @Valid @RequestParam rooli: String,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val userId = userService.getAuthenticatedUser(principal).id!!
         val user = userService.getUser(userId)
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KayttajahallintaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KayttajahallintaResource.kt
@@ -39,7 +39,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.net.URI
-import java.security.Principal
 
 private const val KAYTTAJA_ENTITY_NAME = "kayttaja"
 private const val ERIKOISTUVA_LAAKARI_ENTITY_NAME = "erikoistuvaLaakari"
@@ -200,7 +199,7 @@ open class KayttajahallintaResource(
     fun deleteKayttaja(
         @PathVariable id: Long, principal: Principal?,
         @Valid @RequestBody kayttajahallintaReassignedKouluttajaDTO: KayttajahallintaReassignedKouluttajaDTO
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val kayttaja = getKayttajaOrThrow(id)
         validateCurrentUserIsAllowedToManageKayttaja(principal, id)
 
@@ -317,7 +316,7 @@ open class KayttajahallintaResource(
     @PutMapping("/erikoistuvat-laakarit/{id}/kutsu")
     fun resendErikoistuvaLaakariInvitation(
         @PathVariable id: Long, principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val erikoistuvaLaakari = getErikoistuvaLaakariByIdOrThrow(id)
         validateCurrentUserIsAllowedToManageErikoistuvaLaakari(
             principal,
@@ -330,7 +329,7 @@ open class KayttajahallintaResource(
     @PatchMapping("/kayttajat/{id}/aktivoi")
     fun activateKayttaja(
         @PathVariable id: Long, principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val erikoistuvaLaakari = tryToGetErikoistuvaLaakariByKayttajaId(id)
         if (erikoistuvaLaakari != null) {
             validateCurrentUserIsAllowedToManageErikoistuvaLaakari(
@@ -349,7 +348,7 @@ open class KayttajahallintaResource(
     fun passivateKayttaja(
         @PathVariable id: Long, principal: Principal?,
         @Valid @RequestBody kayttajahallintaReassignedKouluttajaDTO: KayttajahallintaReassignedKouluttajaDTO
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val erikoistuvaLaakari = tryToGetErikoistuvaLaakariByKayttajaId(id)
         if (erikoistuvaLaakari != null) {
             validateCurrentUserIsAllowedToManageErikoistuvaLaakari(
@@ -384,7 +383,7 @@ open class KayttajahallintaResource(
 
     @PatchMapping("/erikoistuvat-laakarit/{userId}")
     fun patchErikoistuvaLaakari(@PathVariable userId: String,
-        @Valid @RequestBody updateErikoistuvaLaakariDTO: KayttajahallintaErikoistuvaLaakariUpdateDTO, principal: Principal?): ResponseEntity<Void> {
+        @Valid @RequestBody updateErikoistuvaLaakariDTO: KayttajahallintaErikoistuvaLaakariUpdateDTO, principal: Principal?): ResponseEntity<Unit> {
         val erikoistuvaLaakariDTO = getErikoistuvaLaakariByUserIdOrThrow(userId)
         validateCurrentUserIsAllowedToManageErikoistuvaLaakari(
             principal,
@@ -402,7 +401,7 @@ open class KayttajahallintaResource(
 
     @PatchMapping("/kouluttajat/{kayttajaId}")
     fun patchKouluttaja(@PathVariable kayttajaId: Long, @Valid @RequestBody kayttajahallintaKayttajaDTO: KayttajahallintaKayttajaDTO,
-        principal: Principal?): ResponseEntity<Void> {
+        principal: Principal?): ResponseEntity<Unit> {
         val existingKayttajaDTO = getKayttajaOrThrow(kayttajaId)
         validateCurrentUserIsAllowedToManageKayttaja(principal, existingKayttajaDTO.id!!)
 
@@ -417,7 +416,7 @@ open class KayttajahallintaResource(
 
     @PutMapping("/kouluttajat/{kayttajaId}/kutsu")
     fun resendKouluttajaInvitation(@PathVariable kayttajaId: Long, principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val existingKayttajaDTO = getKayttajaOrThrow(kayttajaId)
         validateCurrentUserIsAllowedToManageKayttaja(principal, existingKayttajaDTO.id!!)
 
@@ -490,7 +489,7 @@ open class KayttajahallintaResource(
         @PathVariable kayttajaId: Long,
         @Valid @RequestBody kayttajahallintaKayttajaDTO: KayttajahallintaKayttajaDTO,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val existingKayttajaDTO = getKayttajaOrThrow(kayttajaId)
         validateCurrentUserIsAllowedToManageKayttaja(principal, existingKayttajaDTO.id!!)
 
@@ -507,7 +506,7 @@ open class KayttajahallintaResource(
 
     @PatchMapping("/virkailijat/{kayttajaId}")
     fun patchVirkailija(@PathVariable kayttajaId: Long, @Valid @RequestBody kayttajahallintaKayttajaDTO: KayttajahallintaKayttajaDTO,
-        principal: Principal?): ResponseEntity<Void> {
+        principal: Principal?): ResponseEntity<Unit> {
         val existingKayttajaDTO = getKayttajaOrThrow(kayttajaId)
         validateCurrentUserIsAllowedToManageKayttaja(principal, existingKayttajaDTO.id!!)
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KayttajahallintaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KayttajahallintaResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.kayttaja.Authority
 import fi.elsapalvelu.elsa.domain.kayttaja.User
@@ -394,7 +396,7 @@ open class KayttajahallintaResource(
         val userDTO = userService.getUser(userId)
         validateEmailNotExists(sahkoposti, userDTO)
         userService.updateEmail(sahkoposti, userId)
-        opintooikeusService.updateOpintooikeudet(userId, updateErikoistuvaLaakariDTO.opintooikeudet ?: listOf())
+        opintooikeusService.updateOpintooikeudet(userId, updateErikoistuvaLaakariDTO.opintooikeudet.orEmpty())
 
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KoejaksoResource.kt
@@ -25,7 +25,6 @@ import fi.elsapalvelu.elsa.web.rest.kouluttaja.*
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.security.Principal
 
 private const val ENTITY_KOEJAKSON_ALOITUSKESKUSTELU = "koejakson_aloituskeskustelu"
 private const val ENTITY_KOEJAKSON_VALIARVIOINTI = "koejakson_valiarviointi"

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/KoejaksoResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/LogoutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/LogoutResource.kt
@@ -7,7 +7,6 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2A
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
-import java.security.Principal
 import jakarta.servlet.http.HttpServletRequest
 
 @RestController
@@ -17,7 +16,7 @@ class LogoutResource(
 ) {
 
     @GetMapping("/api/local-logout")
-    fun localLogout(request: HttpServletRequest): ResponseEntity<Void> {
+    fun localLogout(request: HttpServletRequest): ResponseEntity<Unit> {
         request.session.invalidate()
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/LogoutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/LogoutResource.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest
 
+import java.security.Principal
 import org.springframework.context.annotation.Profile
 import org.springframework.http.ResponseEntity
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/ResponseEntityExtensions.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/ResponseEntityExtensions.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest
 
+import java.net.URLEncoder
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import java.io.InputStream

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/ResponseEntityExtensions.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/ResponseEntityExtensions.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.web.rest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import java.io.InputStream
-import java.net.URLEncoder
 
 /**
  * Builds a file-download [ResponseEntity] from this [InputStream].

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/SeurantakeskustelutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/SeurantakeskustelutResource.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest
 
 import fi.elsapalvelu.elsa.service.seuranta.SeurantajaksoService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.seuranta.SeurantajaksoDTO
 import fi.elsapalvelu.elsa.service.dto.seuranta.SeurantajaksonTiedotDTO
 import fi.elsapalvelu.elsa.service.dto.enumeration.SeurantajaksoTila
@@ -11,7 +10,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
-import java.security.Principal
 import java.util.*
 
 private const val ENTITY_NAME = "seurantajakso"

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/SeurantakeskustelutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/SeurantakeskustelutResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.seuranta.SeurantajaksoService
 import fi.elsapalvelu.elsa.service.dto.seuranta.SeurantajaksoDTO
 import fi.elsapalvelu.elsa.service.dto.seuranta.SeurantajaksonTiedotDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/SuoritusarviointiResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/SuoritusarviointiResource.kt
@@ -26,18 +26,15 @@ import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
 import tech.jhipster.web.util.ResponseUtil
-import java.security.Principal
 import jakarta.validation.Valid
 
 private const val ENTITY_NAME = "suoritusarviointi"

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/SuoritusarviointiResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/SuoritusarviointiResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.extensions.mapAsiakirja
 import fi.elsapalvelu.elsa.service.*
@@ -104,7 +107,7 @@ open class SuoritusarviointiResource(
             .findAsiakirjaBySuoritusarviointiIdAndArvioinninAntajauserId(id, user.id!!, asiakirjaId)
 
         return asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+            ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             ?: ResponseEntity.notFound().build()
     }
 
@@ -116,7 +119,7 @@ open class SuoritusarviointiResource(
         principal: Principal?
     ): ResponseEntity<SuoritusarviointiDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        suoritusarviointiJson.let {
+        return suoritusarviointiJson.let {
             objectMapper.readValue(it, SuoritusarviointiDTO::class.java)
         }?.let { suoritusarviointiDTO ->
             validateDTO(suoritusarviointiDTO)
@@ -130,7 +133,7 @@ open class SuoritusarviointiResource(
                 deletedAsiakirjaIds,
                 user.id!!
             )
-            return ResponseEntity.ok(result)
+            ResponseEntity.ok(result)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/ArviointityokalutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/ArviointityokalutResource.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.common
 
+import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import fi.elsapalvelu.elsa.service.arviointi.ArviointityokaluKategoriaService
 import fi.elsapalvelu.elsa.service.arviointi.ArviointityokaluService
 import fi.elsapalvelu.elsa.service.dto.arviointi.ArviointityokaluDTO
@@ -8,7 +9,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 
-abstract class ArviointityokalutResource(
+open class ArviointityokalutResource(
     private val arviointityokaluService: ArviointityokaluService,
     private val arviointityokaluKategoriaService: ArviointityokaluKategoriaService,
 ) {
@@ -30,8 +31,8 @@ abstract class ArviointityokalutResource(
         val asiakirjaData = arviointityokaluService.getAsiakirjaDataDTO(arviointityokalu.liite)
         return asiakirjaData.fileInputStream
             ?.toFileDownloadResponse(
-                arviointityokalu.liitetiedostonNimi ?: "",
-                arviointityokalu.liitetiedostonTyyppi ?: ""
+                arviointityokalu.liitetiedostonNimi.orEmpty(),
+                arviointityokalu.liitetiedostonTyyppi.orEmpty()
             )
             ?: ResponseEntity.notFound().build()
     }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/ArviointityokalutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/ArviointityokalutResource.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.service.arviointi.ArviointityokaluKategoriaService
 import fi.elsapalvelu.elsa.service.arviointi.ArviointityokaluService
 import fi.elsapalvelu.elsa.service.dto.arviointi.ArviointityokaluDTO
 import fi.elsapalvelu.elsa.service.dto.arviointi.ArviointityokaluKategoriaDTO
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/JulkisetToiminnotResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/JulkisetToiminnotResource.kt
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import java.security.Principal
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/MuutToiminnotResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/MuutToiminnotResource.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.common
 
 import fi.elsapalvelu.elsa.service.arviointi.ArviointityokaluService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.perustiedot.YliopistoService
 import fi.elsapalvelu.elsa.service.dto.arviointi.ArviointityokaluDTO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.HakaYliopistoDTO
@@ -10,7 +9,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/PalauteResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/PalauteResource.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.common
 
 import fi.elsapalvelu.elsa.service.kayttaja.PalauteService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.PalauteDTO
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import java.security.Principal
 import jakarta.validation.Valid
 
 @RestController
@@ -26,7 +24,7 @@ class PalauteResource(
     fun sendPalaute(
         @Valid @RequestBody palauteDTO: PalauteDTO,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         try {
             palauteService.send(palauteDTO, user.id!!)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/PalauteResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/PalauteResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.common
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.kayttaja.PalauteService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.PalauteDTO
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/SuoritusarvioinninKommenttiResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/SuoritusarvioinninKommenttiResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.common
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.arviointi.SuoritusarvioinninKommenttiService
 import fi.elsapalvelu.elsa.service.dto.arviointi.SuoritusarvioinninKommenttiDTO
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/SuoritusarvioinninKommenttiResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/SuoritusarvioinninKommenttiResource.kt
@@ -1,15 +1,12 @@
 package fi.elsapalvelu.elsa.web.rest.common
 
 import fi.elsapalvelu.elsa.service.arviointi.SuoritusarvioinninKommenttiService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.arviointi.SuoritusarvioinninKommenttiDTO
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import java.net.URI
-import java.security.Principal
 import java.time.Instant
 import jakarta.validation.Valid
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TerveyskeskuskoulutusjaksoBaseResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TerveyskeskuskoulutusjaksoBaseResource.kt
@@ -3,11 +3,9 @@ package fi.elsapalvelu.elsa.web.rest.common
 import fi.elsapalvelu.elsa.service.kayttaja.AsiakirjaService
 import fi.elsapalvelu.elsa.service.kayttaja.KayttajaService
 import fi.elsapalvelu.elsa.service.valmistuminen.TerveyskeskuskoulutusjaksonHyvaksyntaService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
 import fi.elsapalvelu.elsa.web.rest.TERVEYSKESKUSKOULUTUSJAKSO_ENTITY_NAME
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.ValidationException
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TerveyskeskuskoulutusjaksoBaseResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TerveyskeskuskoulutusjaksoBaseResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.common
 
+import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.kayttaja.AsiakirjaService
 import fi.elsapalvelu.elsa.service.kayttaja.KayttajaService
 import fi.elsapalvelu.elsa.service.valmistuminen.TerveyskeskuskoulutusjaksonHyvaksyntaService
@@ -10,7 +12,7 @@ import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.ValidationException
 import org.springframework.http.ResponseEntity
 
-abstract class TerveyskeskuskoulutusjaksoBaseResource(
+open class TerveyskeskuskoulutusjaksoBaseResource(
     protected val userService: UserService,
     protected val kayttajaService: KayttajaService,
     protected val terveyskeskuskoulutusjaksonHyvaksyntaService: TerveyskeskuskoulutusjaksonHyvaksyntaService,
@@ -44,7 +46,6 @@ abstract class TerveyskeskuskoulutusjaksoBaseResource(
      */
     protected fun buildAsiakirjaDownloadResponse(asiakirja: AsiakirjaDTO?): ResponseEntity<ByteArray> =
         asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+            ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             ?: ResponseEntity.notFound().build()
 }
-

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TyoskentelyjaksoResourceSupport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TyoskentelyjaksoResourceSupport.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.common
 
+import java.time.LocalDate
+import java.security.Principal
 import fi.elsapalvelu.elsa.extensions.mapAsiakirja
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TyoskentelyjaksoResourceSupport.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/common/TyoskentelyjaksoResourceSupport.kt
@@ -18,8 +18,6 @@ import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
-import java.security.Principal
-import java.time.LocalDate
 
 private const val TYOSKENTELYJAKSO_ENTITY_NAME = "tyoskentelyjakso"
 private const val KESKEYTYSAIKA_ENTITY_NAME = "keskeytysaika"

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResource.kt
@@ -1,5 +1,9 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import fi.elsapalvelu.elsa.extensions.mapAsiakirja
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
@@ -55,8 +59,8 @@ class ErikoistuvaLaakariAsiakirjaResource(
         }
 
         val asiakirjat = files.map { it.mapAsiakirja() }
-        asiakirjaService.create(asiakirjat, opintooikeusId)?.let {
-            return ResponseEntity
+        return asiakirjaService.create(asiakirjat, opintooikeusId)?.let {
+            ResponseEntity
                 .created(URI("/api/asiakirjat"))
                 .body(it)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -123,7 +127,7 @@ class ErikoistuvaLaakariAsiakirjaResource(
         }
 
         return asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+            ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             ?: ResponseEntity.notFound().build()
     }
 
@@ -141,4 +145,3 @@ class ErikoistuvaLaakariAsiakirjaResource(
             .build()
     }
 }
-

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariAsiakirjaResource.kt
@@ -15,8 +15,6 @@ import fi.elsapalvelu.elsa.service.kayttaja.*
 import fi.elsapalvelu.elsa.service.perustiedot.*
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.GrantedAuthority
@@ -25,7 +23,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
 import java.net.URI
-import java.security.Principal
 import jakarta.validation.Valid
 
 private const val ENTITY_NAME = "asiakirja"
@@ -134,7 +131,7 @@ class ErikoistuvaLaakariAsiakirjaResource(
     fun deleteAsiakirja(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariEtusivuResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariEtusivuResource.kt
@@ -1,14 +1,12 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
 import fi.elsapalvelu.elsa.service.kayttaja.EtusivuService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AvoinAsiaDTO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.ErikoistumisenEdistyminenDTO
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/erikoistuva-laakari/etusivu")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariEtusivuResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariEtusivuResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.kayttaja.EtusivuService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AvoinAsiaDTO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.ErikoistumisenEdistyminenDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKaytonAloitusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKaytonAloitusResource.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI
 import fi.elsapalvelu.elsa.security.YEK_KOULUTETTAVA
 import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.KaytonAloitusDTO
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import org.springframework.http.HttpStatus
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import java.security.Principal
 import jakarta.validation.Valid
 
 @RestController
@@ -27,7 +25,7 @@ class ErikoistuvaLaakariKaytonAloitusResource(
     fun putDataForFirstLogin(
         @Valid @RequestBody kaytonAloitusDTO: KaytonAloitusDTO,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
 
         kaytonAloitusDTO.sahkoposti?.let {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKaytonAloitusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKaytonAloitusResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI
 import fi.elsapalvelu.elsa.security.YEK_KOULUTETTAVA

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoejaksoResource.kt
@@ -27,16 +27,13 @@ import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.service.dto.enumeration.KoejaksoTila
 import fi.elsapalvelu.elsa.web.rest.ENTITY_KOEJAKSON_SOPIMUS
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import java.net.URI
-import java.security.Principal
 import jakarta.validation.Valid
 import org.springframework.web.multipart.MultipartFile
-import java.util.Date
 
 private const val ENTITY_KOEJAKSON_ALOITUSKESKUSTELU = "koejakson_aloituskeskustelu"
 private const val ENTITY_KOEJAKSON_VALIARVIOINTI = "koejakson_valiarviointi"
@@ -226,7 +223,7 @@ class ErikoistuvaLaakariKoejaksoResource(
     fun deleteKoulutussopimus(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         koejaksonKoulutussopimusService.delete(id, user.id!!)
         return ResponseEntity
@@ -325,7 +322,7 @@ class ErikoistuvaLaakariKoejaksoResource(
     fun deleteAloituskeskustelu(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         koejaksonAloituskeskusteluService.delete(id, user.id!!)
         return ResponseEntity
@@ -381,7 +378,7 @@ class ErikoistuvaLaakariKoejaksoResource(
     fun deleteValiarviointi(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         koejaksonValiarviointiService.delete(id, user.id!!)
         return ResponseEntity
@@ -440,7 +437,7 @@ class ErikoistuvaLaakariKoejaksoResource(
     fun deleteKehittamistoimenpiteet(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         koejaksonKehittamistoimenpiteetService.delete(id, user.id!!)
         return ResponseEntity
@@ -504,7 +501,7 @@ class ErikoistuvaLaakariKoejaksoResource(
     fun deleteLoppukeskustelu(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         koejaksonLoppukeskusteluService.delete(id, user.id!!)
         return ResponseEntity

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoejaksoResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
@@ -175,8 +178,8 @@ class ErikoistuvaLaakariKoejaksoResource(
             )
         }
 
-        koejaksonKoulutussopimusService.create(koulutussopimusDTO, opintooikeusId)?.let {
-            return ResponseEntity
+        return koejaksonKoulutussopimusService.create(koulutussopimusDTO, opintooikeusId)?.let {
+            ResponseEntity
                 .created(URI("/api/koejakso/koulutussopimus/${it.id}"))
                 .body(it)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -258,8 +261,8 @@ class ErikoistuvaLaakariKoejaksoResource(
             ENTITY_KOEJAKSON_ALOITUSKESKUSTELU
         )
 
-        koejaksonAloituskeskusteluService.create(aloituskeskusteluDTO, opintooikeusId)?.let {
-            return ResponseEntity
+        return koejaksonAloituskeskusteluService.create(aloituskeskusteluDTO, opintooikeusId)?.let {
+            ResponseEntity
                 .created(URI("/api/koejakso/aloituskeskustelu/${it.id}"))
                 .body(it)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -367,8 +370,8 @@ class ErikoistuvaLaakariKoejaksoResource(
             )
         }
 
-        koejaksonValiarviointiService.create(valiarviointiDTO, opintooikeusId)?.let {
-            return ResponseEntity
+        return koejaksonValiarviointiService.create(valiarviointiDTO, opintooikeusId)?.let {
+            ResponseEntity
                 .created(URI("/api/koejakso/valiarviointi/${it.id}"))
                 .body(it)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -425,9 +428,9 @@ class ErikoistuvaLaakariKoejaksoResource(
             )
         }
 
-        koejaksonKehittamistoimenpiteetService.create(kehittamistoimenpiteetDTO, opintooikeusId)
+        return koejaksonKehittamistoimenpiteetService.create(kehittamistoimenpiteetDTO, opintooikeusId)
             ?.let {
-                return ResponseEntity
+                ResponseEntity
                     .created(URI("/api/koejakso/kehittamistoimenpiteet/${it.id}"))
                     .body(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -490,8 +493,8 @@ class ErikoistuvaLaakariKoejaksoResource(
             )
         }
 
-        koejaksonLoppukeskusteluService.create(loppukeskusteluDTO, opintooikeusId)?.let {
-            return ResponseEntity
+        return koejaksonLoppukeskusteluService.create(loppukeskusteluDTO, opintooikeusId)?.let {
+            ResponseEntity
                 .created(URI("/api/koejakso/loppukeskustelu/${it.id}"))
                 .body(it)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -556,7 +559,7 @@ class ErikoistuvaLaakariKoejaksoResource(
             )
         }
 
-        vastuuhenkilonArvioJson.let {
+        return vastuuhenkilonArvioJson.let {
             objectMapper.readValue(it, KoejaksonVastuuhenkilonArvioDTO::class.java)
         }?.let { vastuuhenkilonArvioDTO ->
 
@@ -596,7 +599,7 @@ class ErikoistuvaLaakariKoejaksoResource(
                 opintooikeusId,
                 asiakirjat
             )?.let {
-                return ResponseEntity
+                ResponseEntity
                     .created(URI("/api/koejakso/vastuuhenkilonarvio/${it.id}"))
                     .body(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -625,7 +628,7 @@ class ErikoistuvaLaakariKoejaksoResource(
             )
         }
 
-        vastuuhenkilonArvioJson.let {
+        return vastuuhenkilonArvioJson.let {
             objectMapper.readValue(it, KoejaksonVastuuhenkilonArvioDTO::class.java)
         }?.let { vastuuhenkilonArvioDTO ->
             if (vastuuhenkilonArvioDTO.id == null) {
@@ -651,7 +654,7 @@ class ErikoistuvaLaakariKoejaksoResource(
                 asiakirjat,
                 deletedAsiakirjaIds
             )
-            return ResponseEntity.ok(result)
+            ResponseEntity.ok(result)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKouluttajavaltuutusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKouluttajavaltuutusResource.kt
@@ -1,16 +1,12 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
 import fi.elsapalvelu.elsa.service.kayttaja.KouluttajavaltuutusService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.KayttajaDTO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.KouluttajavaltuutusDTO
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.net.URI
-import java.security.Principal
-import java.time.LocalDate
 import jakarta.validation.Valid
 
 private const val ENTITY_NAME = "kouluttajavaltuutus"

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKouluttajavaltuutusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKouluttajavaltuutusResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.time.LocalDate
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.kayttaja.KouluttajavaltuutusService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.KayttajaDTO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.KouluttajavaltuutusDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoulutusjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoulutusjaksoResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.repository.koulutus.KoulutusjaksoRepository
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
@@ -55,8 +57,8 @@ class ErikoistuvaLaakariKoulutusjaksoResource(
                 "idexists"
             )
         }
-        koulutusjaksoService.save(koulutusjaksoDTO, opintooikeusId)?.let {
-            return ResponseEntity
+        return koulutusjaksoService.save(koulutusjaksoDTO, opintooikeusId)?.let {
+            ResponseEntity
                 .created(URI("/api/koulutusjaksot/${it.id}"))
                 .body(it)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -91,8 +93,8 @@ class ErikoistuvaLaakariKoulutusjaksoResource(
             )
         }
 
-        koulutusjaksoService.save(koulutusjaksoDTO, opintooikeusId)?.let {
-            return ResponseEntity.ok(it)
+        return koulutusjaksoService.save(koulutusjaksoDTO, opintooikeusId)?.let {
+            ResponseEntity.ok(it)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoulutusjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoulutusjaksoResource.kt
@@ -14,14 +14,12 @@ import fi.elsapalvelu.elsa.service.perustiedot.*
 import fi.elsapalvelu.elsa.service.dto.koulutus.KoulutusjaksoDTO
 import fi.elsapalvelu.elsa.service.dto.koulutus.KoulutusjaksoFormDTO
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import java.net.URI
-import java.security.Principal
 import java.util.*
 import jakarta.validation.Valid
 
@@ -128,7 +126,7 @@ class ErikoistuvaLaakariKoulutusjaksoResource(
     fun deleteKoulutusjakso(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         val opintooikeusId = opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoulutussuunnitelmaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoulutussuunnitelmaResource.kt
@@ -5,11 +5,9 @@ import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED
 import fi.elsapalvelu.elsa.service.kayttaja.FileValidationService
 import fi.elsapalvelu.elsa.service.koulutus.KoulutussuunnitelmaService
 import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
 import fi.elsapalvelu.elsa.service.dto.koulutus.KoulutussuunnitelmaDTO
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -19,7 +17,6 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2A
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
-import java.security.Principal
 import jakarta.validation.Valid
 
 @RestController

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoulutussuunnitelmaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoulutussuunnitelmaResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import fi.elsapalvelu.elsa.extensions.mapAsiakirja
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED
 import fi.elsapalvelu.elsa.service.kayttaja.FileValidationService
@@ -52,9 +55,9 @@ class ErikoistuvaLaakariKoulutussuunnitelmaResource(
         koulutussuunnitelmaDTO.motivaatiokirjeAsiakirja =
             getMappedFile(motivaatiokirjeFile, opintooikeusId)
 
-        koulutussuunnitelmaService.save(koulutussuunnitelmaDTO, opintooikeusId)
+        return koulutussuunnitelmaService.save(koulutussuunnitelmaDTO, opintooikeusId)
             ?.let {
-                return ResponseEntity.ok(it)
+                ResponseEntity.ok(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariMuutToiminnotResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariMuutToiminnotResource.kt
@@ -37,8 +37,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
 import java.net.URI
-import java.security.Principal
-import java.time.LocalDate
 import java.util.*
 
 private const val KAYTTAJA_ENTITY_NAME = "kayttaja"
@@ -190,7 +188,7 @@ class ErikoistuvaLaakariMuutToiminnotResource(
     fun updateOpintooikeusKaytossa(
         @PathVariable(value = "id", required = true) id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         opintooikeusService.setOpintooikeusKaytossa(user.id!!, id)
         return ResponseEntity.ok().build()
@@ -200,7 +198,7 @@ class ErikoistuvaLaakariMuutToiminnotResource(
     fun updateMuokkausoikeudet(
         principal: Principal?,
         @RequestParam muokkausoikeudet: Boolean
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         opintooikeusService.updateMuokkausoikeudet(user.id!!, muokkausoikeudet)
         return ResponseEntity.ok().build()

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariMuutToiminnotResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariMuutToiminnotResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import java.time.LocalDate
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import fi.elsapalvelu.elsa.domain.kayttaja.User
 import fi.elsapalvelu.elsa.domain.kayttaja.KayttajatilinTila
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED
@@ -56,7 +59,7 @@ class ErikoistuvaLaakariMuutToiminnotResource(
         principal: Principal?
     ): ResponseEntity<ErikoistuvaLaakariDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        erikoistuvaLaakariService.findOneByKayttajaUserIdWithValidOpintooikeudet(user.id!!)?.let {
+        return erikoistuvaLaakariService.findOneByKayttajaUserIdWithValidOpintooikeudet(user.id!!)?.let {
             if (user.authorities?.contains(ERIKOISTUVA_LAAKARI_IMPERSONATED) == true ||
                 user.authorities?.contains(ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA) == true
             ) {
@@ -72,7 +75,7 @@ class ErikoistuvaLaakariMuutToiminnotResource(
                 it.muokkausoikeudetVirkailijoilla =
                     it.opintooikeudet?.first { o -> o.id == it.opintooikeusKaytossaId }?.muokkausoikeudetVirkailijoilla
             }
-            return ResponseEntity.ok(it)
+            ResponseEntity.ok(it)
         } ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
     }
 
@@ -118,8 +121,8 @@ class ErikoistuvaLaakariMuutToiminnotResource(
         principal: Principal?
     ): ResponseEntity<LaillistamispaivaDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        erikoistuvaLaakariService.getLaillistamispaiva(user.id!!)?.let {
-            return ResponseEntity.ok(it)
+        return erikoistuvaLaakariService.getLaillistamispaiva(user.id!!)?.let {
+            ResponseEntity.ok(it)
         } ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
     }
 
@@ -130,26 +133,30 @@ class ErikoistuvaLaakariMuutToiminnotResource(
     ): ResponseEntity<KayttajaDTO> {
         val user = userService.getAuthenticatedUser(principal)
         erikoistuvaLaakariService.findOneByKayttajaUserId(user.id!!)
-            ?.let {
-                val kouluttajaEmail = requireNotNull(uusiLahikouluttajaDTO.sahkoposti)
-                val existingKouluttaja = try {
-                    kayttajaService.updateKouluttajaYliopistoAndErikoisalaByEmail(
-                        user.id!!,
-                        kouluttajaEmail
-                    )
-                } catch (ex: EntityExistsException) {
-                    throw BadRequestAlertException(
-                        "Samalla sähköpostilla löytyy jo toinen käyttäjä saman yliopiston ja erikoisalan alta",
-                        KAYTTAJA_ENTITY_NAME,
-                        "dataillegal.samalla-sahkopostilla-loytyy-jo-toinen-kayttaja-saman-yliopiston-ja-erikoisalan-alta"
-                    )
-                }
+            ?: throw BadRequestAlertException(
+                "Uuden lahikouluttajan voi lisätä vain erikoistuva lääkäri",
+                KAYTTAJA_ENTITY_NAME,
+                "dataillegal.uuden-lahikouluttajan-voi-lisata-vain-erikoistuva-laakari"
+            )
+        val kouluttajaEmail = requireNotNull(uusiLahikouluttajaDTO.sahkoposti)
+        val existingKouluttaja = try {
+            kayttajaService.updateKouluttajaYliopistoAndErikoisalaByEmail(
+                user.id!!,
+                kouluttajaEmail
+            )
+        } catch (ex: EntityExistsException) {
+            throw BadRequestAlertException(
+                "Samalla sähköpostilla löytyy jo toinen käyttäjä saman yliopiston ja erikoisalan alta",
+                KAYTTAJA_ENTITY_NAME,
+                "dataillegal.samalla-sahkopostilla-loytyy-jo-toinen-kayttaja-saman-yliopiston-ja-erikoisalan-alta"
+            )
+        }
 
-                if (existingKouluttaja != null) {
-                    return ResponseEntity.ok(existingKouluttaja)
-                }
+        if (existingKouluttaja != null) {
+            return ResponseEntity.ok(existingKouluttaja)
+        }
 
-                val result = kayttajaService.saveKouluttaja(
+        val result = kayttajaService.saveKouluttaja(
                     user.id!!,
                     KayttajaDTO(
                         etunimi = uusiLahikouluttajaDTO.etunimi,
@@ -163,25 +170,20 @@ class ErikoistuvaLaakariMuutToiminnotResource(
                         authorities = setOf(KOULUTTAJA)
                     )
                 )
-                val token = verificationTokenService.save(result.userId!!)
-                mailService.sendEmailFromTemplate(
-                    User(email = uusiLahikouluttajaDTO.sahkoposti),
-                    templateName = "uusiKouluttaja.html",
-                    titleKey = "email.uusikouluttaja.title",
-                    properties = mapOf(
-                        Pair(MailProperty.ID, token),
-                        Pair(MailProperty.NAME, user.firstName + " " + user.lastName)
-                    )
-                )
-
-                return ResponseEntity
-                    .created(URI("/api/kayttajat/${result.id}"))
-                    .body(result)
-            } ?: throw BadRequestAlertException(
-            "Uuden lahikouluttajan voi lisätä vain erikoistuva lääkäri",
-            KAYTTAJA_ENTITY_NAME,
-            "dataillegal.uuden-lahikouluttajan-voi-lisata-vain-erikoistuva-laakari"
+        val token = verificationTokenService.save(result.userId!!)
+        mailService.sendEmailFromTemplate(
+            User(email = uusiLahikouluttajaDTO.sahkoposti),
+            templateName = "uusiKouluttaja.html",
+            titleKey = "email.uusikouluttaja.title",
+            properties = mapOf(
+                Pair(MailProperty.ID, token),
+                Pair(MailProperty.NAME, user.firstName + " " + user.lastName)
+            )
         )
+
+        return ResponseEntity
+            .created(URI("/api/kayttajat/${result.id}"))
+            .body(result)
     }
 
     @PatchMapping("opinto-oikeus/{id}")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariOpintosuoritusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariOpintosuoritusResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
 import fi.elsapalvelu.elsa.service.koulutus.OpintosuoritusService
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuorituksetDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariOpintosuoritusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariOpintosuoritusResource.kt
@@ -2,13 +2,11 @@ package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
 import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
 import fi.elsapalvelu.elsa.service.koulutus.OpintosuoritusService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuorituksetDTO
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/erikoistuva-laakari")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariPaivakirjamerkintaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariPaivakirjamerkintaResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.repository.seuranta.PaivakirjamerkintaRepository
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED
 import fi.elsapalvelu.elsa.service.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariPaivakirjamerkintaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariPaivakirjamerkintaResource.kt
@@ -17,7 +17,6 @@ import fi.elsapalvelu.elsa.service.dto.seuranta.PaivakirjamerkinnatOptionsDTO
 import fi.elsapalvelu.elsa.service.dto.seuranta.PaivakirjamerkintaDTO
 import fi.elsapalvelu.elsa.service.dto.seuranta.PaivakirjamerkintaFormDTO
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
@@ -29,7 +28,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import tech.jhipster.service.filter.BooleanFilter
 import java.net.URI
-import java.security.Principal
 import java.util.*
 import jakarta.validation.Valid
 
@@ -141,7 +139,7 @@ class ErikoistuvaLaakariPaivakirjamerkintaResource(
     fun deletePaivakirjamerkinta(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSeurantakeskustelutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSeurantakeskustelutResource.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
 import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
 import fi.elsapalvelu.elsa.service.seuranta.SeurantajaksoService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.seuranta.SeurantajaksoDTO
 import fi.elsapalvelu.elsa.service.dto.seuranta.SeurantajaksonTiedotDTO
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
@@ -12,8 +11,6 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import java.net.URI
-import java.security.Principal
-import java.time.LocalDate
 import java.util.*
 import jakarta.validation.Valid
 
@@ -137,7 +134,7 @@ class ErikoistuvaLaakariSeurantakeskustelutResource(
     fun deleteSeurantajakso(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         val opintooikeusId = opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSeurantakeskustelutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSeurantakeskustelutResource.kt
@@ -1,5 +1,9 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.time.LocalDate
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
 import fi.elsapalvelu.elsa.service.seuranta.SeurantajaksoService
 import fi.elsapalvelu.elsa.service.dto.seuranta.SeurantajaksoDTO
@@ -74,10 +78,10 @@ class ErikoistuvaLaakariSeurantakeskustelutResource(
         val opintooikeusId = opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
         validateNewSeurantajaksoDTO(seurantajaksoDTO)
 
-        seurantajaksoService.create(seurantajaksoDTO, opintooikeusId)?.let {
-            return ResponseEntity
-            .created(URI("/api/seurantakeskustelut/seurantajakso/${it.id}"))
-            .body(it)
+        return seurantajaksoService.create(seurantajaksoDTO, opintooikeusId)?.let {
+            ResponseEntity
+                .created(URI("/api/seurantakeskustelut/seurantajakso/${it.id}"))
+                .body(it)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSuoritemerkintaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSuoritemerkintaResource.kt
@@ -22,14 +22,12 @@ import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import jakarta.validation.Valid
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import java.net.URI
-import java.security.Principal
 
 private const val ENTITY_NAME = "suoritemerkinta"
 
@@ -110,7 +108,7 @@ class ErikoistuvaLaakariSuoritemerkintaResource(
     fun deleteSuoritemerkinta(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         suoritemerkintaService.delete(id, user.id!!)
         return ResponseEntity

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSuoritemerkintaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSuoritemerkintaResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*
@@ -57,8 +59,8 @@ class ErikoistuvaLaakariSuoritemerkintaResource(
 
         uusiSuoritemerkintaDTO.arviointiasteikko =
             arviointiasteikkoService.findByOpintooikeusId(opintooikeusId)
-        suoritemerkintaService.create(uusiSuoritemerkintaDTO, user.id!!)?.let {
-            return ResponseEntity
+        return suoritemerkintaService.create(uusiSuoritemerkintaDTO, user.id!!)?.let {
+            ResponseEntity
                 .created(URI("/api/suoritemerkinnat"))
                 .body(it)
         } ?: throw BadRequestAlertException(
@@ -84,8 +86,8 @@ class ErikoistuvaLaakariSuoritemerkintaResource(
         suoritemerkintaDTO.lukittu = false
         val user = userService.getAuthenticatedUser(principal)
 
-        suoritemerkintaService.save(suoritemerkintaDTO, user.id!!)?.let {
-            return ResponseEntity.ok(it)
+        return suoritemerkintaService.save(suoritemerkintaDTO, user.id!!)?.let {
+            ResponseEntity.ok(it)
         } ?: throw BadRequestAlertException(
             "Suoritemerkinnän työskentelyjakso täytyy olla oma.",
             ENTITY_NAME,
@@ -99,8 +101,8 @@ class ErikoistuvaLaakariSuoritemerkintaResource(
         principal: Principal?
     ): ResponseEntity<SuoritemerkintaDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        suoritemerkintaService.findOne(id, user.id!!)?.let {
-            return ResponseEntity.ok(it)
+        return suoritemerkintaService.findOne(id, user.id!!)?.let {
+            ResponseEntity.ok(it)
         } ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
     }
 
@@ -180,11 +182,8 @@ class ErikoistuvaLaakariSuoritemerkintaResource(
     }
 
     private fun toSortedSuoritteenKategoriat(suoritteenKategoriat: List<SuoritteenKategoriaDTO>): Set<SuoritteenKategoriaDTO> {
-        return suoritteenKategoriat.map {
-            it.apply {
-                suoritteet = suoritteet?.sortedBy { suoritteet -> suoritteet.nimi }?.toSet()
-            }
-            it
+        return suoritteenKategoriat.onEach {
+            it.suoritteet = it.suoritteet?.sortedBy { suorite -> suorite.nimi }?.toSet()
         }.sortedWith(compareBy({ it.jarjestysnumero }, { it.nimi })).toSet()
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSuoritusarviointiResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSuoritusarviointiResource.kt
@@ -1,5 +1,10 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.time.LocalDate
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.extensions.mapAsiakirja
 import fi.elsapalvelu.elsa.service.*
@@ -229,7 +234,7 @@ class ErikoistuvaLaakariSuoritusarviointiResource(
         principal: Principal?
     ): ResponseEntity<SuoritusarviointiDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        suoritusarviointiJson.let {
+        return suoritusarviointiJson.let {
             objectMapper.readValue(it, SuoritusarviointiDTO::class.java)
         }?.let { suoritusarviointiDTO ->
             if (suoritusarviointiDTO.id == null) {
@@ -250,7 +255,7 @@ class ErikoistuvaLaakariSuoritusarviointiResource(
                 deletedAsiakirjaIds,
                 user.id!!
             )
-            return ResponseEntity.ok(result)
+            ResponseEntity.ok(result)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 
@@ -284,7 +289,7 @@ class ErikoistuvaLaakariSuoritusarviointiResource(
             )
 
         return asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+            ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             ?: ResponseEntity.notFound().build()
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSuoritusarviointiResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariSuoritusarviointiResource.kt
@@ -24,8 +24,6 @@ import fi.elsapalvelu.elsa.service.dto.valmistuminen.*
 import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -35,9 +33,6 @@ import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
 import tech.jhipster.web.util.ResponseUtil
 import java.net.URI
-import java.net.URLEncoder
-import java.security.Principal
-import java.time.LocalDate
 import java.time.ZoneId
 import jakarta.validation.Valid
 
@@ -297,7 +292,7 @@ class ErikoistuvaLaakariSuoritusarviointiResource(
     fun deleteSuoritusarviointi(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTeoriakoulutusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTeoriakoulutusResource.kt
@@ -1,6 +1,9 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.extensions.mapAsiakirja
 import fi.elsapalvelu.elsa.repository.koulutus.TeoriakoulutusRepository

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTeoriakoulutusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTeoriakoulutusResource.kt
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
 import java.net.URI
-import java.security.Principal
 import java.util.*
 import jakarta.validation.Valid
 
@@ -151,7 +150,7 @@ class ErikoistuvaLaakariTeoriakoulutusResource(
     fun deleteTeoriakoulutus(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
 
         validateMuokkausoikeudet(principal, user.id!!)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
@@ -2,7 +2,6 @@ package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
-import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*
@@ -37,8 +36,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
 import java.net.URI
-import java.security.Principal
-import java.time.LocalDate
 import kotlin.jvm.optionals.getOrNull
 
 private const val TYOSKENTELYJAKSO_ENTITY_NAME = "tyoskentelyjakso"
@@ -256,7 +253,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
     fun deleteTyoskentelyjakso(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
 
         tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "erikoistujan")
@@ -422,7 +419,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
     fun deleteKeskeytysaika(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
 
         tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME, "erikoistujan")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTyoskentelyjaksoResource.kt
@@ -1,5 +1,10 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.time.LocalDate
+import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.service.*
@@ -41,8 +46,6 @@ import kotlin.jvm.optionals.getOrNull
 private const val TYOSKENTELYJAKSO_ENTITY_NAME = "tyoskentelyjakso"
 private const val KESKEYTYSAIKA_ENTITY_NAME = "keskeytysaika"
 private const val ASIAKIRJA_ENTITY_NAME = "asiakirja"
-private const val TYOSKENTELYPAIKKA_ENTITY_NAME = "tyoskentelypaikka"
-
 @RestController
 @RequestMapping("/api/erikoistuva-laakari")
 class ErikoistuvaLaakariTyoskentelyjaksoResource(
@@ -74,7 +77,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
 
         tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "erikoistujan")
 
-        tyoskentelyjaksoJson.let {
+        return tyoskentelyjaksoJson.let {
             objectMapper.readValue(it, TyoskentelyjaksoDTO::class.java)
         }?.let {
             val opintooikeusId =
@@ -85,13 +88,12 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
 
             val asiakirjaDTOs = tyoskentelyjaksoResourceSupport.getMappedFiles(files, opintooikeusId) ?: mutableSetOf()
             tyoskentelyjaksoService.create(it, opintooikeusId, asiakirjaDTOs)?.let { result ->
-                return ResponseEntity
+                ResponseEntity
                     .created(URI("/api/tyoskentelyjaksot/${result.id}"))
                     .body(result)
-            }
+            } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
 
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
-        throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 
     @PutMapping("/tyoskentelyjaksot")
@@ -107,7 +109,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
 
         tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "erikoistujan")
 
-        tyoskentelyjaksoJson.let {
+        return tyoskentelyjaksoJson.let {
             objectMapper.readValue(it, TyoskentelyjaksoDTO::class.java)
         }?.let {
             if (it.id == null) {
@@ -132,13 +134,12 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
                     deletedAsiakirjaIds
                 )
                     ?.let { result ->
-                        return ResponseEntity.ok(result)
-                    }
+                        ResponseEntity.ok(result)
+                    } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
             } catch (e: ValidationException) {
                 throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
             }
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
-        throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 
     @GetMapping("/tyoskentelyjaksot-taulukko")
@@ -167,7 +168,7 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
 
         // If erikoisala is hammaslääketiede, return terveyskeskuskoulutus = hyväksytty since on that specialty it is not needed to be completed
         if (opintooikeus.erikoisalaId != null && opintooikeus.erikoisalaId!!::class.simpleName == "Long") {
-            var erikoisAla: ErikoisalaDTO? = erikoisalaService.findOne(opintooikeus.erikoisalaId!!).getOrNull()
+            val erikoisAla: ErikoisalaDTO? = erikoisalaService.findOne(opintooikeus.erikoisalaId!!).getOrNull()
             val hammaslaaketiede: ErikoisalaTyyppi = enumValueOf("HAMMASLAAKETIEDE")
             if (erikoisAla != null && erikoisAla.tyyppi == hammaslaaketiede) {
                 table.terveyskeskuskoulutusjaksonTila = TerveyskeskuskoulutusjaksoTila.HYVAKSYTTY
@@ -218,8 +219,8 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
         val user = userService.getAuthenticatedUser(principal)
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
-        tyoskentelyjaksoService.findOne(id, opintooikeusId)?.let {
-            return ResponseEntity.ok(it)
+        return tyoskentelyjaksoService.findOne(id, opintooikeusId)?.let {
+            ResponseEntity.ok(it)
         } ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
     }
 
@@ -236,13 +237,13 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
 
         tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, ASIAKIRJA_ENTITY_NAME, "erikoistujan")
 
-        try {
+        return try {
             tyoskentelyjaksoService.updateAsiakirjat(
                 id,
                 tyoskentelyjaksoResourceSupport.getMappedFiles(addedFiles, opintooikeusId),
                 deletedFiles?.toSet()
             )?.let {
-                return ResponseEntity.ok(it)
+                ResponseEntity.ok(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         } catch (e: ValidationException) {
             throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
@@ -342,9 +343,9 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
             )
         }
 
-        try {
+        return try {
             keskeytysaikaService.save(keskeytysaikaDTO, opintooikeusId)?.let {
-                return ResponseEntity
+                ResponseEntity
                     .created(URI("/api/tyoskentelyjaksot/poissaolot/${it.id}"))
                     .body(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -393,9 +394,9 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
             tyoskentelyjaksoResourceSupport.throwOverlappingTyoskentelyjaksotException()
         }
 
-        try {
+        return try {
             keskeytysaikaService.save(keskeytysaikaDTO, opintooikeusId)?.let {
-                return ResponseEntity.ok(it)
+                ResponseEntity.ok(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         } catch (e: ValidationException) {
             throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
@@ -410,8 +411,8 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
         val user = userService.getAuthenticatedUser(principal)
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id!!)
-        keskeytysaikaService.findOne(id, opintooikeusId)?.let {
-            return ResponseEntity.ok(it)
+        return keskeytysaikaService.findOne(id, opintooikeusId)?.let {
+            ResponseEntity.ok(it)
         } ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
     }
 
@@ -469,13 +470,13 @@ class ErikoistuvaLaakariTyoskentelyjaksoResource(
             )
         }
 
-        tyoskentelyjaksoService.updateLiitettyKoejaksoon(
+        return tyoskentelyjaksoService.updateLiitettyKoejaksoon(
             tyoskentelyjaksoDTO.id!!,
             opintooikeusId,
             tyoskentelyjaksoDTO.liitettyKoejaksoon!!
         )?.let {
             val response = ResponseEntity.ok()
-            return if (tyoskentelyjaksoDTO.liitettyKoejaksoon!!) response.body(it) else response.build()
+            if (tyoskentelyjaksoDTO.liitettyKoejaksoon!!) response.body(it) else response.build()
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariValmistumispyyntoResource.kt
@@ -26,7 +26,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import java.net.URI
-import java.security.Principal
 import jakarta.validation.Valid
 
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariValmistumispyyntoResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaEtusivuResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaEtusivuResource.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.web.rest.kouluttaja
 import fi.elsapalvelu.elsa.service.kayttaja.EtusivuService
 import fi.elsapalvelu.elsa.service.koejakso.KoejaksonVaiheetService
 import fi.elsapalvelu.elsa.service.seuranta.SeurantajaksoService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.criteria.ErikoistujanEteneminenCriteria
 import fi.elsapalvelu.elsa.service.dto.*
 import fi.elsapalvelu.elsa.service.dto.koejakso.*
@@ -21,7 +20,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/kouluttaja/etusivu")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaEtusivuResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaEtusivuResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.kouluttaja
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.kayttaja.EtusivuService
 import fi.elsapalvelu.elsa.service.koejakso.KoejaksonVaiheetService
 import fi.elsapalvelu.elsa.service.seuranta.SeurantajaksoService

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoCommonResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoCommonResource.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.kouluttaja
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoResource.kt
@@ -27,7 +27,6 @@ import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import tech.jhipster.web.util.ResponseUtil
-import java.security.Principal
 
 
 @RestController

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaKoejaksoResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.kouluttaja
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaSeurantakeskustelutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaSeurantakeskustelutResource.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.kouluttaja
 
 import fi.elsapalvelu.elsa.service.seuranta.SeurantajaksoService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.web.rest.SeurantakeskustelutResource
 import org.springframework.web.bind.annotation.*
 import java.util.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaSeurantakeskustelutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaSeurantakeskustelutResource.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.kouluttaja
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.seuranta.SeurantajaksoService
 import fi.elsapalvelu.elsa.web.rest.SeurantakeskustelutResource
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaSuoritusarviointiResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaSuoritusarviointiResource.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.kouluttaja
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaArviointityokalutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaArviointityokalutResource.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.web.rest.tekninenpaakayttaja
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.service.arviointi.ArviointityokaluKategoriaService
 import fi.elsapalvelu.elsa.service.arviointi.ArviointityokaluService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.arviointi.ArviointityokaluDTO
 import fi.elsapalvelu.elsa.service.dto.arviointi.ArviointityokaluKategoriaDTO
 import jakarta.validation.Valid
@@ -11,7 +10,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import tech.jhipster.web.util.ResponseUtil
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/tekninen-paakayttaja")
@@ -52,7 +50,7 @@ class TekninenPaakayttajaArviointityokalutResource(
     @DeleteMapping("/arviointityokalut/kategoria/{id}")
     fun deleteArviointityokaluKategoria(
         @PathVariable id: Long
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         arviointityokaluKategoriaService.delete(id)
         return ResponseEntity.noContent().build()
     }
@@ -98,7 +96,7 @@ class TekninenPaakayttajaArviointityokalutResource(
     @DeleteMapping("/arviointityokalu/{id}")
     fun deleteArviointityokalu(
         @PathVariable id: Long,
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         arviointityokaluService.delete(id)
         return ResponseEntity.noContent().build()
     }
@@ -106,7 +104,7 @@ class TekninenPaakayttajaArviointityokalutResource(
     @PatchMapping("/arviointityokalu/{id}/palauta")
     fun palautaArviointityokalu(
         @PathVariable id: Long
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         arviointityokaluService.palauta(id)
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaArviointityokalutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaArviointityokalutResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.tekninenpaakayttaja
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.service.arviointi.ArviointityokaluKategoriaService
 import fi.elsapalvelu.elsa.service.arviointi.ArviointityokaluService

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaIlmoituksetResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaIlmoituksetResource.kt
@@ -13,7 +13,6 @@ import fi.elsapalvelu.elsa.service.perustiedot.*
 import fi.elsapalvelu.elsa.service.dto.seuranta.IlmoitusDTO
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.security.Principal
 import jakarta.validation.Valid
 
 @RestController
@@ -34,7 +33,7 @@ class TekninenPaakayttajaIlmoituksetResource(
     @DeleteMapping("/ilmoitukset/{id}")
     fun deleteTeoriakoulutus(
         @PathVariable id: Long,
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         ilmoitusService.delete(id)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaKayttajahallintaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaKayttajahallintaResource.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.tekninenpaakayttaja
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaOpetussuunnitelmatResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaOpetussuunnitelmatResource.kt
@@ -29,7 +29,6 @@ import org.springframework.web.server.ResponseStatusException
 import tech.jhipster.web.util.ResponseUtil
 import java.net.URI
 import jakarta.validation.Valid
-import java.security.Principal
 
 private const val OPINTOOPAS_ENTITY_NAME = "opintoopas"
 private const val ERIKOISALA_ENTITY_NAME = "erikoisala"
@@ -198,7 +197,7 @@ class TekninenPaakayttajaOpetussuunnitelmatResource(
     @DeleteMapping("/arvioitavatkokonaisuudet/{id}")
     fun deleteArvioitavaKokonaisuus(
         @PathVariable id: Long
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         arvioitavaKokonaisuusService.delete(id)
         return ResponseEntity
             .noContent()
@@ -286,7 +285,7 @@ class TekninenPaakayttajaOpetussuunnitelmatResource(
     @DeleteMapping("/suoritteet/{id}")
     fun deleteSuorite(
         @PathVariable id: Long
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         suoriteService.delete(id)
         return ResponseEntity
             .noContent()

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaOpetussuunnitelmatResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/tekninenpaakayttaja/TekninenPaakayttajaOpetussuunnitelmatResource.kt
@@ -87,8 +87,8 @@ class TekninenPaakayttajaOpetussuunnitelmatResource(
             )
         }
         validateOpintoopas(opintoopasDTO)
-        opintoopasService.update(opintoopasDTO)?.let {
-            return ResponseEntity
+        return opintoopasService.update(opintoopasDTO)?.let {
+            ResponseEntity
                 .created(URI("/api/tekninen-paakayttaja/opintoopas/${it.id}"))
                 .body(it)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloEtusivuResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloEtusivuResource.kt
@@ -30,7 +30,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import tech.jhipster.service.filter.LongFilter
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/vastuuhenkilo/etusivu")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloEtusivuResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloEtusivuResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloKoejaksoCommonResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloKoejaksoCommonResource.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloKoejaksoResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
+import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*
@@ -175,7 +178,7 @@ class VastuuhenkiloKoejaksoResource(
             val asiakirja = asiakirjaService.findByIdAndLiitettykoejaksoon(asiakirjaId)
 
             asiakirja?.asiakirjaData?.fileInputStream
-                ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+                ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
                 ?.let { return it }
         }
 
@@ -195,7 +198,7 @@ class VastuuhenkiloKoejaksoResource(
             ?.let { asiakirja ->
                 asiakirjaService.findById(asiakirja.id!!)
                     ?.asiakirjaData?.fileInputStream
-                    ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+                    ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             }
             ?: ResponseEntity.notFound().build()
     }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloKoejaksoResource.kt
@@ -22,12 +22,10 @@ import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.web.rest.ENTITY_KOEJAKSON_SOPIMUS
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import tech.jhipster.web.util.ResponseUtil
-import java.security.Principal
 
 private const val ENTITY_KOEJAKSON_VASTUUHENKILON_ARVIO = "koejakson_vastuuhenkilon_arvio"
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloSeurantakeskustelutResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloSeurantakeskustelutResource.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloSuoritusarviointiResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloSuoritusarviointiResource.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResource.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.domain.tyoskentely.TyoskentelyjaksoTyyppi
 import fi.elsapalvelu.elsa.service.kayttaja.AsiakirjaService
 import fi.elsapalvelu.elsa.service.kayttaja.KayttajaService
 import fi.elsapalvelu.elsa.service.valmistuminen.TerveyskeskuskoulutusjaksonHyvaksyntaService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.TerveyskeskuskoulutusjaksoSimpleDTO
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.TerveyskeskuskoulutusjaksoUpdateDTO
@@ -14,7 +13,6 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/vastuuhenkilo")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloTerveyskeskuskoulutusjaksoResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.domain.tyoskentely.TyoskentelyjaksoTyyppi
 import fi.elsapalvelu.elsa.service.kayttaja.AsiakirjaService
 import fi.elsapalvelu.elsa.service.kayttaja.KayttajaService

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
+import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.audit.AuditLoggingWrapper
 import fi.elsapalvelu.elsa.service.valmistuminen.ValmistumispyyntoService
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
@@ -146,7 +149,7 @@ class VastuuhenkiloValmistumispyyntoResource(
         val asiakirja = valmistumispyyntoService.getValmistumispyynnonAsiakirja(user.id!!, valmistumispyyntoId, asiakirjaId)
 
         return asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+            ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             ?: ResponseEntity.notFound().build()
     }
 
@@ -160,7 +163,7 @@ class VastuuhenkiloValmistumispyyntoResource(
         val asiakirja = valmistumispyyntoService.getValmistumispyynnonTyoskentelyjaksoAsiakirja(user.id!!, valmistumispyyntoId, asiakirjaId)
 
         return asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+            ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             ?: ResponseEntity.notFound().build()
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoResource.kt
@@ -1,7 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
 import fi.elsapalvelu.elsa.audit.AuditLoggingWrapper
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.valmistuminen.ValmistumispyyntoService
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.*
@@ -16,13 +15,11 @@ import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.web.rest.VALMISTUMISPYYNTO_ENTITY_NAME
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.security.Principal
 import jakarta.validation.Valid
 
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloVastuualueResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloVastuualueResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.service.kayttaja.KayttajaService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.VastuuhenkilonVastuualueetDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloVastuualueResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloVastuualueResource.kt
@@ -2,13 +2,11 @@ package fi.elsapalvelu.elsa.web.rest.vastuuhenkilo
 
 import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
 import fi.elsapalvelu.elsa.service.kayttaja.KayttajaService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.VastuuhenkilonVastuualueetDTO
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/vastuuhenkilo")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaEtusivuResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaEtusivuResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.virkailija
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaEtusivuResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaEtusivuResource.kt
@@ -29,7 +29,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/virkailija/etusivu")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaKayttajahallintaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaKayttajahallintaResource.kt
@@ -1,5 +1,6 @@
 package fi.elsapalvelu.elsa.web.rest.virkailija
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaKoejaksoResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest.virkailija
 
+import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*
@@ -69,7 +72,7 @@ class VirkailijaKoejaksoResource(
                 kayttaja.orElse(null)?.yliopistot?.map { it.id!! })
 
         return asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+            ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             ?: ResponseEntity.notFound().build()
     }
 
@@ -86,7 +89,7 @@ class VirkailijaKoejaksoResource(
             ?.let { asiakirja ->
                 asiakirjaService.findById(asiakirja.id!!)
                     ?.asiakirjaData?.fileInputStream
-                    ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+                    ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             }
             ?: ResponseEntity.notFound().build()
     }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaKoejaksoResource.kt
@@ -14,13 +14,11 @@ import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.koejakso.KoejaksonVaiheDTO
 import fi.elsapalvelu.elsa.service.dto.koejakso.KoejaksonVastuuhenkilonArvioDTO
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import tech.jhipster.web.util.ResponseUtil
-import java.security.Principal
 import jakarta.validation.Valid
 
 private const val ENTITY_KOEJAKSON_VASTUUHENKILON_ARVIO = "koejakson_vastuuhenkilon_arvio"

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaKurssikooditResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaKurssikooditResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.virkailija
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*
 import fi.elsapalvelu.elsa.service.tyoskentely.*
@@ -72,8 +74,8 @@ class VirkailijaKurssikooditResource(
             )
         }
 
-        opintosuoritusKurssikooditService.save(user.id!!, opintosuoritusKurssikoodiDTO)?.let {
-            return ResponseEntity
+        return opintosuoritusKurssikooditService.save(user.id!!, opintosuoritusKurssikoodiDTO)?.let {
+            ResponseEntity
                 .created(URI("/api/virkailija/kurssikoodi/${it.id}"))
                 .body(it)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaKurssikooditResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaKurssikooditResource.kt
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import tech.jhipster.web.util.ResponseUtil
 import java.net.URI
-import java.security.Principal
 
 private const val KURSSIKOODI_ENTITY_NAME = "opintosuoritus_kurssikoodi"
 
@@ -107,7 +106,7 @@ class VirkailijaKurssikooditResource(
     fun deleteKurssikoodi(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         opintosuoritusKurssikooditService.delete(id, user.id!!)
         return ResponseEntity

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaMuutToiminnotResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaMuutToiminnotResource.kt
@@ -6,7 +6,6 @@ import fi.elsapalvelu.elsa.service.dto.perustiedot.ErikoisalaDTO
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResource.kt
@@ -1,5 +1,9 @@
 package fi.elsapalvelu.elsa.web.rest.virkailija
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.time.LocalDate
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import fi.elsapalvelu.elsa.domain.tyoskentely.TyoskentelyjaksoTyyppi
 import fi.elsapalvelu.elsa.service.kayttaja.AsiakirjaService
 import fi.elsapalvelu.elsa.service.kayttaja.KayttajaService

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaTerveyskeskuskoulutusjaksoResource.kt
@@ -4,7 +4,6 @@ import fi.elsapalvelu.elsa.domain.tyoskentely.TyoskentelyjaksoTyyppi
 import fi.elsapalvelu.elsa.service.kayttaja.AsiakirjaService
 import fi.elsapalvelu.elsa.service.kayttaja.KayttajaService
 import fi.elsapalvelu.elsa.service.valmistuminen.TerveyskeskuskoulutusjaksonHyvaksyntaService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.TerveyskeskuskoulutusjaksoSimpleDTO
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.TerveyskeskuskoulutusjaksoUpdateDTO
@@ -15,8 +14,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
-import java.security.Principal
-import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/virkailija")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaValmistumispyyntoResource.kt
@@ -1,5 +1,9 @@
 package fi.elsapalvelu.elsa.web.rest.virkailija
 
+import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.service.kayttaja.AsiakirjaService
 import fi.elsapalvelu.elsa.service.kayttaja.KayttajaService
@@ -35,7 +39,7 @@ class VirkailijaValmistumispyyntoResource(
             valmistumispyyntoService.findAllForVirkailijaByCriteria(
                 user.id!!,
                 criteria,
-                criteria.erikoisalaId?.let { listOf(it.equals) } ?: listOf(),
+                criteria.erikoisalaId?.let { listOf(it.equals) }.orEmpty(),
                 if (criteria.erikoisalaId?.equals == YEK_ERIKOISALA_ID) listOf() else listOf(YEK_ERIKOISALA_ID),
                 pageable
             )
@@ -97,7 +101,7 @@ class VirkailijaValmistumispyyntoResource(
         )
 
         return asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+            ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             ?: ResponseEntity.notFound().build()
     }
 
@@ -114,7 +118,7 @@ class VirkailijaValmistumispyyntoResource(
                 kayttaja.orElse(null)?.yliopistot?.map { it.id!! })
 
         return asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+            ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             ?: ResponseEntity.notFound().build()
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaValmistumispyyntoResource.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.web.rest.virkailija
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.service.kayttaja.AsiakirjaService
 import fi.elsapalvelu.elsa.service.kayttaja.KayttajaService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.valmistuminen.ValmistumispyyntoService
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyynnonTarkistusDTO
@@ -11,14 +10,12 @@ import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyynnonTarkistus
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoListItemDTO
 import fi.elsapalvelu.elsa.web.rest.VALMISTUMISPYYNTO_ENTITY_NAME
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
 import jakarta.validation.Valid
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
-import java.security.Principal
 
 
 @RestController

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaAsiakirjaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaAsiakirjaResource.kt
@@ -17,8 +17,6 @@ import fi.elsapalvelu.elsa.service.perustiedot.*
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
 import jakarta.validation.Valid
-import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.GrantedAuthority
@@ -27,8 +25,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
 import java.net.URI
-import java.net.URLEncoder
-import java.security.Principal
 
 private const val ASIAKIRJA_ENTITY_NAME = "asiakirja"
 
@@ -143,7 +139,7 @@ class YekKoulutettavaAsiakirjaResource(
     fun deleteAsiakirja(
       @PathVariable id: Long,
       principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaAsiakirjaResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaAsiakirjaResource.kt
@@ -1,5 +1,9 @@
 package fi.elsapalvelu.elsa.web.rest.yekkoulutettava
 
+import fi.elsapalvelu.elsa.web.rest.toFileDownloadResponse
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.extensions.mapAsiakirja
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED
@@ -58,8 +62,8 @@ class YekKoulutettavaAsiakirjaResource(
         }
 
         val asiakirjat = files.map { it.mapAsiakirja() }
-        asiakirjaService.create(asiakirjat, opintooikeusId)?.let {
-            return ResponseEntity.created(URI("/api/asiakirjat"))
+        return asiakirjaService.create(asiakirjat, opintooikeusId)?.let {
+            ResponseEntity.created(URI("/api/asiakirjat"))
                 .body(it)
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
@@ -131,7 +135,7 @@ class YekKoulutettavaAsiakirjaResource(
         }
 
         return asiakirja?.asiakirjaData?.fileInputStream
-            ?.toFileDownloadResponse(asiakirja.nimi ?: "", asiakirja.tyyppi ?: "")
+            ?.toFileDownloadResponse(asiakirja.nimi.orEmpty(), asiakirja.tyyppi.orEmpty())
             ?: ResponseEntity.notFound().build()
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaEtusivuResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaEtusivuResource.kt
@@ -1,14 +1,12 @@
 package fi.elsapalvelu.elsa.web.rest.yekkoulutettava
 
 import fi.elsapalvelu.elsa.service.kayttaja.EtusivuService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AvoinAsiaDTO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.ErikoistumisenEdistyminenDTO
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/yek-koulutettava/etusivu")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaEtusivuResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaEtusivuResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.yekkoulutettava
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.service.kayttaja.EtusivuService
 import fi.elsapalvelu.elsa.service.dto.kayttaja.AvoinAsiaDTO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.ErikoistumisenEdistyminenDTO

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaMuutToiminnotResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaMuutToiminnotResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest.yekkoulutettava
 
+import java.time.LocalDate
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI_IMPERSONATED_VIRKAILIJA
 import fi.elsapalvelu.elsa.service.kayttaja.ErikoistuvaLaakariService
 import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
@@ -54,8 +57,8 @@ class YekKoulutettavaMuutToiminnotResource(
         principal: Principal?
     ): ResponseEntity<LaillistamispaivaDTO> {
         val user = userService.getAuthenticatedUser(principal)
-        erikoistuvaLaakariService.getLaillistamispaiva(user.id!!)?.let {
-            return ResponseEntity.ok(it)
+        return erikoistuvaLaakariService.getLaillistamispaiva(user.id!!)?.let {
+            ResponseEntity.ok(it)
         } ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaMuutToiminnotResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaMuutToiminnotResource.kt
@@ -13,8 +13,6 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2A
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
-import java.security.Principal
-import java.time.LocalDate
 
 private const val ERIKOISTUVA_LAAKARI_ENTITY_NAME = "erikoistuvaLaakari"
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTeoriakoulutusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTeoriakoulutusResource.kt
@@ -4,13 +4,11 @@ import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusTyyppiEnum
 import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
 import fi.elsapalvelu.elsa.service.koulutus.OpintosuoritusService
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuoritusDTO
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.security.Principal
 
 @RestController
 @RequestMapping("/api/yek-koulutettava")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTeoriakoulutusResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTeoriakoulutusResource.kt
@@ -1,5 +1,7 @@
 package fi.elsapalvelu.elsa.web.rest.yekkoulutettava
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.security.Principal
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusTyyppiEnum
 import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResource.kt
@@ -1,5 +1,9 @@
 package fi.elsapalvelu.elsa.web.rest.yekkoulutettava
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import java.time.LocalDate
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
@@ -41,8 +45,6 @@ import java.net.URI
 private const val TYOSKENTELYJAKSO_ENTITY_NAME = "tyoskentelyjakso"
 private const val KESKEYTYSAIKA_ENTITY_NAME = "keskeytysaika"
 private const val ASIAKIRJA_ENTITY_NAME = "asiakirja"
-private const val TYOSKENTELYPAIKKA_ENTITY_NAME = "tyoskentelypaikka"
-
 @RestController
 @RequestMapping("/api/yek-koulutettava")
 class YekKoulutettavaTyoskentelyjaksoResource(
@@ -74,7 +76,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
 
         tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "yek koulutettavan")
 
-        tyoskentelyjaksoJson.let {
+        return tyoskentelyjaksoJson.let {
             objectMapper.readValue(it, TyoskentelyjaksoDTO::class.java)
         }?.let {
             it.kaytannonKoulutus = KaytannonKoulutusTyyppi.OMAN_ERIKOISALAN_KOULUTUS
@@ -86,13 +88,12 @@ class YekKoulutettavaTyoskentelyjaksoResource(
 
             val asiakirjaDTOs = tyoskentelyjaksoResourceSupport.getMappedFiles(files, opintooikeusId) ?: mutableSetOf()
             tyoskentelyjaksoService.create(it, opintooikeusId, asiakirjaDTOs)?.let { result ->
-                return ResponseEntity
+                ResponseEntity
                     .created(URI("/api/yektyoskentelyjaksot/${result.id}"))
                     .body(result)
-            }
+            } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
 
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
-        throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 
 
@@ -109,7 +110,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
 
         tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "yek koulutettavan")
 
-        tyoskentelyjaksoJson.let {
+        return tyoskentelyjaksoJson.let {
             objectMapper.readValue(it, TyoskentelyjaksoDTO::class.java)
         }?.let {
             if (it.id == null) {
@@ -134,13 +135,12 @@ class YekKoulutettavaTyoskentelyjaksoResource(
                     deletedAsiakirjaIds
                 )
                     ?.let { result ->
-                        return ResponseEntity.ok(result)
-                    }
+                        ResponseEntity.ok(result)
+                    } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
             } catch (e: ValidationException) {
                 throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
             }
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
-        throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 
     @GetMapping("/tyoskentelyjaksot-taulukko")
@@ -200,8 +200,8 @@ class YekKoulutettavaTyoskentelyjaksoResource(
         val user = userService.getAuthenticatedUser(principal)
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(user.id!!, YEK_ERIKOISALA_ID)
-        tyoskentelyjaksoService.findOne(id, opintooikeusId)?.let {
-            return ResponseEntity.ok(it)
+        return tyoskentelyjaksoService.findOne(id, opintooikeusId)?.let {
+            ResponseEntity.ok(it)
         } ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
     }
 
@@ -219,13 +219,13 @@ class YekKoulutettavaTyoskentelyjaksoResource(
 
         tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, ASIAKIRJA_ENTITY_NAME, "yek koulutettavan")
 
-        try {
+        return try {
             tyoskentelyjaksoService.updateAsiakirjat(
                 id,
                 tyoskentelyjaksoResourceSupport.getMappedFiles(addedFiles, opintooikeusId),
                 deletedFiles?.toSet()
             )?.let {
-                return ResponseEntity.ok(it)
+                ResponseEntity.ok(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         } catch (e: ValidationException) {
             throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
@@ -325,9 +325,9 @@ class YekKoulutettavaTyoskentelyjaksoResource(
             )
         }
 
-        try {
+        return try {
             keskeytysaikaService.save(keskeytysaikaDTO, opintooikeusId)?.let {
-                return ResponseEntity
+                ResponseEntity
                     .created(URI("/api/tyoskentelyjaksot/poissaolot/${it.id}"))
                     .body(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
@@ -376,9 +376,9 @@ class YekKoulutettavaTyoskentelyjaksoResource(
             tyoskentelyjaksoResourceSupport.throwOverlappingTyoskentelyjaksotException()
         }
 
-        try {
+        return try {
             keskeytysaikaService.save(keskeytysaikaDTO, opintooikeusId)?.let {
-                return ResponseEntity.ok(it)
+                ResponseEntity.ok(it)
             } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         } catch (e: ValidationException) {
             throw tyoskentelyjaksoResourceSupport.liitettyTerveyskoulutusjaksoonException(e)
@@ -393,8 +393,8 @@ class YekKoulutettavaTyoskentelyjaksoResource(
         val user = userService.getAuthenticatedUser(principal)
         val opintooikeusId =
             opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(user.id!!, YEK_ERIKOISALA_ID)
-        keskeytysaikaService.findOne(id, opintooikeusId)?.let {
-            return ResponseEntity.ok(it)
+        return keskeytysaikaService.findOne(id, opintooikeusId)?.let {
+            ResponseEntity.ok(it)
         } ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
     }
 
@@ -452,13 +452,13 @@ class YekKoulutettavaTyoskentelyjaksoResource(
             )
         }
 
-        tyoskentelyjaksoService.updateLiitettyKoejaksoon(
+        return tyoskentelyjaksoService.updateLiitettyKoejaksoon(
             tyoskentelyjaksoDTO.id!!,
             opintooikeusId,
             tyoskentelyjaksoDTO.liitettyKoejaksoon!!
         )?.let {
             val response = ResponseEntity.ok()
-            return if (tyoskentelyjaksoDTO.liitettyKoejaksoon!!) response.body(it) else response.build()
+            if (tyoskentelyjaksoDTO.liitettyKoejaksoon!!) response.body(it) else response.build()
         } ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaTyoskentelyjaksoResource.kt
@@ -37,8 +37,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
 import java.net.URI
-import java.security.Principal
-import java.time.LocalDate
 
 private const val TYOSKENTELYJAKSO_ENTITY_NAME = "tyoskentelyjakso"
 private const val KESKEYTYSAIKA_ENTITY_NAME = "keskeytysaika"
@@ -238,7 +236,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
     fun deleteTyoskentelyjakso(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
 
         tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, TYOSKENTELYJAKSO_ENTITY_NAME, "yek koulutettavan")
@@ -404,7 +402,7 @@ class YekKoulutettavaTyoskentelyjaksoResource(
     fun deleteKeskeytysaika(
         @PathVariable id: Long,
         principal: Principal?
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         val user = userService.getAuthenticatedUser(principal)
 
         tyoskentelyjaksoResourceSupport.validateMuokkausoikeudet(principal, user.id!!, KESKEYTYSAIKA_ENTITY_NAME, "yek koulutettavan")

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaValmistumispyyntoResource.kt
@@ -1,5 +1,8 @@
 package fi.elsapalvelu.elsa.web.rest.yekkoulutettava
 
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import org.springframework.web.bind.annotation.RequestParam
+import java.security.Principal
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
 import fi.elsapalvelu.elsa.service.*
 import fi.elsapalvelu.elsa.service.koejakso.*

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaValmistumispyyntoResource.kt
@@ -27,7 +27,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import java.net.URI
-import java.security.Principal
 
 private const val VALMISTUMISPYYNTO_ENTITY_NAME = "valmistumispyyntö"
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/config/SecurityConfigurationTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/config/SecurityConfigurationTest.kt
@@ -17,6 +17,7 @@ import fi.elsapalvelu.elsa.service.koulutus.OpintotietodataPersistenceService
 import fi.elsapalvelu.elsa.service.kayttaja.UserService
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintosuorituksetPersistenceDTO
 import fi.elsapalvelu.elsa.service.dto.koulutus.OpintotietodataDTO
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -26,6 +27,7 @@ import org.springframework.core.env.Environment
 import org.springframework.web.filter.CorsFilter
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.jvm.isAccessible
@@ -137,8 +139,13 @@ class SecurityConfigurationTest {
         mock(UserRepository::class.java),
         mock(KouluttajavaltuutusRepository::class.java),
         mock(Environment::class.java),
-        mock(ApplicationContext::class.java)
+        mock(ApplicationContext::class.java),
+        DirectTestDispatcher
     )
+
+    private object DirectTestDispatcher : CoroutineDispatcher() {
+        override fun dispatch(context: CoroutineContext, block: Runnable) = block.run()
+    }
 
     private class TestOpintotietodataFetchingService(
         private val yliopisto: YliopistoEnum,
@@ -181,4 +188,3 @@ class SecurityConfigurationTest {
         override fun getYliopisto() = yliopisto
     }
 }
-


### PR DESCRIPTION
This pull request primarily focuses on improving coroutine management and import organization throughout the codebase. The most significant change is the introduction of a centralized `CoroutineDispatcher` bean for IO operations, which is now injected and used in relevant services and configurations. Additionally, there are numerous import cleanups and reorderings, especially regarding `LocalDate` and domain class imports, to enhance code clarity and maintain consistency.

**Coroutine management improvements:**

* Introduced a new `CoroutineConfiguration` class that defines a Spring bean for `ioDispatcher` using `Dispatchers.IO`, centralizing coroutine dispatcher configuration. (`src/main/kotlin/fi/elsapalvelu/elsa/config/CoroutineConfiguration.kt`)
* Updated `SecurityConfiguration` to inject and use the new `ioDispatcher` instead of directly referencing `Dispatchers.IO` for coroutine operations, improving testability and flexibility. (`src/main/kotlin/fi/elsapalvelu/elsa/config/SecurityConfiguration.kt`) [[1]](diffhunk://#diff-19835b16131875979bb6ff061c388d3dbf9aa80fc6c976d18ea02cd5388d7e08R3) [[2]](diffhunk://#diff-19835b16131875979bb6ff061c388d3dbf9aa80fc6c976d18ea02cd5388d7e08L113-R115) [[3]](diffhunk://#diff-19835b16131875979bb6ff061c388d3dbf9aa80fc6c976d18ea02cd5388d7e08L543-R545) [[4]](diffhunk://#diff-19835b16131875979bb6ff061c388d3dbf9aa80fc6c976d18ea02cd5388d7e08L571-R573)

**Import and code cleanup:**

* Reorganized and deduplicated imports, especially for `LocalDate` and domain classes like `Opintooikeus` and `KoejaksonVastuuhenkilonArvio`, across multiple domain model files to follow best practices and reduce confusion. [[1]](diffhunk://#diff-649f0e3260c1410ad301a04d18cbf6bee5531aaaa9df0d1cf93b2a10c67d2500R3-L6) [[2]](diffhunk://#diff-0bdb0855a05c2a8ccf9eef23604a1ff2312fbe3f7035ac1c453ab084fad0b433R3) [[3]](diffhunk://#diff-0bdb0855a05c2a8ccf9eef23604a1ff2312fbe3f7035ac1c453ab084fad0b433L13) [[4]](diffhunk://#diff-81dc215f2a3cc494726f82724172251a478aca9af40805bbf014cdc0e2fcef83R3) [[5]](diffhunk://#diff-81dc215f2a3cc494726f82724172251a478aca9af40805bbf014cdc0e2fcef83L13) [[6]](diffhunk://#diff-370febc38aa4ea6eb826d36e4eb0781bf18b473cc44eebd556b3d82ddc2a6750R3-L8) [[7]](diffhunk://#diff-9ecc0ddcf82c6f88b39c01650d37f83ebbc5726f6c0e138d6ab57b29d5b1a0c8R3-L9) [[8]](diffhunk://#diff-5213b84162dd457f06da7e3f23f53f1f4c4a1688de93ee300214aa9939de02c6R3) [[9]](diffhunk://#diff-5213b84162dd457f06da7e3f23f53f1f4c4a1688de93ee300214aa9939de02c6L12) [[10]](diffhunk://#diff-e34bd97ca49f8b4d41b58e2006e496bf366ce2ee0c9160ce063b8c8a098a2c06R3-L14) [[11]](diffhunk://#diff-6b0017e208ad3f5daad5e4b5274cacd5058bf3d84730014a123b35aaefeef801R3-L14) [[12]](diffhunk://#diff-4212415c02f29194453a5135dea6aeefaade4d4a42aa809702ac05f89d81616dR3-L14) [[13]](diffhunk://#diff-781db3d82ce67b71b3d5f1b46b40d1a9331bdc740d1dbb5beb10dc71110fb169R3-L14) [[14]](diffhunk://#diff-da2d671041489a329181f8c3fa3b4a1cc288c2fc16d1389fd503aa93b00f88d5R3-L14) [[15]](diffhunk://#diff-f587c11c3192620e065ecf7c8fdfa8b999064745261c8db0114537fc54b3b91dR3-L15) [[16]](diffhunk://#diff-0ed506e3c3eb409ef89265a51d1adcf4b0b0242c9c3b946923ef2539518ab401R3-L8) [[17]](diffhunk://#diff-a1ee80c913111f866fb5bb79a0329ba0262692767cb5d6281aa69229f57186bcR3-L8)
* Added missing imports for new domain classes in `CacheConfiguration` to ensure all required classes are available for cache setup. (`src/main/kotlin/fi/elsapalvelu/elsa/config/CacheConfiguration.kt`)
* Minor import adjustments in `LoggingConfiguration` and `ElsaBackendApp` to remove unused imports and improve clarity. (`src/main/kotlin/fi/elsapalvelu/elsa/config/LoggingConfiguration.kt`, `src/main/kotlin/fi/elsapalvelu/elsa/ElsaBackendApp.kt`) [[1]](diffhunk://#diff-8545a63b76cb30085c12a38ad882ec5adfa858eb376a7a99c914b4ef8b4c2593R3) [[2]](diffhunk://#diff-8545a63b76cb30085c12a38ad882ec5adfa858eb376a7a99c914b4ef8b4c2593L11) [[3]](diffhunk://#diff-14313797492d8d7e9342d6570c1130486a354cef2d30dbd276cbdab81e688994R3-L6)

**Entity inheritance adjustment:**

* Changed `AbstractAuditingEntity` from `abstract` to `open` to allow for more flexible inheritance in domain entities. (`src/main/kotlin/fi/elsapalvelu/elsa/domain/AbstractAuditingEntity.kt`)