### PR TITLE
Refactoring of the archiving ("arkistointi") integration infrastructure

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiAdapter.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiAdapter.kt
@@ -1,0 +1,19 @@
+package fi.elsapalvelu.elsa.service.arkistointi
+
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
+
+data class ArkistointiDeliveryRequest(
+    val yliopisto: YliopistoEnum,
+    val filePath: String,
+    val caseType: CaseType,
+    val yek: Boolean,
+    val caseId: String?,
+    val erikoistujanNimi: String?
+)
+
+interface ArkistointiAdapter {
+    val yliopisto: YliopistoEnum
+
+    fun laheta(request: ArkistointiDeliveryRequest)
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiConfigurationProvider.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiConfigurationProvider.kt
@@ -1,0 +1,61 @@
+package fi.elsapalvelu.elsa.service.arkistointi
+
+import fi.elsapalvelu.elsa.config.ApplicationProperties
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
+import org.springframework.stereotype.Component
+
+data class ArkistointiConfiguration(
+    val metadata: ApplicationProperties.Arkistointi.Metadata,
+    val case: ApplicationProperties.Arkistointi.Case
+)
+
+@Component
+class ArkistointiConfigurationProvider(
+    private val applicationProperties: ApplicationProperties
+) {
+    fun getConfiguration(
+        yliopisto: YliopistoEnum,
+        caseType: CaseType
+    ): ArkistointiConfiguration {
+        val metadata = getMetadata(yliopisto)
+        val case = metadata?.getCaseMetadata(caseType)
+            ?: throw IllegalArgumentException(
+                "Arkistointia ${caseType.value} ei ole määritelty yliopistolle ${yliopisto.name}"
+            )
+
+        return ArkistointiConfiguration(metadata, case)
+    }
+
+    fun onKaytossa(yliopisto: YliopistoEnum, caseType: CaseType): Boolean {
+        if (!isEnabled(yliopisto)) {
+            return false
+        }
+
+        return getMetadata(yliopisto)?.getCaseMetadata(caseType) != null
+    }
+
+    fun getTampereHost(): String? = applicationProperties.getArkistointi().getTre().host
+
+    private fun getMetadata(yliopisto: YliopistoEnum): ApplicationProperties.Arkistointi.Metadata? {
+        val arkistointi = applicationProperties.getArkistointi()
+        return when (yliopisto) {
+            YliopistoEnum.TAMPEREEN_YLIOPISTO -> arkistointi.getTre().metadata
+            YliopistoEnum.HELSINGIN_YLIOPISTO -> arkistointi.getHki().metadata
+            YliopistoEnum.OULUN_YLIOPISTO -> arkistointi.getOulu().metadata
+            YliopistoEnum.TURUN_YLIOPISTO -> arkistointi.getTurku().metadata
+            YliopistoEnum.ITA_SUOMEN_YLIOPISTO -> arkistointi.getUef().metadata
+        }
+    }
+
+    private fun isEnabled(yliopisto: YliopistoEnum): Boolean {
+        val arkistointi = applicationProperties.getArkistointi()
+        return when (yliopisto) {
+            YliopistoEnum.OULUN_YLIOPISTO -> arkistointi.getOulu().kaytossa
+            YliopistoEnum.HELSINGIN_YLIOPISTO -> arkistointi.getHki().kaytossa
+            YliopistoEnum.TAMPEREEN_YLIOPISTO -> arkistointi.getTre().kaytossa
+            YliopistoEnum.TURUN_YLIOPISTO -> arkistointi.getTurku().kaytossa
+            YliopistoEnum.ITA_SUOMEN_YLIOPISTO -> arkistointi.getUef().kaytossa
+        }
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiDispatcher.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiDispatcher.kt
@@ -1,0 +1,86 @@
+package fi.elsapalvelu.elsa.service.arkistointi
+
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.service.kayttaja.AlertPublisherService
+import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class ArkistointiDispatcher(
+    adapters: List<ArkistointiAdapter>,
+    private val configurationProvider: ArkistointiConfigurationProvider,
+    private val alertPublisherService: AlertPublisherService,
+    private val arkistointiMetrics: ArkistointiMetricsService
+) {
+    private val log = LoggerFactory.getLogger(ArkistointiDispatcher::class.java)
+    private val adaptersByYliopisto = adapters.associateBy(ArkistointiAdapter::yliopisto)
+
+    fun laheta(request: ArkistointiDeliveryRequest) {
+        arkistointiMetrics.activeArkistointiOperations.incrementAndGet()
+        try {
+            val adapter = adaptersByYliopisto[request.yliopisto]
+            if (adapter == null) {
+                log.info("Integraatiota arkistointiin ei ole tuettu yliopistossa ${request.yliopisto.name}")
+            } else {
+                send(adapter, request)
+            }
+            arkistointiMetrics.recordSuccess(request.yliopisto, request.caseType)
+        } finally {
+            arkistointiMetrics.activeArkistointiOperations.updateAndGet { maxOf(0, it - 1) }
+        }
+    }
+
+    private fun send(adapter: ArkistointiAdapter, request: ArkistointiDeliveryRequest) {
+        try {
+            adapter.laheta(request)
+        } catch (e: Exception) {
+            publishFailureAlert(request, e)
+            arkistointiMetrics.recordError(request.yliopisto, request.caseType)
+            throw e
+        }
+    }
+
+    private fun publishFailureAlert(request: ArkistointiDeliveryRequest, exception: Exception) {
+        when (request.yliopisto) {
+            YliopistoEnum.TAMPEREEN_YLIOPISTO -> alertPublisherService.publishAlert(
+                subject = "Tampere arkistointi epäonnistui",
+                message = buildAlertMessage(
+                    intro = "Arkistointitiedoston lähetys Louhi SFTP-palvelimelle epäonnistui.",
+                    extra = "SFTP-palvelin: ${configurationProvider.getTampereHost() ?: "tuntematon"}.",
+                    request = request,
+                    error = exception.message
+                )
+            )
+
+            YliopistoEnum.HELSINGIN_YLIOPISTO -> alertPublisherService.publishAlert(
+                subject = "Helsinki arkistointi epäonnistui",
+                message = buildAlertMessage(
+                    intro = "Arkistointitiedoston lähetys HY Siilo-palveluun epäonnistui.",
+                    extra = null,
+                    request = request,
+                    error = exception.message
+                )
+            )
+
+            else -> Unit
+        }
+    }
+
+    private fun buildAlertMessage(
+        intro: String,
+        extra: String?,
+        request: ArkistointiDeliveryRequest,
+        error: String?
+    ): String = buildString {
+        append(intro)
+        if (extra != null) append(" $extra")
+        append(" CaseType: ${request.caseType.value}")
+        if (request.caseId != null) append(", Id: ${request.caseId}")
+        if (request.erikoistujanNimi != null) {
+            append(". Erikoistuva lääkäri: ${request.erikoistujanNimi}")
+        }
+        append(". Tiedosto: ${request.filePath}")
+        append(". Virhe: $error")
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiServiceImpl.kt
@@ -1,45 +1,23 @@
 package fi.elsapalvelu.elsa.service.arkistointi
 
-import fi.elsapalvelu.elsa.required
-
-import java.time.LocalDate
 import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
-import com.fasterxml.jackson.dataformat.xml.XmlMapper
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
-import fi.elsapalvelu.elsa.service.kayttaja.AlertPublisherService
-import fi.elsapalvelu.elsa.service.dto.arkistointi.ArkistointiMetadata
 import fi.elsapalvelu.elsa.service.dto.arkistointi.ArkistointiResult
-import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseFile
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
-import fi.elsapalvelu.elsa.service.dto.arkistointi.ContactInformation
-import fi.elsapalvelu.elsa.service.dto.arkistointi.PublicityClass
-import fi.elsapalvelu.elsa.service.dto.arkistointi.Record
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
-import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
-import fi.elsapalvelu.elsa.service.dto.arkistointi.TransferInformation
-import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
-import org.apache.commons.codec.digest.DigestUtils
-import org.slf4j.LoggerFactory
+import fi.elsapalvelu.elsa.service.arkistointi.sahke.SahkeMetadataBuilder
+import fi.elsapalvelu.elsa.service.arkistointi.sahke.SahkeMetadataRequest
+import fi.elsapalvelu.elsa.service.arkistointi.sahke.SahkePakettiBuilder
 import org.springframework.stereotype.Service
-import java.io.FileOutputStream
-import java.text.SimpleDateFormat
-import java.util.ResourceBundle
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
+import java.time.LocalDate
 
 @Service
 class ArkistointiServiceImpl(
-    private val applicationProperties: ApplicationProperties,
-    private val tampereLouhiService: TampereLouhiService,
-    private val helsinkiSiiloService: HelsinkiSiiloService,
-    private val alertPublisherService: AlertPublisherService,
-    private val arkistointiMetrics: ArkistointiMetricsService
+    private val configurationProvider: ArkistointiConfigurationProvider,
+    private val metadataBuilder: SahkeMetadataBuilder,
+    private val pakettiBuilder: SahkePakettiBuilder,
+    private val dispatcher: ArkistointiDispatcher
 ) : ArkistointiService {
-    private val log = LoggerFactory.getLogger(ArkistointiServiceImpl::class.java)
-
     override fun muodostaSahke(
         opintooikeus: Opintooikeus?,
         asiakirjat: List<RecordProperties>,
@@ -51,187 +29,26 @@ class ArkistointiServiceImpl(
         yliopisto: YliopistoEnum?,
         caseType: CaseType
     ): ArkistointiResult {
-        val name = opintooikeus?.erikoistuvaLaakari?.kayttaja?.user?.getName()
-        val syntymaaika = opintooikeus?.erikoistuvaLaakari?.syntymaaika
-        //val title = "${case.type} $name"
-        val metadata = ArkistointiMetadata()
-
         val yliopistoValue = requireNotNull(yliopisto)
-        val metadataProperties = getMetadataForYliopisto(yliopistoValue)
-        val case = metadataProperties?.getCaseMetadata(caseType) ?: throw IllegalArgumentException(
-            "Arkistointia ${caseType.value} ei ole määritelty yliopistolle ${yliopistoValue.name}"
+        val configuration = configurationProvider.getConfiguration(yliopistoValue, caseType)
+        val metadataResult = metadataBuilder.build(
+            SahkeMetadataRequest(
+                opintooikeus = opintooikeus,
+                asiakirjat = asiakirjat,
+                caseId = caseId,
+                tarkastaja = tarkastaja,
+                tarkastusPaiva = tarkastusPaiva,
+                hyvaksyja = hyvaksyja,
+                hyvaksymisPaiva = hyvaksymisPaiva
+            ),
+            configuration
         )
 
-        buildTransferInformation(metadata.transferInformation, metadataProperties, opintooikeus?.id)
-        buildContactInformation(metadata.contactInformation, metadataProperties)
-        buildCaseFile(metadata.caseFile, caseId, name, syntymaaika, metadataProperties, case)
-
-        val configuredAsiakirjat = asiakirjat.filter { recordProperties ->
-            metadataProperties.getDocumentMetadata(recordProperties.type, case) != null
-        }
-
-        buildRecords(
-            configuredAsiakirjat,
-            metadata,
-            metadataProperties,
-            opintooikeus,
-            tarkastaja,
-            tarkastusPaiva,
-            hyvaksyja,
-            hyvaksymisPaiva,
-            case
+        return pakettiBuilder.build(
+            metadataResult = metadataResult,
+            opintooikeus = opintooikeus,
+            zipMetadata = configuration.metadata.zipMetadata
         )
-
-        val mapper = XmlMapper()
-        mapper.registerModule(JavaTimeModule())
-        mapper.dateFormat = SimpleDateFormat("dd.MM.yyyy")
-        mapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)
-
-        val user = opintooikeus?.erikoistuvaLaakari?.kayttaja?.user
-        val title = "${metadata.caseFile.action.type?.lowercase()}_${user?.firstName?.lowercase()}_${user?.lastName?.lowercase()}"
-        val filePath = "/tmp/$title.zip"
-        val fos = FileOutputStream(filePath)
-        val zipOut = ZipOutputStream(fos)
-
-        if (metadataProperties.zipMetadata) {
-            zipOut.putNextEntry(ZipEntry("sahke.xml"))
-            zipOut.write(mapper.writeValueAsBytes(metadata))
-        }
-
-        configuredAsiakirjat.forEach {
-            val asiakirja = it.asiakirja
-            val zipEntry = ZipEntry("pdf/${asiakirja.nimi}")
-            zipOut.putNextEntry(zipEntry)
-            zipOut.write(asiakirja.asiakirjaData?.data)
-        }
-
-        zipOut.close()
-        fos.close()
-
-        val metadataBytes = if (metadataProperties.zipMetadata) null else mapper.writeValueAsBytes(metadata)
-        return ArkistointiResult(filePath, metadataBytes)
-    }
-
-    private fun getMetadataForYliopisto(yliopisto: YliopistoEnum): ApplicationProperties.Arkistointi.Metadata? {
-        val arkistointi = applicationProperties.getArkistointi()
-        return when (yliopisto) {
-            YliopistoEnum.TAMPEREEN_YLIOPISTO -> arkistointi.getTre().metadata
-            YliopistoEnum.HELSINGIN_YLIOPISTO -> arkistointi.getHki().metadata
-            YliopistoEnum.OULUN_YLIOPISTO -> arkistointi.getOulu().metadata
-            YliopistoEnum.TURUN_YLIOPISTO -> arkistointi.getTurku().metadata
-            YliopistoEnum.ITA_SUOMEN_YLIOPISTO -> arkistointi.getUef().metadata
-        }
-    }
-
-    private fun buildTransferInformation(transferInformation: TransferInformation, metadata: ApplicationProperties.Arkistointi.Metadata, opintooikeusId: Long?) {
-        val year = LocalDate.now().year
-        transferInformation.nativeId = "urn:oid:1.2.246.582.200.${opintooikeusId}$year.$year.0001"
-        transferInformation.transferContractId = opintooikeusId?.toString()
-        metadata.useType?.let { transferInformation.useType = it }
-    }
-
-    private fun buildContactInformation(
-        contactInformation: ContactInformation,
-        metadata: ApplicationProperties.Arkistointi.Metadata
-    ) {
-        contactInformation.organisation.name = metadata.organisation
-
-        val contactPerson = contactInformation.contactPerson
-        val contact = metadata.contact
-        contactPerson.name = contact?.person
-        contactPerson.address = contact?.address
-        contactPerson.phoneNumber = contact?.phone
-        contactPerson.email = contact?.email
-    }
-
-    private fun buildCaseFile(
-        caseFile: CaseFile,
-        nativeId: String?,
-        name: String?,
-        syntymaaika: LocalDate?,
-        metadata: ApplicationProperties.Arkistointi.Metadata,
-        caseMetadata: ApplicationProperties.Arkistointi.Case?,
-    ) {
-        caseFile.created = LocalDate.now()
-        caseFile.nativeId = nativeId
-        caseFile.title = caseMetadata?.title
-        caseFile.type = caseMetadata?.type
-        caseFile.function = caseMetadata?.function
-
-        caseFile.restriction.person.name = name
-        caseFile.restriction.person.ssn = syntymaaika
-        caseFile.restriction.owner = metadata.organisation
-        caseFile.retentionReason = metadata.retentionReason
-        caseFile.retentionPeriod = metadata.retentionPeriod
-
-        val action = caseFile.action
-        action.created = LocalDate.now()
-        action.title = caseMetadata?.title
-        action.type = caseMetadata?.type
-    }
-
-    private fun buildRecords(
-        asiakirjat: List<RecordProperties>,
-        metadata: ArkistointiMetadata,
-        arkistointiProperties: ApplicationProperties.Arkistointi.Metadata,
-        opintooikeus: Opintooikeus?,
-        tarkastaja: String?,
-        tarkastusPaiva: LocalDate?,
-        hyvaksyja: String?,
-        hyvaksymisPaiva: LocalDate?,
-        case: ApplicationProperties.Arkistointi.Case?
-    ) {
-        val name = opintooikeus?.erikoistuvaLaakari?.kayttaja?.user?.getName()
-        val resourceBundle = ResourceBundle.getBundle("i18n/messages")
-
-        asiakirjat.forEach { recordProperties ->
-            val documentMetadata = arkistointiProperties.getDocumentMetadata(recordProperties.type, case).required()
-
-            val asiakirja = recordProperties.asiakirja
-            val record = Record()
-            record.created = LocalDate.now()
-            record.nativeId = asiakirja.id?.toString()
-
-            val user = opintooikeus?.erikoistuvaLaakari?.kayttaja?.user
-            record.title = "${user?.lastName}, ${user?.firstName}, ${opintooikeus?.erikoisala?.nimi}"
-            record.type = case?.type
-            record.retentionPeriod = documentMetadata.retentionPeriod
-            record.function = metadata.caseFile.function
-
-            val publicityClass = when (recordProperties.type) {
-                RecordType.YHTEENVETO -> PublicityClass.PUBLIC
-                RecordType.LIITE -> PublicityClass.PARTIALLY_RESTRICTED
-                RecordType.ARVIOINTI -> PublicityClass.PUBLIC
-                RecordType.SOPIMUS -> PublicityClass.PUBLIC
-            }
-
-            record.restriction.publicityClass = publicityClass.displayName
-            record.restriction.securityReason = publicityClass.securityReason
-            record.restriction.person.name = name
-            record.restriction.person.ssn = opintooikeus?.erikoistuvaLaakari?.syntymaaika
-            record.restriction.owner = arkistointiProperties.organisation
-
-            val custom = record.custom
-            custom.erikoistujanNimi = name
-            custom.erikoisala = opintooikeus?.erikoisala?.nimi
-            custom.opiskelijanumero = opintooikeus?.opiskelijatunnus
-            custom.syntymaaika = opintooikeus?.erikoistuvaLaakari?.syntymaaika
-            opintooikeus?.yliopisto?.nimi?.toString()?.let { custom.yliopisto = resourceBundle.getString(it) }
-            custom.tarkastaja = tarkastaja
-            custom.tarkastuspaiva = tarkastusPaiva
-            custom.hyvaksyja = hyvaksyja
-            custom.hyvaksymispaiva = hyvaksymisPaiva
-            custom.asiakirjatyyppi = case?.title
-
-            val document = record.document
-            document.nativeId = asiakirja.nimi
-            document.file.name = asiakirja.nimi
-            document.file.path = "pdf/${asiakirja.nimi}"
-
-            document.format.name = asiakirja.tyyppi
-            document.hashValue = DigestUtils.sha256Hex(asiakirja.asiakirjaData?.data)
-            metadata.caseFile.action.record.add(record)
-        }
     }
 
     override fun laheta(
@@ -242,106 +59,18 @@ class ArkistointiServiceImpl(
         caseId: String?,
         erikoistujanNimi: String?
     ) {
-        arkistointiMetrics.activeArkistointiOperations.incrementAndGet()
-        try {
-            when (yliopisto) {
-                YliopistoEnum.TAMPEREEN_YLIOPISTO -> {
-                    try {
-                        tampereLouhiService.laheta(filePath, yek)
-                    } catch (e: Exception) {
-                        val sftpHost = applicationProperties.getArkistointi().getTre().host ?: "tuntematon"
-                        alertPublisherService.publishAlert(
-                            subject = "Tampere arkistointi epäonnistui",
-                            message = buildAlertMessage(
-                                intro = "Arkistointitiedoston lähetys Louhi SFTP-palvelimelle epäonnistui.",
-                                extra = "SFTP-palvelin: $sftpHost.",
-                                filePath = filePath,
-                                caseType = caseType,
-                                caseId = caseId,
-                                erikoistujanNimi = erikoistujanNimi,
-                                error = e.message
-                            )
-                        )
-                        arkistointiMetrics.recordError(yliopisto, caseType)
-                        throw e
-                    }
-                }
-
-                YliopistoEnum.HELSINGIN_YLIOPISTO -> {
-                    try {
-                        helsinkiSiiloService.laheta(filePath, caseType)
-                    } catch (e: Exception) {
-                        alertPublisherService.publishAlert(
-                            subject = "Helsinki arkistointi epäonnistui",
-                            message = buildAlertMessage(
-                                intro = "Arkistointitiedoston lähetys HY Siilo-palveluun epäonnistui.",
-                                extra = null,
-                                filePath = filePath,
-                                caseType = caseType,
-                                caseId = caseId,
-                                erikoistujanNimi = erikoistujanNimi,
-                                error = e.message
-                            )
-                        )
-                        arkistointiMetrics.recordError(yliopisto, caseType)
-                        throw e
-                    }
-                }
-
-                else -> log.info("Integraatiota arkistointiin ei ole tuettu yliopistossa ${yliopisto.name}")
-            }
-            arkistointiMetrics.recordSuccess(yliopisto, caseType)
-        } finally {
-            arkistointiMetrics.activeArkistointiOperations.updateAndGet { maxOf(0, it - 1) }
-        }
+        dispatcher.laheta(
+            ArkistointiDeliveryRequest(
+                yliopisto = yliopisto,
+                filePath = filePath,
+                caseType = caseType,
+                yek = yek,
+                caseId = caseId,
+                erikoistujanNimi = erikoistujanNimi
+            )
+        )
     }
 
-    override fun onKaytossa(yliopisto: YliopistoEnum, caseType: CaseType): Boolean {
-        val kaytossa = when (yliopisto) {
-            YliopistoEnum.OULUN_YLIOPISTO -> {
-                applicationProperties.getArkistointi().getOulu().kaytossa
-            }
-
-            YliopistoEnum.HELSINGIN_YLIOPISTO -> {
-                applicationProperties.getArkistointi().getHki().kaytossa
-            }
-
-            YliopistoEnum.TAMPEREEN_YLIOPISTO -> {
-                applicationProperties.getArkistointi().getTre().kaytossa
-            }
-
-            YliopistoEnum.TURUN_YLIOPISTO -> {
-                applicationProperties.getArkistointi().getTurku().kaytossa
-            }
-
-            YliopistoEnum.ITA_SUOMEN_YLIOPISTO -> {
-                applicationProperties.getArkistointi().getUef().kaytossa
-            }
-        }
-
-        if (!kaytossa) {
-            return false
-        }
-
-        val metadataProperties = getMetadataForYliopisto(yliopisto)
-        return metadataProperties?.getCaseMetadata(caseType) != null
-    }
-
-    private fun buildAlertMessage(
-        intro: String,
-        extra: String?,
-        filePath: String,
-        caseType: CaseType,
-        caseId: String?,
-        erikoistujanNimi: String?,
-        error: String?
-    ): String = buildString {
-        append(intro)
-        if (extra != null) append(" $extra")
-        append(" CaseType: ${caseType.value}")
-        if (caseId != null) append(", Id: $caseId")
-        if (erikoistujanNimi != null) append(". Erikoistuva lääkäri: $erikoistujanNimi")
-        append(". Tiedosto: $filePath")
-        append(". Virhe: $error")
-    }
+    override fun onKaytossa(yliopisto: YliopistoEnum, caseType: CaseType): Boolean =
+        configurationProvider.onKaytossa(yliopisto, caseType)
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/louhi/LouhiArkistointiAdapter.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/louhi/LouhiArkistointiAdapter.kt
@@ -1,0 +1,17 @@
+package fi.elsapalvelu.elsa.service.arkistointi.louhi
+
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiAdapter
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiDeliveryRequest
+import org.springframework.stereotype.Component
+
+@Component
+class LouhiArkistointiAdapter(
+    private val tampereLouhiService: TampereLouhiService
+) : ArkistointiAdapter {
+    override val yliopisto = YliopistoEnum.TAMPEREEN_YLIOPISTO
+
+    override fun laheta(request: ArkistointiDeliveryRequest) {
+        tampereLouhiService.laheta(request.filePath, request.yek)
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/louhi/TampereLouhiService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/louhi/TampereLouhiService.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.arkistointi
+package fi.elsapalvelu.elsa.service.arkistointi.louhi
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import org.apache.sshd.client.SshClient

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/sahke/SahkeMetadataBuilder.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/sahke/SahkeMetadataBuilder.kt
@@ -1,0 +1,181 @@
+package fi.elsapalvelu.elsa.service.arkistointi.sahke
+
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiConfiguration
+import fi.elsapalvelu.elsa.service.dto.arkistointi.ArkistointiMetadata
+import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseFile
+import fi.elsapalvelu.elsa.service.dto.arkistointi.ContactInformation
+import fi.elsapalvelu.elsa.service.dto.arkistointi.PublicityClass
+import fi.elsapalvelu.elsa.service.dto.arkistointi.Record
+import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
+import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
+import fi.elsapalvelu.elsa.service.dto.arkistointi.TransferInformation
+import org.apache.commons.codec.digest.DigestUtils
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.util.ResourceBundle
+
+data class SahkeMetadataRequest(
+    val opintooikeus: Opintooikeus?,
+    val asiakirjat: List<RecordProperties>,
+    val caseId: String?,
+    val tarkastaja: String?,
+    val tarkastusPaiva: LocalDate?,
+    val hyvaksyja: String?,
+    val hyvaksymisPaiva: LocalDate?
+)
+
+data class SahkeMetadataResult(
+    val metadata: ArkistointiMetadata,
+    val asiakirjat: List<RecordProperties>
+)
+
+@Component
+class SahkeMetadataBuilder {
+    fun build(
+        request: SahkeMetadataRequest,
+        configuration: ArkistointiConfiguration
+    ): SahkeMetadataResult {
+        val metadata = ArkistointiMetadata()
+        val opintooikeus = request.opintooikeus
+        val name = opintooikeus?.erikoistuvaLaakari?.kayttaja?.user?.getName()
+        val syntymaaika = opintooikeus?.erikoistuvaLaakari?.syntymaaika
+
+        buildTransferInformation(metadata.transferInformation, configuration, opintooikeus?.id)
+        buildContactInformation(metadata.contactInformation, configuration)
+        buildCaseFile(metadata.caseFile, request.caseId, name, syntymaaika, configuration)
+
+        val configuredAsiakirjat = request.asiakirjat.filter { recordProperties ->
+            configuration.metadata.getDocumentMetadata(recordProperties.type, configuration.case) != null
+        }
+
+        buildRecords(configuredAsiakirjat, metadata, configuration, request)
+        return SahkeMetadataResult(metadata, configuredAsiakirjat)
+    }
+
+    private fun buildTransferInformation(
+        transferInformation: TransferInformation,
+        configuration: ArkistointiConfiguration,
+        opintooikeusId: Long?
+    ) {
+        val year = LocalDate.now().year
+        transferInformation.nativeId = "urn:oid:1.2.246.582.200.${opintooikeusId}$year.$year.0001"
+        transferInformation.transferContractId = opintooikeusId?.toString()
+        configuration.metadata.useType?.let { transferInformation.useType = it }
+    }
+
+    private fun buildContactInformation(
+        contactInformation: ContactInformation,
+        configuration: ArkistointiConfiguration
+    ) {
+        val metadata = configuration.metadata
+        contactInformation.organisation.name = metadata.organisation
+
+        val contactPerson = contactInformation.contactPerson
+        val contact = metadata.contact
+        contactPerson.name = contact?.person
+        contactPerson.address = contact?.address
+        contactPerson.phoneNumber = contact?.phone
+        contactPerson.email = contact?.email
+    }
+
+    private fun buildCaseFile(
+        caseFile: CaseFile,
+        nativeId: String?,
+        name: String?,
+        syntymaaika: LocalDate?,
+        configuration: ArkistointiConfiguration
+    ) {
+        val metadata = configuration.metadata
+        val case = configuration.case
+        caseFile.created = LocalDate.now()
+        caseFile.nativeId = nativeId
+        caseFile.title = case.title
+        caseFile.type = case.type
+        caseFile.function = case.function
+
+        caseFile.restriction.person.name = name
+        caseFile.restriction.person.ssn = syntymaaika
+        caseFile.restriction.owner = metadata.organisation
+        caseFile.retentionReason = metadata.retentionReason
+        caseFile.retentionPeriod = metadata.retentionPeriod
+
+        val action = caseFile.action
+        action.created = LocalDate.now()
+        action.title = case.title
+        action.type = case.type
+    }
+
+    private fun buildRecords(
+        asiakirjat: List<RecordProperties>,
+        metadata: ArkistointiMetadata,
+        configuration: ArkistointiConfiguration,
+        request: SahkeMetadataRequest
+    ) {
+        val opintooikeus = request.opintooikeus
+        val name = opintooikeus?.erikoistuvaLaakari?.kayttaja?.user?.getName()
+        val resourceBundle = ResourceBundle.getBundle("i18n/messages")
+
+        asiakirjat.forEach { recordProperties ->
+            val documentMetadata = configuration.metadata
+                .getDocumentMetadata(recordProperties.type, configuration.case)
+                .required()
+            val asiakirja = recordProperties.asiakirja
+            val record = Record()
+            record.created = LocalDate.now()
+            record.nativeId = asiakirja.id?.toString()
+
+            val user = opintooikeus?.erikoistuvaLaakari?.kayttaja?.user
+            record.title = "${user?.lastName}, ${user?.firstName}, ${opintooikeus?.erikoisala?.nimi}"
+            record.type = configuration.case.type
+            record.retentionPeriod = documentMetadata.retentionPeriod
+            record.function = metadata.caseFile.function
+
+            val publicityClass = getPublicityClass(recordProperties.type)
+            record.restriction.publicityClass = publicityClass.displayName
+            record.restriction.securityReason = publicityClass.securityReason
+            record.restriction.person.name = name
+            record.restriction.person.ssn = opintooikeus?.erikoistuvaLaakari?.syntymaaika
+            record.restriction.owner = configuration.metadata.organisation
+
+            buildCustomMetadata(record, request, configuration, name, resourceBundle)
+
+            val document = record.document
+            document.nativeId = asiakirja.nimi
+            document.file.name = asiakirja.nimi
+            document.file.path = "pdf/${asiakirja.nimi}"
+            document.format.name = asiakirja.tyyppi
+            document.hashValue = DigestUtils.sha256Hex(asiakirja.asiakirjaData?.data)
+            metadata.caseFile.action.record.add(record)
+        }
+    }
+
+    private fun buildCustomMetadata(
+        record: Record,
+        request: SahkeMetadataRequest,
+        configuration: ArkistointiConfiguration,
+        name: String?,
+        resourceBundle: ResourceBundle
+    ) {
+        val opintooikeus = request.opintooikeus
+        val custom = record.custom
+        custom.erikoistujanNimi = name
+        custom.erikoisala = opintooikeus?.erikoisala?.nimi
+        custom.opiskelijanumero = opintooikeus?.opiskelijatunnus
+        custom.syntymaaika = opintooikeus?.erikoistuvaLaakari?.syntymaaika
+        opintooikeus?.yliopisto?.nimi?.toString()?.let { custom.yliopisto = resourceBundle.getString(it) }
+        custom.tarkastaja = request.tarkastaja
+        custom.tarkastuspaiva = request.tarkastusPaiva
+        custom.hyvaksyja = request.hyvaksyja
+        custom.hyvaksymispaiva = request.hyvaksymisPaiva
+        custom.asiakirjatyyppi = configuration.case.title
+    }
+
+    private fun getPublicityClass(recordType: RecordType): PublicityClass = when (recordType) {
+        RecordType.YHTEENVETO -> PublicityClass.PUBLIC
+        RecordType.LIITE -> PublicityClass.PARTIALLY_RESTRICTED
+        RecordType.ARVIOINTI -> PublicityClass.PUBLIC
+        RecordType.SOPIMUS -> PublicityClass.PUBLIC
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/sahke/SahkePakettiBuilder.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/sahke/SahkePakettiBuilder.kt
@@ -1,0 +1,50 @@
+package fi.elsapalvelu.elsa.service.arkistointi.sahke
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
+import fi.elsapalvelu.elsa.service.dto.arkistointi.ArkistointiResult
+import org.springframework.stereotype.Component
+import java.io.FileOutputStream
+import java.text.SimpleDateFormat
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+@Component
+class SahkePakettiBuilder {
+    fun build(
+        metadataResult: SahkeMetadataResult,
+        opintooikeus: Opintooikeus?,
+        zipMetadata: Boolean
+    ): ArkistointiResult {
+        val mapper = createXmlMapper()
+        val metadata = metadataResult.metadata
+        val user = opintooikeus?.erikoistuvaLaakari?.kayttaja?.user
+        val title = "${metadata.caseFile.action.type?.lowercase()}_" +
+            "${user?.firstName?.lowercase()}_${user?.lastName?.lowercase()}"
+        val filePath = "/tmp/$title.zip"
+
+        ZipOutputStream(FileOutputStream(filePath)).use { zipOut ->
+            if (zipMetadata) {
+                zipOut.putNextEntry(ZipEntry("sahke.xml"))
+                zipOut.write(mapper.writeValueAsBytes(metadata))
+            }
+
+            metadataResult.asiakirjat.forEach {
+                val asiakirja = it.asiakirja
+                zipOut.putNextEntry(ZipEntry("pdf/${asiakirja.nimi}"))
+                zipOut.write(asiakirja.asiakirjaData?.data)
+            }
+        }
+
+        val metadataBytes = if (zipMetadata) null else mapper.writeValueAsBytes(metadata)
+        return ArkistointiResult(filePath, metadataBytes)
+    }
+
+    private fun createXmlMapper(): XmlMapper = XmlMapper().apply {
+        registerModule(JavaTimeModule())
+        dateFormat = SimpleDateFormat("dd.MM.yyyy")
+        configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/siilo/HelsinkiSiiloService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/siilo/HelsinkiSiiloService.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.arkistointi
+package fi.elsapalvelu.elsa.service.arkistointi.siilo
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/siilo/SiiloArkistointiAdapter.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/siilo/SiiloArkistointiAdapter.kt
@@ -1,0 +1,17 @@
+package fi.elsapalvelu.elsa.service.arkistointi.siilo
+
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiAdapter
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiDeliveryRequest
+import org.springframework.stereotype.Component
+
+@Component
+class SiiloArkistointiAdapter(
+    private val helsinkiSiiloService: HelsinkiSiiloService
+) : ArkistointiAdapter {
+    override val yliopisto = YliopistoEnum.HELSINGIN_YLIOPISTO
+
+    override fun laheta(request: ArkistointiDeliveryRequest) {
+        helsinkiSiiloService.laheta(request.filePath, request.caseType)
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/arkistointi/tampere/TampereArkistointiExternalIntegrationTests.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/externalintegration/arkistointi/tampere/TampereArkistointiExternalIntegrationTests.kt
@@ -13,9 +13,15 @@ import fi.elsapalvelu.elsa.domain.kayttaja.*
 import fi.elsapalvelu.elsa.domain.perustiedot.*
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.externalintegration.ExternalIntegrationTestSupport
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiConfigurationProvider
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiDispatcher
 import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiServiceImpl
-import fi.elsapalvelu.elsa.service.arkistointi.HelsinkiSiiloService
-import fi.elsapalvelu.elsa.service.arkistointi.TampereLouhiService
+import fi.elsapalvelu.elsa.service.arkistointi.louhi.LouhiArkistointiAdapter
+import fi.elsapalvelu.elsa.service.arkistointi.louhi.TampereLouhiService
+import fi.elsapalvelu.elsa.service.arkistointi.sahke.SahkeMetadataBuilder
+import fi.elsapalvelu.elsa.service.arkistointi.sahke.SahkePakettiBuilder
+import fi.elsapalvelu.elsa.service.arkistointi.siilo.HelsinkiSiiloService
+import fi.elsapalvelu.elsa.service.arkistointi.siilo.SiiloArkistointiAdapter
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
@@ -238,12 +244,18 @@ class TampereArkistointiExternalIntegrationTests : ExternalIntegrationTestSuppor
  * [TampereLouhiService] and [ArkistointiServiceImpl].
  *
  * [HelsinkiSiiloService] is mocked because it is not under test here and would
- * require its own network credentials + HKI SFTP access.
+ * require its own network credentials and HTTP endpoint.
  */
 @SpringBootConfiguration
 @EnableConfigurationProperties(ApplicationProperties::class)
 @Import(
     TampereLouhiService::class,
+    LouhiArkistointiAdapter::class,
+    SiiloArkistointiAdapter::class,
+    ArkistointiConfigurationProvider::class,
+    SahkeMetadataBuilder::class,
+    SahkePakettiBuilder::class,
+    ArkistointiDispatcher::class,
     ArkistointiServiceImpl::class,
     ArkistointiMetricsService::class,
     AlertPublisherServiceImpl::class  // single always-registered impl; no-ops when SNS not configured
@@ -262,4 +274,3 @@ class TampereArkistointiExternalIntegrationTestApplication {
     @Bean
     fun meterRegistry(): MeterRegistry = SimpleMeterRegistry()
 }
-

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiConfigurationProviderTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiConfigurationProviderTest.kt
@@ -1,0 +1,110 @@
+package fi.elsapalvelu.elsa.service.arkistointi
+
+import fi.elsapalvelu.elsa.config.ApplicationProperties
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class ArkistointiConfigurationProviderTest {
+    private val applicationProperties = ApplicationProperties()
+    private val provider = ArkistointiConfigurationProvider(applicationProperties)
+
+    @Test
+    fun `getConfiguration resolves metadata for every university`() {
+        YliopistoEnum.entries.forEach { yliopisto ->
+            val metadata = createMetadata(yliopisto.name)
+            configure(yliopisto, enabled = true, metadata = metadata)
+
+            val configuration = provider.getConfiguration(yliopisto, CaseType.VALMISTUMINEN)
+
+            assertThat(configuration.metadata).isSameAs(metadata)
+            assertThat(configuration.case).isSameAs(
+                metadata.getCaseMetadata(CaseType.VALMISTUMINEN)
+            )
+            assertThat(provider.onKaytossa(yliopisto, CaseType.VALMISTUMINEN)).isTrue()
+        }
+    }
+
+    @Test
+    fun `onKaytossa requires both university enablement and case metadata`() {
+        configure(
+            YliopistoEnum.HELSINGIN_YLIOPISTO,
+            enabled = false,
+            metadata = createMetadata("Helsinki")
+        )
+        configure(
+            YliopistoEnum.TAMPEREEN_YLIOPISTO,
+            enabled = true,
+            metadata = ApplicationProperties.Arkistointi.Metadata()
+        )
+
+        assertThat(
+            provider.onKaytossa(YliopistoEnum.HELSINGIN_YLIOPISTO, CaseType.VALMISTUMINEN)
+        ).isFalse()
+        assertThat(
+            provider.onKaytossa(YliopistoEnum.TAMPEREEN_YLIOPISTO, CaseType.VALMISTUMINEN)
+        ).isFalse()
+    }
+
+    @Test
+    fun `getConfiguration reports missing case metadata with university context`() {
+        configure(
+            YliopistoEnum.TURUN_YLIOPISTO,
+            enabled = true,
+            metadata = ApplicationProperties.Arkistointi.Metadata()
+        )
+
+        assertThatThrownBy {
+            provider.getConfiguration(YliopistoEnum.TURUN_YLIOPISTO, CaseType.KOEJAKSO)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining(CaseType.KOEJAKSO.value)
+            .hasMessageContaining(YliopistoEnum.TURUN_YLIOPISTO.name)
+    }
+
+    private fun createMetadata(organisation: String): ApplicationProperties.Arkistointi.Metadata {
+        val case = ApplicationProperties.Arkistointi.Case().apply {
+            title = "Valmistuminen"
+        }
+        return ApplicationProperties.Arkistointi.Metadata().apply {
+            this.organisation = organisation
+            cases = mapOf(CaseType.VALMISTUMINEN.value to case)
+        }
+    }
+
+    private fun configure(
+        yliopisto: YliopistoEnum,
+        enabled: Boolean,
+        metadata: ApplicationProperties.Arkistointi.Metadata
+    ) {
+        val arkistointi = applicationProperties.getArkistointi()
+        when (yliopisto) {
+            YliopistoEnum.OULUN_YLIOPISTO -> arkistointi.getOulu().apply {
+                kaytossa = enabled
+                this.metadata = metadata
+            }
+
+            YliopistoEnum.HELSINGIN_YLIOPISTO -> arkistointi.getHki().apply {
+                kaytossa = enabled
+                this.metadata = metadata
+            }
+
+            YliopistoEnum.TAMPEREEN_YLIOPISTO -> arkistointi.getTre().apply {
+                kaytossa = enabled
+                this.metadata = metadata
+            }
+
+            YliopistoEnum.TURUN_YLIOPISTO -> arkistointi.getTurku().apply {
+                kaytossa = enabled
+                this.metadata = metadata
+            }
+
+            YliopistoEnum.ITA_SUOMEN_YLIOPISTO -> arkistointi.getUef().apply {
+                kaytossa = enabled
+                this.metadata = metadata
+            }
+        }
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/louhi/TampereLouhiServiceTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/louhi/TampereLouhiServiceTest.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.arkistointi
+package fi.elsapalvelu.elsa.service.arkistointi.louhi
 
 import org.apache.sshd.sftp.client.SftpClient
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/sahke/SahkeMetadataBuilderTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/sahke/SahkeMetadataBuilderTest.kt
@@ -1,0 +1,98 @@
+package fi.elsapalvelu.elsa.service.arkistointi.sahke
+
+import fi.elsapalvelu.elsa.config.ApplicationProperties
+import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
+import fi.elsapalvelu.elsa.domain.kayttaja.AsiakirjaData
+import fi.elsapalvelu.elsa.domain.kayttaja.ErikoistuvaLaakari
+import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
+import fi.elsapalvelu.elsa.domain.kayttaja.User
+import fi.elsapalvelu.elsa.domain.perustiedot.Erikoisala
+import fi.elsapalvelu.elsa.domain.perustiedot.Yliopisto
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiConfiguration
+import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
+import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
+import org.apache.commons.codec.digest.DigestUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class SahkeMetadataBuilderTest {
+    private val builder = SahkeMetadataBuilder()
+
+    @Test
+    fun `build includes only configured documents in metadata and package input`() {
+        val opintooikeus = createOpintooikeus()
+        val included = createRecordProperties(opintooikeus, "yhteenveto.pdf", RecordType.YHTEENVETO)
+        val excluded = createRecordProperties(opintooikeus, "liite.pdf", RecordType.LIITE)
+        val case = ApplicationProperties.Arkistointi.Case().apply {
+            title = "Valmistumisen asiakirjat"
+            type = "VALMISTUMINEN"
+            function = "04.01.04"
+            documents = mapOf(
+                RecordType.YHTEENVETO.name.lowercase() to
+                    ApplicationProperties.Arkistointi.DocumentMetadata().apply {
+                        retentionPeriod = "10"
+                    }
+            )
+        }
+        val metadata = ApplicationProperties.Arkistointi.Metadata().apply {
+            organisation = "Testiorganisaatio"
+            cases = emptyMap()
+        }
+
+        val result = builder.build(
+            request = SahkeMetadataRequest(
+                opintooikeus = opintooikeus,
+                asiakirjat = listOf(included, excluded),
+                caseId = "CASE-123",
+                tarkastaja = "Testi Tarkastaja",
+                tarkastusPaiva = LocalDate.of(2024, 1, 2),
+                hyvaksyja = "Testi Hyväksyjä",
+                hyvaksymisPaiva = LocalDate.of(2024, 1, 3)
+            ),
+            configuration = ArkistointiConfiguration(metadata, case)
+        )
+
+        assertThat(result.asiakirjat).containsExactly(included)
+        assertThat(result.metadata.caseFile.action.record).hasSize(1)
+        val record = result.metadata.caseFile.action.record.single()
+        assertThat(record.document.file.path).isEqualTo("pdf/yhteenveto.pdf")
+        assertThat(record.document.hashValue).isEqualTo(
+            DigestUtils.sha256Hex(included.asiakirja.asiakirjaData?.data)
+        )
+        assertThat(record.custom.asiakirjatyyppi).isEqualTo(case.title)
+        assertThat(record.custom.tarkastaja).isEqualTo("Testi Tarkastaja")
+        assertThat(record.custom.hyvaksyja).isEqualTo("Testi Hyväksyjä")
+    }
+
+    private fun createOpintooikeus(): Opintooikeus {
+        val user = User(firstName = "Matti", lastName = "Meikäläinen")
+        return Opintooikeus(
+            id = 123L,
+            erikoistuvaLaakari = ErikoistuvaLaakari(
+                kayttaja = Kayttaja(user = user),
+                syntymaaika = LocalDate.of(1990, 12, 31)
+            ),
+            yliopisto = Yliopisto(nimi = YliopistoEnum.TAMPEREEN_YLIOPISTO),
+            erikoisala = Erikoisala(nimi = "Kirurgia"),
+            opiskelijatunnus = "OP123"
+        )
+    }
+
+    private fun createRecordProperties(
+        opintooikeus: Opintooikeus,
+        name: String,
+        recordType: RecordType
+    ): RecordProperties = RecordProperties(
+        asiakirja = Asiakirja(
+            id = 321L,
+            opintooikeus = opintooikeus,
+            nimi = name,
+            tyyppi = "application/pdf",
+            asiakirjaData = AsiakirjaData(data = name.toByteArray())
+        ),
+        type = recordType
+    )
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/siilo/HelsinkiSiiloServiceTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/siilo/HelsinkiSiiloServiceTest.kt
@@ -1,4 +1,4 @@
-package fi.elsapalvelu.elsa.service.arkistointi
+package fi.elsapalvelu.elsa.service.arkistointi.siilo
 
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiAlertTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiAlertTest.kt
@@ -7,11 +7,17 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
-import fi.elsapalvelu.elsa.service.kayttaja.AlertPublisherService
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiConfigurationProvider
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiDispatcher
 import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiServiceImpl
-import fi.elsapalvelu.elsa.service.arkistointi.HelsinkiSiiloService
-import fi.elsapalvelu.elsa.service.arkistointi.TampereLouhiService
+import fi.elsapalvelu.elsa.service.arkistointi.louhi.LouhiArkistointiAdapter
+import fi.elsapalvelu.elsa.service.arkistointi.louhi.TampereLouhiService
+import fi.elsapalvelu.elsa.service.arkistointi.sahke.SahkeMetadataBuilder
+import fi.elsapalvelu.elsa.service.arkistointi.sahke.SahkePakettiBuilder
+import fi.elsapalvelu.elsa.service.arkistointi.siilo.HelsinkiSiiloService
+import fi.elsapalvelu.elsa.service.arkistointi.siilo.SiiloArkistointiAdapter
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
+import fi.elsapalvelu.elsa.service.kayttaja.AlertPublisherService
 import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
@@ -23,9 +29,9 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 
 /**
- * Unit tests verifying that [ArkistointiServiceImpl.laheta] publishes an alert via
- * [AlertPublisherService] whenever Helsinki (HY Siilo) or Tampere (Louhi SFTP) archiving fails,
- * and that no alert is published on success.
+ * Unit tests verifying that synchronous delivery through [ArkistointiServiceImpl.laheta]
+ * publishes an alert via [AlertPublisherService] whenever Helsinki (HY Siilo) or Tampere
+ * (Louhi SFTP) archiving fails, and that no alert is published on success.
  */
 @ExtendWith(MockitoExtension::class)
 class ArkistointiAlertTest {
@@ -48,12 +54,21 @@ class ArkistointiAlertTest {
         applicationProperties.getArkistointi().getTre().port = "22"
         applicationProperties.getArkistointi().getTre().user = "test-user"
 
-        arkistointiService = ArkistointiServiceImpl(
-            applicationProperties = applicationProperties,
-            tampereLouhiService = tampereLouhiService,
-            helsinkiSiiloService = helsinkiSiiloService,
+        val configurationProvider = ArkistointiConfigurationProvider(applicationProperties)
+        val dispatcher = ArkistointiDispatcher(
+            adapters = listOf(
+                LouhiArkistointiAdapter(tampereLouhiService),
+                SiiloArkistointiAdapter(helsinkiSiiloService)
+            ),
+            configurationProvider = configurationProvider,
             alertPublisherService = alertPublisherService,
             arkistointiMetrics = ArkistointiMetricsService(SimpleMeterRegistry())
+        )
+        arkistointiService = ArkistointiServiceImpl(
+            configurationProvider = configurationProvider,
+            metadataBuilder = SahkeMetadataBuilder(),
+            pakettiBuilder = SahkePakettiBuilder(),
+            dispatcher = dispatcher
         )
     }
 
@@ -203,4 +218,3 @@ class ArkistointiAlertTest {
         verify(alertPublisherService, never()).publishAlert(any(), any())
     }
 }
-

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
@@ -14,13 +14,20 @@ import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
 import fi.elsapalvelu.elsa.domain.kayttaja.User
 import fi.elsapalvelu.elsa.domain.perustiedot.Yliopisto
 import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
-import fi.elsapalvelu.elsa.service.kayttaja.AlertPublisherService
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiAdapter
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiConfigurationProvider
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiDispatcher
 import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiServiceImpl
-import fi.elsapalvelu.elsa.service.arkistointi.HelsinkiSiiloService
-import fi.elsapalvelu.elsa.service.arkistointi.TampereLouhiService
+import fi.elsapalvelu.elsa.service.arkistointi.louhi.LouhiArkistointiAdapter
+import fi.elsapalvelu.elsa.service.arkistointi.louhi.TampereLouhiService
+import fi.elsapalvelu.elsa.service.arkistointi.sahke.SahkeMetadataBuilder
+import fi.elsapalvelu.elsa.service.arkistointi.sahke.SahkePakettiBuilder
+import fi.elsapalvelu.elsa.service.arkistointi.siilo.HelsinkiSiiloService
+import fi.elsapalvelu.elsa.service.arkistointi.siilo.SiiloArkistointiAdapter
 import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
 import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
+import fi.elsapalvelu.elsa.service.kayttaja.AlertPublisherService
 import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.apache.commons.codec.digest.DigestUtils
@@ -61,10 +68,13 @@ class ArkistointiServiceImplTest {
     fun setUp() {
         metricsRegistry = SimpleMeterRegistry()
         arkistointiMetrics = ArkistointiMetricsService(metricsRegistry)
-        lahetaService = ArkistointiServiceImpl(
-            applicationProperties = ApplicationProperties(),
-            tampereLouhiService = tampereLouhiService,
-            helsinkiSiiloService = helsinkiSiiloService,
+        val applicationProperties = ApplicationProperties()
+        lahetaService = createService(
+            applicationProperties = applicationProperties,
+            adapters = listOf(
+                LouhiArkistointiAdapter(tampereLouhiService),
+                SiiloArkistointiAdapter(helsinkiSiiloService)
+            ),
             alertPublisherService = alertPublisherService,
             arkistointiMetrics = arkistointiMetrics
         )
@@ -238,14 +248,35 @@ class ArkistointiServiceImplTest {
         applicationProperties.getArkistointi().getTre().user = "test-user"
         applicationProperties.getArkistointi().getTre().metadata = createMetadata(zipMetadata)
 
-        return ArkistointiServiceImpl(
+        return createService(
             applicationProperties = applicationProperties,
-            tampereLouhiService = TampereLouhiService(org.springframework.core.io.DefaultResourceLoader(), applicationProperties),
-            helsinkiSiiloService = HelsinkiSiiloService(applicationProperties),
+            adapters = emptyList(),
             alertPublisherService = object : AlertPublisherService {
                 override fun publishAlert(subject: String, message: String) = Unit
             },
             arkistointiMetrics = ArkistointiMetricsService(SimpleMeterRegistry())
+        )
+    }
+
+    private fun createService(
+        applicationProperties: ApplicationProperties,
+        adapters: List<ArkistointiAdapter>,
+        alertPublisherService: AlertPublisherService,
+        arkistointiMetrics: ArkistointiMetricsService
+    ): ArkistointiServiceImpl {
+        val configurationProvider = ArkistointiConfigurationProvider(applicationProperties)
+        val dispatcher = ArkistointiDispatcher(
+            adapters = adapters,
+            configurationProvider = configurationProvider,
+            alertPublisherService = alertPublisherService,
+            arkistointiMetrics = arkistointiMetrics
+        )
+
+        return ArkistointiServiceImpl(
+            configurationProvider = configurationProvider,
+            metadataBuilder = SahkeMetadataBuilder(),
+            pakettiBuilder = SahkePakettiBuilder(),
+            dispatcher = dispatcher
         )
     }
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiXmlSerializationTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiXmlSerializationTest.kt
@@ -19,7 +19,7 @@ import java.text.SimpleDateFormat
  * Any Jackson module compiled against databind < 2.18.0 will throw
  * NoSuchFieldError at runtime when Jackson databind 2.18.x is on the classpath.
  *
- * The crash happens in ArkistointiServiceImpl.muodostaSahke() →
+ * The crash happens in SahkePakettiBuilder.build() →
  *   XmlMapper().writeValueAsBytes(metadata)
  *
  * Test 1 mirrors the production code verbatim.
@@ -32,13 +32,13 @@ import java.text.SimpleDateFormat
 class ArkistointiXmlSerializationTest {
 
     /**
-     * Mirrors ArkistointiServiceImpl.muodostaSahke() line-for-line.
+     * Mirrors the mapper setup in SahkePakettiBuilder.
      * Will throw NoSuchFieldError: _anyGetterWriter if any Jackson module
      * on the classpath was compiled against databind < 2.18.0.
      */
     @Test
     fun `XmlMapper serializes ArkistointiMetadata without Jackson field name mismatch`() {
-        // Exact copy of the mapper setup in ArkistointiServiceImpl.muodostaSahke()
+        // Exact copy of the mapper setup in SahkePakettiBuilder.
         val mapper = XmlMapper()
         mapper.registerModule(JavaTimeModule())
         mapper.dateFormat = SimpleDateFormat("dd.MM.yyyy")
@@ -102,4 +102,3 @@ class ArkistointiXmlSerializationTest {
             .isEqualTo(databindDotted)
     }
 }
-


### PR DESCRIPTION
This pull request introduces a major refactoring of the archiving ("arkistointi") integration infrastructure, focusing on modularizing university-specific logic, centralizing configuration, and improving maintainability. The core changes include extracting university-specific delivery logic into adapters, introducing a dispatcher for routing, and centralizing configuration management. Several legacy code paths and direct service dependencies have been removed from `ArkistointiServiceImpl`, replaced by the new, more flexible architecture.

**Key changes:**

### Architecture & Modularity

* Introduced the `ArkistointiAdapter` interface and `ArkistointiDeliveryRequest` data class to encapsulate university-specific archiving logic, decoupling it from the main service implementation.
* Added `LouhiArkistointiAdapter` for Tampere University, implementing the adapter interface and encapsulating SFTP delivery logic.
* Introduced the `ArkistointiDispatcher` component, which routes delivery requests to the correct adapter based on university, handles metrics, and centralizes alert publishing for failures.

### Configuration Management

* Created `ArkistointiConfigurationProvider` to centralize and abstract configuration and metadata retrieval for each university and case type, replacing scattered configuration access logic.

### Refactoring & Simplification

* Refactored `ArkistointiServiceImpl` to use the new dispatcher, adapters, and configuration provider, removing direct dependencies on university-specific services and legacy configuration logic. This includes delegating `onKaytossa` checks and delivery logic to the new components. [[1]](diffhunk://#diff-0e7858052fd90ca86550c4768e8048b19db3979706dea4c1f1e6181a31243302L3-L42) [[2]](diffhunk://#diff-0e7858052fd90ca86550c4768e8048b19db3979706dea4c1f1e6181a31243302L54-L234) [[3]](diffhunk://#diff-0e7858052fd90ca86550c4768e8048b19db3979706dea4c1f1e6181a31243302L245-R75)
* Moved Tampere-specific service to a new package and file (`louhi/TampereLouhiService.kt`) for better separation of concerns.

These changes significantly improve the flexibility and maintainability of the archiving integration by introducing a modular, pluggable architecture for university-specific logic and centralizing configuration management.