### PR TITLE
Lisää arkistointi testit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,7 @@ dependencies {
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     testImplementation "org.springframework.security:spring-security-test"
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"
     testImplementation "com.h2database:h2:2.4.240"
     implementation "org.jetbrains.kotlin:kotlin-reflect"
     implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.2.1'

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/TampereLouhiService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/TampereLouhiService.kt
@@ -6,9 +6,12 @@ import org.apache.sshd.common.NamedResource
 import org.apache.sshd.common.config.keys.FilePasswordProvider
 import org.apache.sshd.common.signature.BuiltinSignatures
 import org.apache.sshd.common.util.security.SecurityUtils
+import org.apache.sshd.sftp.client.SftpClient
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.io.ResourceLoader
 import org.springframework.http.HttpStatus
+import org.springframework.integration.file.remote.session.SessionFactory
 import org.springframework.integration.sftp.session.DefaultSftpSessionFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
@@ -16,43 +19,54 @@ import java.io.File
 import java.io.FileInputStream
 
 @Service
-class TampereLouhiService(
-    resourceLoader: ResourceLoader,
-    applicationProperties: ApplicationProperties
+class TampereLouhiService internal constructor(
+    private val sessionFactory: SessionFactory<SftpClient.DirEntry>
 ) {
     private val log = LoggerFactory.getLogger(TampereLouhiService::class.java)
-    private val sessionFactory: DefaultSftpSessionFactory
     private val inProgress = "InProgress"
     private val finished = "Finished"
     private val yekFolder = "YEK"
     private val elsaFolder = "ELSA"
 
-    init {
-        val arkistointiProperties = applicationProperties.getArkistointi().getTre()
-        val client = SshClient.setUpDefaultClient()
-        client.signatureFactories = listOf(
-            BuiltinSignatures.ed25519,
-            BuiltinSignatures.ed25519_cert,
-            BuiltinSignatures.sk_ssh_ed25519)
+    @Autowired
+    constructor(
+        resourceLoader: ResourceLoader,
+        applicationProperties: ApplicationProperties
+    ) : this(createSessionFactory(resourceLoader, applicationProperties))
 
-        arkistointiProperties.privateKeyLocation?.takeIf { it.isNotBlank() }?.let {
-            val resource = resourceLoader.getResource(it)
+    companion object {
+        private fun createSessionFactory(
+            resourceLoader: ResourceLoader,
+            applicationProperties: ApplicationProperties
+        ): DefaultSftpSessionFactory {
+            val arkistointiProperties = applicationProperties.getArkistointi().getTre()
+            val client = SshClient.setUpDefaultClient()
+            client.signatureFactories = listOf(
+                BuiltinSignatures.ed25519,
+                BuiltinSignatures.ed25519_cert,
+                BuiltinSignatures.sk_ssh_ed25519
+            )
 
-            resource.inputStream.use { input ->
-                val keyPairs = SecurityUtils.loadKeyPairIdentities(
-                    null,
-                    NamedResource { it },
-                    input,
-                    FilePasswordProvider.EMPTY
-                )
-                client.addPublicKeyIdentity(keyPairs.iterator().next())
+            arkistointiProperties.privateKeyLocation?.takeIf { it.isNotBlank() }?.let {
+                val resource = resourceLoader.getResource(it)
+
+                resource.inputStream.use { input ->
+                    val keyPairs = SecurityUtils.loadKeyPairIdentities(
+                        null,
+                        NamedResource { it },
+                        input,
+                        FilePasswordProvider.EMPTY
+                    )
+                    client.addPublicKeyIdentity(keyPairs.iterator().next())
+                }
+            }
+
+            return DefaultSftpSessionFactory(client, false).apply {
+                setHost(arkistointiProperties.host)
+                setPort(arkistointiProperties.port?.takeIf { it.isNotBlank() }?.toIntOrNull() ?: 22)
+                setUser(arkistointiProperties.user)
             }
         }
-
-        sessionFactory = DefaultSftpSessionFactory(client, false)
-        sessionFactory.setHost(arkistointiProperties.host)
-        sessionFactory.setPort(arkistointiProperties.port?.takeIf { it.isNotBlank() }?.toIntOrNull() ?: 22)
-        sessionFactory.setUser(arkistointiProperties.user)
     }
 
     fun laheta(filePath: String, yek: Boolean) {

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/HelsinkiSiiloServiceTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/HelsinkiSiiloServiceTest.kt
@@ -1,0 +1,114 @@
+package fi.elsapalvelu.elsa.service.arkistointi
+
+import fi.elsapalvelu.elsa.config.ApplicationProperties
+import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class HelsinkiSiiloServiceTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var service: HelsinkiSiiloService
+    private var temporaryFile: Path? = null
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+
+        val properties = ApplicationProperties()
+        properties.getArkistointi().getHki().apply {
+            host = server.url("/").toString().removeSuffix("/")
+            apiKey = "test-api-key"
+            metadata = ApplicationProperties.Arkistointi.Metadata().apply {
+                cases = mapOf(
+                    CaseType.VALMISTUMINEN.value to ApplicationProperties.Arkistointi.Case().apply {
+                        siiloKoodi = "siilo-123"
+                    }
+                )
+            }
+        }
+        service = HelsinkiSiiloService(properties)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        temporaryFile?.let(Files::deleteIfExists)
+        server.shutdown()
+    }
+
+    @Test
+    fun `laheta posts archive zip as authenticated multipart request and deletes temporary file`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("archived"))
+        val zipFile = createTemporaryZip("siilo-package")
+
+        service.laheta(zipFile.toString(), CaseType.VALMISTUMINEN)
+
+        val request = server.takeRequest()
+        assertThat(request.method).isEqualTo("POST")
+        assertThat(request.path).isEqualTo("/unisign/elsa/archive/siilo-123")
+        assertThat(request.getHeader("X-Api-Key")).isEqualTo("test-api-key")
+        assertThat(request.getHeader("Content-Type")).startsWith("multipart/form-data;")
+        assertThat(request.body.readUtf8())
+            .contains("name=\"file\"")
+            .contains("filename=\"${zipFile.fileName}\"")
+            .contains("siilo-package")
+        assertThat(zipFile).doesNotExist()
+    }
+
+    @Test
+    fun `laheta reports non-successful response and deletes temporary file`() {
+        server.enqueue(MockResponse().setResponseCode(503).setStatus("HTTP/1.1 503 Service Unavailable").setBody("maintenance"))
+        val zipFile = createTemporaryZip("failed-package")
+
+        assertThatThrownBy {
+            service.laheta(zipFile.toString(), CaseType.VALMISTUMINEN)
+        }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("HTTP 503")
+            .hasMessageContaining("maintenance")
+
+        assertThat(zipFile).doesNotExist()
+    }
+
+    @Test
+    fun `laheta propagates connection failure and deletes temporary file`() {
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+        val zipFile = createTemporaryZip("disconnected-package")
+
+        assertThatThrownBy {
+            service.laheta(zipFile.toString(), CaseType.VALMISTUMINEN)
+        }.isInstanceOf(java.io.IOException::class.java)
+
+        assertThat(zipFile).doesNotExist()
+    }
+
+    @Test
+    fun `laheta fails before making request when archive file does not exist`() {
+        val missingFile = Files.createTempFile("missing-siilo-", ".zip")
+        Files.delete(missingFile)
+
+        assertThatThrownBy {
+            service.laheta(missingFile.toString(), CaseType.VALMISTUMINEN)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Arkistointitiedostoa ei löydy")
+
+        assertThat(server.requestCount).isZero()
+    }
+
+    private fun createTemporaryZip(content: String): Path {
+        return Files.createTempFile("siilo-test-", ".zip").also {
+            temporaryFile = it
+            Files.writeString(it, content)
+        }
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/TampereLouhiServiceTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/TampereLouhiServiceTest.kt
@@ -1,0 +1,117 @@
+package fi.elsapalvelu.elsa.service.arkistointi
+
+import org.apache.sshd.sftp.client.SftpClient
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.integration.file.remote.session.Session
+import org.springframework.integration.file.remote.session.SessionFactory
+import org.springframework.web.server.ResponseStatusException
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
+
+class TampereLouhiServiceTest {
+
+    private val sessionFactory = mock<SessionFactory<SftpClient.DirEntry>>()
+    private val session = mock<Session<SftpClient.DirEntry>>()
+    private var temporaryFile: Path? = null
+
+    @AfterEach
+    fun tearDown() {
+        temporaryFile?.let(Files::deleteIfExists)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "false, ELSA",
+        "true, YEK"
+    )
+    fun `laheta uploads through in-progress path and moves file to correct destination`(
+        yek: Boolean,
+        destinationFolder: String
+    ) {
+        whenever(sessionFactory.session).thenReturn(session)
+        whenever(session.list("InProgress")).thenReturn(arrayOf(mock()))
+        var uploadedBytes = byteArrayOf()
+        doAnswer { invocation ->
+            uploadedBytes = invocation.getArgument<InputStream>(0).readBytes()
+            Unit
+        }.whenever(session).write(any(), any())
+        val zipFile = createTemporaryZip("louhi-package")
+
+        TampereLouhiService(sessionFactory).laheta(zipFile.toString(), yek)
+
+        verify(session).write(any(), org.mockito.kotlin.eq("InProgress/${zipFile.fileName}"))
+        verify(session).rename(
+            "InProgress/${zipFile.fileName}",
+            "Finished/$destinationFolder/${zipFile.fileName}"
+        )
+        assertThat(uploadedBytes).isEqualTo("louhi-package".toByteArray())
+        assertThat(zipFile).doesNotExist()
+    }
+
+    @Test
+    fun `laheta fails when in-progress directory is unavailable and deletes temporary file`() {
+        whenever(sessionFactory.session).thenReturn(session)
+        whenever(session.list("InProgress")).thenReturn(emptyArray())
+        val zipFile = createTemporaryZip("unavailable-package")
+
+        assertThatThrownBy {
+            TampereLouhiService(sessionFactory).laheta(zipFile.toString(), false)
+        }
+            .isInstanceOf(ResponseStatusException::class.java)
+            .hasMessageContaining("Arkistointipalvelun hakemisto ei ole käytettävissä")
+
+        verify(session, never()).write(any(), any())
+        verify(session, never()).rename(any(), any())
+        assertThat(zipFile).doesNotExist()
+    }
+
+    @Test
+    fun `laheta propagates upload failure without moving file and deletes temporary file`() {
+        whenever(sessionFactory.session).thenReturn(session)
+        whenever(session.list("InProgress")).thenReturn(arrayOf(mock()))
+        whenever(session.write(any(), any())).thenThrow(IllegalStateException("SFTP write failed"))
+        val zipFile = createTemporaryZip("failed-package")
+
+        assertThatThrownBy {
+            TampereLouhiService(sessionFactory).laheta(zipFile.toString(), false)
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("SFTP write failed")
+
+        verify(session, never()).rename(any(), any())
+        assertThat(zipFile).doesNotExist()
+    }
+
+    @Test
+    fun `laheta fails before opening session when archive file does not exist`() {
+        val missingFile = Files.createTempFile("missing-louhi-", ".zip")
+        Files.delete(missingFile)
+
+        assertThatThrownBy {
+            TampereLouhiService(sessionFactory).laheta(missingFile.toString(), false)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Arkistointitiedostoa ei löydy")
+
+        verify(sessionFactory, never()).session
+    }
+
+    private fun createTemporaryZip(content: String): Path {
+        return Files.createTempFile("louhi-test-", ".zip").also {
+            temporaryFile = it
+            Files.writeString(it, content)
+        }
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
@@ -141,11 +141,26 @@ class ArkistointiServiceImplTest {
             yek = false
         )
 
+        verify(helsinkiSiiloService).laheta("/tmp/ok.zip", CaseType.VALMISTUMINEN)
+        verify(tampereLouhiService, never()).laheta(any(), any())
         verify(alertPublisherService, never()).publishAlert(any(), any())
 
         assertThat(successCount(YliopistoEnum.HELSINGIN_YLIOPISTO, CaseType.VALMISTUMINEN)).isEqualTo(1.0)
         assertThat(errorCount(YliopistoEnum.HELSINGIN_YLIOPISTO, CaseType.VALMISTUMINEN)).isEqualTo(0.0)
         assertThat(arkistointiMetrics.activeArkistointiOperations.get()).isEqualTo(0)
+    }
+
+    @Test
+    fun `laheta routes Tampere archive to Louhi with YEK destination`() {
+        lahetaService.laheta(
+            yliopisto = YliopistoEnum.TAMPEREEN_YLIOPISTO,
+            filePath = "/tmp/yek.zip",
+            caseType = CaseType.VALMISTUMINEN,
+            yek = true
+        )
+
+        verify(tampereLouhiService).laheta("/tmp/yek.zip", true)
+        verify(helsinkiSiiloService, never()).laheta(any(), any())
     }
 
     @Test
@@ -322,4 +337,3 @@ class ArkistointiServiceImplTest {
         return entries
     }
 }
-


### PR DESCRIPTION
This pull request introduces significant improvements to the archiving services, focusing on refactoring the `TampereLouhiService` for better testability and adding comprehensive unit tests for both Helsinki and Tampere archiving logic. The main changes include refactoring the service's constructor, extracting session factory creation, and adding new test classes for improved coverage and reliability.

**Refactoring for testability and maintainability:**

- Refactored `TampereLouhiService` to accept a `SessionFactory<SftpClient.DirEntry>` as a constructor parameter, allowing easier mocking and dependency injection. The session factory creation logic is now encapsulated in a companion object factory method, and the original constructor is annotated with `@Autowired` for Spring compatibility. [[1]](diffhunk://#diff-3a1ffb65c7538417de33b82121baa7ded1077fbce1b6c4874b0a8eb655ca13abR9-R48) [[2]](diffhunk://#diff-3a1ffb65c7538417de33b82121baa7ded1077fbce1b6c4874b0a8eb655ca13abL52-R69)

**Test coverage improvements:**

- Added `TampereLouhiServiceTest`, providing unit tests for the SFTP upload logic, error handling, and file cleanup. The tests use mocks for the session factory and session, covering successful uploads, directory unavailability, upload failures, and missing files.
- Added `HelsinkiSiiloServiceTest`, which uses `MockWebServer` to test HTTP archive uploads, authentication, error handling, and file deletion logic for the Helsinki service.
- Enhanced `ArkistointiServiceImplTest` to verify correct routing of archives to the appropriate service (`laheta` method), including a new test for routing Tampere YEK archives to Louhi.

These changes collectively improve the codebase's testability, reliability, and maintainability by isolating dependencies and ensuring robust coverage of critical archiving workflows.