### PR TITLE
Ensuring that the documents sent for archiving are the same as those persisted in the database

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonVastuuhenkilonArvioServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/koejakso/KoejaksonVastuuhenkilonArvioServiceImpl.kt
@@ -315,7 +315,8 @@ class KoejaksonVastuuhenkilonArvioServiceImpl(
         }
 
         if (vastuuhenkilonArvio.vastuuhenkilonKuittausaika != null) {
-            luoPdf(mapVastuuhenkilonArvio(result), result)
+            val asiakirja = luoPdf(mapVastuuhenkilonArvio(result), result)
+            arkistoiVastuuhenkilonArvio(result, asiakirja)
 
             if (vastuuhenkilonArvio.koejaksoHyvaksytty == false) {
                 mailService.sendEmailFromTemplate(
@@ -347,7 +348,7 @@ class KoejaksonVastuuhenkilonArvioServiceImpl(
     private fun luoPdf(
         vastuuhenkilonArvioDTO: KoejaksonVastuuhenkilonArvioDTO,
         vastuuhenkilonArvio: KoejaksonVastuuhenkilonArvio
-    ) {
+    ): Asiakirja {
         val locale = Locale.forLanguageTag("fi")
         val context = Context(locale).apply {
             setVariable("arvio", vastuuhenkilonArvioDTO)
@@ -371,7 +372,7 @@ class KoejaksonVastuuhenkilonArvioServiceImpl(
         pdfService.luoPdf("pdf/vastuuhenkilonarvio.html", context, outputStream)
         val timestamp = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
 
-        val asiakirja = asiakirjaRepository.save(
+        return asiakirjaRepository.save(
             Asiakirja(
                 opintooikeus = vastuuhenkilonArvio.opintooikeus,
                 nimi = "koejakson_vastuuhenkilon_arvio_${timestamp}.pdf",
@@ -380,7 +381,12 @@ class KoejaksonVastuuhenkilonArvioServiceImpl(
                 asiakirjaData = AsiakirjaData(data = outputStream.toByteArray())
             )
         )
+    }
 
+    private fun arkistoiVastuuhenkilonArvio(
+        vastuuhenkilonArvio: KoejaksonVastuuhenkilonArvio,
+        asiakirja: Asiakirja
+    ) {
         val yliopisto = vastuuhenkilonArvio.opintooikeus?.yliopisto?.nimi.required()
         val erikoisala = vastuuhenkilonArvio.opintooikeus?.erikoisala.required()
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoServiceImpl.kt
@@ -373,26 +373,20 @@ class ValmistumispyyntoServiceImpl(
             log.info("Kuittausaika tallennettu [valmistumispyyntoId=$id]")
 
             result.valmistumispyynnonTarkistus?.let {
-                if (it.valmistumispyynto?.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID) {
-                    log.info("Luodaan YEK PDF:t [valmistumispyyntoId=$id]")
-                    luoYEKYhteenvetoPdf(mapValmistumispyynnonTarkistus(valmistumispyynnonTarkistusMapper.toDto(it)), valmistumispyynto)
-                    luoLiitteetPdf(valmistumispyynto)
-                    log.info("YEK PDF:t luotu [valmistumispyyntoId=$id]")
-                    sendMailNotificationHyvaksyttyYek(valmistumispyynto)
-                    log.info("YEK hyvaksynta-sahkoposti lahetetty [valmistumispyyntoId=$id]")
-                } else {
-                    log.info("Luodaan PDF:t [valmistumispyyntoId=$id]")
-                    luoLiitteetPdf(valmistumispyynto)
-                    luoErikoistujanTiedotPdf(valmistumispyynto)
-                    luoYhteenvetoPdf(mapValmistumispyynnonTarkistus(valmistumispyynnonTarkistusMapper.toDto(it)), valmistumispyynto)
-                    log.info("PDF:t luotu [valmistumispyyntoId=$id]")
-                    sendMailNotificationHyvaksytty(valmistumispyynto)
-                    log.info("Hyvaksynta-sahkoposti lahetetty [valmistumispyyntoId=$id]")
-                }
+                val arkistoitavatAsiakirjat = luoValmistumispyynnonAsiakirjatJaLahetaViesti(
+                    id,
+                    it,
+                    valmistumispyynto
+                )
 
                 log.info("Tarkistetaan arkistointi [valmistumispyyntoId=$id, yliopisto=${yliopisto.nimi}]")
                 if (arkistointiService.onKaytossa(yliopisto.nimi.required(), CaseType.VALMISTUMINEN)) {
-                    arkistoiValmistumispyynto(id, valmistumispyynto, yliopisto.nimi)
+                    arkistoiValmistumispyynto(
+                        id,
+                        valmistumispyynto,
+                        yliopisto.nimi,
+                        arkistoitavatAsiakirjat
+                    )
                 } else {
                     log.info("Arkistointi ei kaytossa [valmistumispyyntoId=$id, yliopisto=${yliopisto.nimi}]")
                 }
@@ -408,11 +402,50 @@ class ValmistumispyyntoServiceImpl(
         }
     }
 
-    private fun arkistoiValmistumispyynto(id: Long, valmistumispyynto: Valmistumispyynto, nimi: YliopistoEnum?) {
+    private fun luoValmistumispyynnonAsiakirjatJaLahetaViesti(
+        id: Long,
+        tarkistus: ValmistumispyynnonTarkistus,
+        valmistumispyynto: Valmistumispyynto
+    ): List<RecordProperties> {
+        val mappedTarkistus = mapValmistumispyynnonTarkistus(
+            valmistumispyynnonTarkistusMapper.toDto(tarkistus)
+        )
+        if (tarkistus.valmistumispyynto?.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID) {
+            log.info("Luodaan YEK PDF:t [valmistumispyyntoId=$id]")
+            val yhteenveto = luoYEKYhteenvetoPdf(mappedTarkistus, valmistumispyynto)
+            val liitteet = luoLiitteetPdf(valmistumispyynto)
+            log.info("YEK PDF:t luotu [valmistumispyyntoId=$id]")
+            sendMailNotificationHyvaksyttyYek(valmistumispyynto)
+            log.info("YEK hyvaksynta-sahkoposti lahetetty [valmistumispyyntoId=$id]")
+            return listOf(
+                RecordProperties(yhteenveto, YHTEENVETO),
+                RecordProperties(liitteet, LIITE)
+            )
+        }
+
+        log.info("Luodaan PDF:t [valmistumispyyntoId=$id]")
+        val liitteet = luoLiitteetPdf(valmistumispyynto)
+        luoErikoistujanTiedotPdf(valmistumispyynto)
+        val yhteenveto = luoYhteenvetoPdf(mappedTarkistus, valmistumispyynto)
+        log.info("PDF:t luotu [valmistumispyyntoId=$id]")
+        sendMailNotificationHyvaksytty(valmistumispyynto)
+        log.info("Hyvaksynta-sahkoposti lahetetty [valmistumispyyntoId=$id]")
+        return listOf(
+            RecordProperties(yhteenveto, YHTEENVETO),
+            RecordProperties(liitteet, LIITE)
+        )
+    }
+
+    private fun arkistoiValmistumispyynto(
+        id: Long,
+        valmistumispyynto: Valmistumispyynto,
+        nimi: YliopistoEnum?,
+        asiakirjat: List<RecordProperties>
+    ) {
         log.info("Arkistointi kaytossa, muodostetaan sahke [valmistumispyyntoId=$id]")
         val result = arkistointiService.muodostaSahke(
             valmistumispyynto.opintooikeus,
-            listOf(RecordProperties(valmistumispyynto.yhteenvetoAsiakirja.required(), YHTEENVETO), RecordProperties(valmistumispyynto.liitteetAsiakirja.required(), LIITE)),
+            asiakirjat,
             caseId = valmistumispyynto.id.required().toString(),
             tarkastaja = valmistumispyynto.virkailija?.user?.getName(),
             tarkastusPaiva = valmistumispyynto.virkailijanKuittausaika,
@@ -1221,9 +1254,17 @@ class ValmistumispyyntoServiceImpl(
         return dto
     }
 
-    private fun luoYhteenvetoPdf(valmistumispyynnonTarkistusDTO: ValmistumispyynnonTarkistusDTO, valmistumispyynto: Valmistumispyynto) {
+    private fun luoYhteenvetoPdf(
+        valmistumispyynnonTarkistusDTO: ValmistumispyynnonTarkistusDTO,
+        valmistumispyynto: Valmistumispyynto
+    ): Asiakirja {
         val context = getYhteenvetoPdfContext(valmistumispyynnonTarkistusDTO, valmistumispyynto)
-        saveYhteenvetoPdf(valmistumispyynto = valmistumispyynto, template = "pdf/valmistumisenyhteenveto.html", fileNamePrefix = "valmistumisen_yhteenveto", context = context)
+        return saveYhteenvetoPdf(
+            valmistumispyynto = valmistumispyynto,
+            template = "pdf/valmistumisenyhteenveto.html",
+            fileNamePrefix = "valmistumisen_yhteenveto",
+            context = context
+        )
     }
 
     private fun getYhteenvetoPdfContext(valmistumispyynnonTarkistusDTO: ValmistumispyynnonTarkistusDTO, valmistumispyynto: Valmistumispyynto): Context {
@@ -1293,7 +1334,10 @@ class ValmistumispyyntoServiceImpl(
         }
     }
 
-    private fun luoYEKYhteenvetoPdf(valmistumispyynnonTarkistusDTO: ValmistumispyynnonTarkistusDTO, valmistumispyynto: Valmistumispyynto) {
+    private fun luoYEKYhteenvetoPdf(
+        valmistumispyynnonTarkistusDTO: ValmistumispyynnonTarkistusDTO,
+        valmistumispyynto: Valmistumispyynto
+    ): Asiakirja {
         val locale = Locale.forLanguageTag("fi")
         val context = Context(locale).apply {
             setVariable("tarkistus", valmistumispyynnonTarkistusDTO)
@@ -1324,11 +1368,20 @@ class ValmistumispyyntoServiceImpl(
                 setVariable("teoriakoulutukset", opintosuoritukset.opintosuoritukset)
             }
         }
-        saveYhteenvetoPdf(valmistumispyynto = valmistumispyynto, template = "pdf/valmistumisenyhteenveto_yek.html", fileNamePrefix = "valmistumisen_yhteenveto_yek",
-            context = context)
+        return saveYhteenvetoPdf(
+            valmistumispyynto = valmistumispyynto,
+            template = "pdf/valmistumisenyhteenveto_yek.html",
+            fileNamePrefix = "valmistumisen_yhteenveto_yek",
+            context = context
+        )
     }
 
-    private fun saveYhteenvetoPdf(valmistumispyynto: Valmistumispyynto, template: String, fileNamePrefix: String, context: Context) {
+    private fun saveYhteenvetoPdf(
+        valmistumispyynto: Valmistumispyynto,
+        template: String,
+        fileNamePrefix: String,
+        context: Context
+    ): Asiakirja {
         val outputStream = ByteArrayOutputStream()
         pdfService.luoPdf(template, context, outputStream)
         val timestamp = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
@@ -1340,33 +1393,34 @@ class ValmistumispyyntoServiceImpl(
 
         valmistumispyynto.yhteenvetoAsiakirja = asiakirja
         valmistumispyyntoRepository.save(valmistumispyynto)
+        return asiakirja
     }
 
-    private fun luoLiitteetPdf(valmistumispyynto: Valmistumispyynto) {
-        valmistumispyynto.opintooikeus?.let {
-            val tyoskentelyjaksot = tyoskentelyjaksoRepository.findAllByOpintooikeusId(it.id.required())
+    private fun luoLiitteetPdf(valmistumispyynto: Valmistumispyynto): Asiakirja {
+        val opintooikeus = valmistumispyynto.opintooikeus.required()
+        val tyoskentelyjaksot = tyoskentelyjaksoRepository.findAllByOpintooikeusId(opintooikeus.id.required())
 
-            val outputStream = ByteArrayOutputStream()
-            try {
-                pdfService.yhdistaAsiakirjat(tyoskentelyjaksot.flatMap { t -> t.asiakirjat }, outputStream)
-            } catch (e: Exception) {
-                log.error("Virhe yhdistäessä asiakirjoja valmistumispyynnölle: ${valmistumispyynto.id}", e)
-            }
-            val timestamp = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
-
-            val asiakirja = asiakirjaRepository.save(
-                Asiakirja(
-                    opintooikeus = valmistumispyynto.opintooikeus,
-                    nimi = "valmistumisen_yhteenvedon_liitteet_${timestamp}.pdf",
-                    tyyppi = MediaType.APPLICATION_PDF_VALUE,
-                    lisattypvm = LocalDateTime.now(),
-                    asiakirjaData = AsiakirjaData(data = outputStream.toByteArray())
-                )
-            )
-
-            valmistumispyynto.liitteetAsiakirja = asiakirja
-            valmistumispyyntoRepository.save(valmistumispyynto)
+        val outputStream = ByteArrayOutputStream()
+        try {
+            pdfService.yhdistaAsiakirjat(tyoskentelyjaksot.flatMap { t -> t.asiakirjat }, outputStream)
+        } catch (e: Exception) {
+            log.error("Virhe yhdistäessä asiakirjoja valmistumispyynnölle: ${valmistumispyynto.id}", e)
         }
+        val timestamp = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
+
+        val asiakirja = asiakirjaRepository.save(
+            Asiakirja(
+                opintooikeus = opintooikeus,
+                nimi = "valmistumisen_yhteenvedon_liitteet_${timestamp}.pdf",
+                tyyppi = MediaType.APPLICATION_PDF_VALUE,
+                lisattypvm = LocalDateTime.now(),
+                asiakirjaData = AsiakirjaData(data = outputStream.toByteArray())
+            )
+        )
+
+        valmistumispyynto.liitteetAsiakirja = asiakirja
+        valmistumispyyntoRepository.save(valmistumispyynto)
+        return asiakirja
     }
 
     private fun luoErikoistujanTiedotPdf(valmistumispyynto: Valmistumispyynto) {

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/ValmistumispyyntoHyvaksyntaArkistointiIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/ValmistumispyyntoHyvaksyntaArkistointiIT.kt
@@ -5,6 +5,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -29,6 +30,9 @@ import fi.elsapalvelu.elsa.security.VASTUUHENKILO
 import fi.elsapalvelu.elsa.service.kayttaja.MailService
 import fi.elsapalvelu.elsa.service.valmistuminen.PdfService
 import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiService
+import fi.elsapalvelu.elsa.service.dto.arkistointi.ArkistointiResult
+import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
+import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType
 import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoHyvaksyntaFormDTO
 import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
 import fi.elsapalvelu.elsa.web.rest.convertObjectToJsonBytes
@@ -226,6 +230,52 @@ class ValmistumispyyntoHyvaksyntaArkistointiIT {
         assertThat(updated.vastuuhenkiloHyvaksyjaKorjausehdotus).isNull()
 
         verifyEmailSent()
+    }
+
+    @Test
+    fun updateValmistumispyyntoByHyvaksyjaUserId_archivingEnabled_usesGeneratedPersistedDocuments() {
+        val valmistumispyyntoId = initTestInTransaction()
+        whenever(arkistointiService.onKaytossa(any(), any())).thenReturn(true)
+        whenever(
+            arkistointiService.muodostaSahke(
+                any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        ).thenReturn(ArkistointiResult("/tmp/valmistumispyynto.zip", null))
+
+        restMockMvc.perform(
+            put("$ARKISTOINTI_HYVAKSYNTA_ENDPOINT/{id}", valmistumispyyntoId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(convertObjectToJsonBytes(ValmistumispyyntoHyvaksyntaFormDTO(null)))
+                .with(csrf())
+        ).andExpect(status().isOk)
+
+        val asiakirjatCaptor = argumentCaptor<List<RecordProperties>>()
+        verify(arkistointiService).muodostaSahke(
+            any(),
+            asiakirjatCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any()
+        )
+        assertThat(asiakirjatCaptor.firstValue.map { it.type })
+            .containsExactly(
+                RecordType.YHTEENVETO,
+                RecordType.LIITE
+            )
+
+        val persistedAsiakirjaIds = transactionTemplate.execute {
+            val valmistumispyynto = valmistumispyyntoRepository.findById(valmistumispyyntoId).orElseThrow()
+            listOf(
+                valmistumispyynto.yhteenvetoAsiakirja?.id,
+                valmistumispyynto.liitteetAsiakirja?.id
+            )
+        }
+        assertThat(asiakirjatCaptor.firstValue.map { it.asiakirja.id })
+            .containsExactlyElementsOf(persistedAsiakirjaIds)
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
This pull request refactors and improves the document generation and archiving logic for graduation requests (`Valmistumispyynto`) and responsible person's evaluations (`KoejaksonVastuuhenkilonArvio`). The main focus is on ensuring that the documents sent for archiving are the same as those persisted in the database, and on making the document creation functions consistently return the persisted document entities. Additionally, a new integration test verifies this improved behavior.

**Document generation and archiving improvements:**

* Refactored `luoPdf`, `luoYhteenvetoPdf`, `luoYEKYhteenvetoPdf`, and `luoLiitteetPdf` methods to return the persisted `Asiakirja` entity instead of `Unit`, ensuring that the exact documents sent for archiving are those stored in the database. [[1]](diffhunk://#diff-6efb54e88485e6691727fb832253a3e796d3f56d05117be6e14d9af570f8490fL350-R351) [[2]](diffhunk://#diff-0fcb7223078d127cc0e94ef7aaf6abbb459732cc694b79c37ea09bde35a37b27L1224-R1267) [[3]](diffhunk://#diff-0fcb7223078d127cc0e94ef7aaf6abbb459732cc694b79c37ea09bde35a37b27L1296-R1340) [[4]](diffhunk://#diff-0fcb7223078d127cc0e94ef7aaf6abbb459732cc694b79c37ea09bde35a37b27R1396-R1401) [[5]](diffhunk://#diff-0fcb7223078d127cc0e94ef7aaf6abbb459732cc694b79c37ea09bde35a37b27L1369-R1423)
* Updated the graduation request approval flow to collect generated documents into a list, which is then passed to the archiving service, guaranteeing consistency between persisted and archived documents. [[1]](diffhunk://#diff-0fcb7223078d127cc0e94ef7aaf6abbb459732cc694b79c37ea09bde35a37b27L376-R389) [[2]](diffhunk://#diff-0fcb7223078d127cc0e94ef7aaf6abbb459732cc694b79c37ea09bde35a37b27L411-R448)

**Code structure and maintainability:**

* Extracted the document creation and notification logic into a new method `luoValmistumispyynnonAsiakirjatJaLahetaViesti` for better separation of concerns and code readability.

**Testing:**

* Added an integration test (`updateValmistumispyyntoByHyvaksyjaUserId_archivingEnabled_usesGeneratedPersistedDocuments`) to verify that the documents sent for archiving are exactly those persisted in the database, checking both types and IDs.

**Other:**

* Minor improvements to test imports to support new test logic. [[1]](diffhunk://#diff-73addb39df0614c9a59c7681bc17b432cd56bcea00438c66757e15fdb2f8acacR8) [[2]](diffhunk://#diff-73addb39df0614c9a59c7681bc17b432cd56bcea00438c66757e15fdb2f8acacR33-R35)