### PR TITLE
ArkistointiDispatcherTest

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiDispatcher.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiDispatcher.kt
@@ -14,30 +14,45 @@ class ArkistointiDispatcher(
     private val arkistointiMetrics: ArkistointiMetricsService
 ) {
     private val log = LoggerFactory.getLogger(ArkistointiDispatcher::class.java)
-    private val adaptersByYliopisto = adapters.associateBy(ArkistointiAdapter::yliopisto)
+    private val adaptersByYliopisto = adapters
+        .groupBy(ArkistointiAdapter::yliopisto)
+        .also(::requireUniqueAdapters)
+        .mapValues { (_, yliopistonAdapters) -> yliopistonAdapters.single() }
 
     fun laheta(request: ArkistointiDeliveryRequest) {
         arkistointiMetrics.activeArkistointiOperations.incrementAndGet()
         try {
-            val adapter = adaptersByYliopisto[request.yliopisto]
-            if (adapter == null) {
-                log.info("Integraatiota arkistointiin ei ole tuettu yliopistossa ${request.yliopisto.name}")
-            } else {
-                send(adapter, request)
-            }
+            val adapter = resolveAdapter(request) ?: return
+            adapter.laheta(request)
             arkistointiMetrics.recordSuccess(request.yliopisto, request.caseType)
+        } catch (e: Exception) {
+            publishFailureAlert(request, e)
+            arkistointiMetrics.recordError(request.yliopisto, request.caseType)
+            throw e
         } finally {
             arkistointiMetrics.activeArkistointiOperations.updateAndGet { maxOf(0, it - 1) }
         }
     }
 
-    private fun send(adapter: ArkistointiAdapter, request: ArkistointiDeliveryRequest) {
-        try {
-            adapter.laheta(request)
-        } catch (e: Exception) {
-            publishFailureAlert(request, e)
-            arkistointiMetrics.recordError(request.yliopisto, request.caseType)
-            throw e
+    private fun resolveAdapter(request: ArkistointiDeliveryRequest): ArkistointiAdapter? {
+        return adaptersByYliopisto[request.yliopisto] ?: if (
+            configurationProvider.onKaytossa(request.yliopisto, request.caseType)
+        ) {
+            error(
+                "Arkistointi on käytössä yliopistossa ${request.yliopisto.name} " +
+                    "asiatyypille ${request.caseType.value}, mutta adapteria ei ole määritelty"
+            )
+        } else {
+            log.info("Integraatiota arkistointiin ei ole tuettu yliopistossa ${request.yliopisto.name}")
+            null
+        }
+    }
+
+    private fun requireUniqueAdapters(adapters: Map<YliopistoEnum, List<ArkistointiAdapter>>) {
+        val duplicateYliopistot = adapters.filterValues { it.size > 1 }.keys
+        require(duplicateYliopistot.isEmpty()) {
+            "Yliopistolle saa olla vain yksi arkistointiadapteri. Useita adaptereita: " +
+                duplicateYliopistot.joinToString { it.name }
         }
     }
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiDispatcherTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/arkistointi/ArkistointiDispatcherTest.kt
@@ -1,0 +1,150 @@
+package fi.elsapalvelu.elsa.service.arkistointi
+
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
+import fi.elsapalvelu.elsa.service.kayttaja.AlertPublisherService
+import fi.elsapalvelu.elsa.service.metrics.ArkistointiMetricsService
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class ArkistointiDispatcherTest {
+
+    @Mock
+    private lateinit var configurationProvider: ArkistointiConfigurationProvider
+
+    @Mock
+    private lateinit var alertPublisherService: AlertPublisherService
+
+    private lateinit var meterRegistry: SimpleMeterRegistry
+    private lateinit var arkistointiMetrics: ArkistointiMetricsService
+
+    @BeforeEach
+    fun setUp() {
+        meterRegistry = SimpleMeterRegistry()
+        arkistointiMetrics = ArkistointiMetricsService(meterRegistry)
+    }
+
+    @Test
+    fun `enabled destination without adapter fails and records error`() {
+        val request = createRequest(YliopistoEnum.TURUN_YLIOPISTO)
+        whenever(configurationProvider.onKaytossa(request.yliopisto, request.caseType)).thenReturn(true)
+        val dispatcher = createDispatcher(emptyList())
+
+        assertThatIllegalStateException()
+            .isThrownBy { dispatcher.laheta(request) }
+            .withMessageContaining(YliopistoEnum.TURUN_YLIOPISTO.name)
+            .withMessageContaining(CaseType.VALMISTUMINEN.value)
+
+        assertThat(successCount(request)).isZero()
+        assertThat(errorCount(request)).isEqualTo(1.0)
+        assertThat(arkistointiMetrics.activeArkistointiOperations.get()).isZero()
+        verify(alertPublisherService, never()).publishAlert(any(), any())
+    }
+
+    @Test
+    fun `disabled destination without adapter is ignored without recording success`() {
+        val request = createRequest(YliopistoEnum.OULUN_YLIOPISTO)
+        whenever(configurationProvider.onKaytossa(request.yliopisto, request.caseType)).thenReturn(false)
+        val dispatcher = createDispatcher(emptyList())
+
+        dispatcher.laheta(request)
+
+        assertThat(successCount(request)).isZero()
+        assertThat(errorCount(request)).isZero()
+        assertThat(arkistointiMetrics.activeArkistointiOperations.get()).isZero()
+        verify(alertPublisherService, never()).publishAlert(any(), any())
+    }
+
+    @Test
+    fun `duplicate adapters for same university are rejected during construction`() {
+        val firstAdapter = TestAdapter(YliopistoEnum.ITA_SUOMEN_YLIOPISTO)
+        val secondAdapter = TestAdapter(YliopistoEnum.ITA_SUOMEN_YLIOPISTO)
+
+        assertThatIllegalArgumentException()
+            .isThrownBy { createDispatcher(listOf(firstAdapter, secondAdapter)) }
+            .withMessageContaining(YliopistoEnum.ITA_SUOMEN_YLIOPISTO.name)
+    }
+
+    @Test
+    fun `success is recorded only after adapter completes`() {
+        val request = createRequest(YliopistoEnum.HELSINGIN_YLIOPISTO)
+        val adapter = TestAdapter(request.yliopisto) {
+            assertThat(successCount(request)).isZero()
+        }
+        val dispatcher = createDispatcher(listOf(adapter))
+
+        dispatcher.laheta(request)
+
+        assertThat(adapter.receivedRequest).isSameAs(request)
+        assertThat(successCount(request)).isEqualTo(1.0)
+        assertThat(errorCount(request)).isZero()
+    }
+
+    @Test
+    fun `adapter failure does not record success`() {
+        val request = createRequest(YliopistoEnum.TURUN_YLIOPISTO)
+        val adapter = TestAdapter(request.yliopisto) {
+            throw RuntimeException("Dynasty ei vastaa")
+        }
+        val dispatcher = createDispatcher(listOf(adapter))
+
+        org.assertj.core.api.Assertions.assertThatThrownBy { dispatcher.laheta(request) }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessage("Dynasty ei vastaa")
+
+        assertThat(successCount(request)).isZero()
+        assertThat(errorCount(request)).isEqualTo(1.0)
+        assertThat(arkistointiMetrics.activeArkistointiOperations.get()).isZero()
+    }
+
+    private fun createDispatcher(adapters: List<ArkistointiAdapter>) = ArkistointiDispatcher(
+        adapters = adapters,
+        configurationProvider = configurationProvider,
+        alertPublisherService = alertPublisherService,
+        arkistointiMetrics = arkistointiMetrics
+    )
+
+    private fun createRequest(yliopisto: YliopistoEnum) = ArkistointiDeliveryRequest(
+        yliopisto = yliopisto,
+        filePath = "/tmp/archive.zip",
+        caseType = CaseType.VALMISTUMINEN,
+        yek = false,
+        caseId = "123",
+        erikoistujanNimi = "Testi Erikoistuja"
+    )
+
+    private fun successCount(request: ArkistointiDeliveryRequest): Double =
+        meterRegistry.find("arkistointi.requests.total")
+            .tags("yliopisto", request.yliopisto.name, "caseType", request.caseType.value)
+            .counter()?.count() ?: 0.0
+
+    private fun errorCount(request: ArkistointiDeliveryRequest): Double =
+        meterRegistry.find("arkistointi.errors.total")
+            .tags("yliopisto", request.yliopisto.name, "caseType", request.caseType.value)
+            .counter()?.count() ?: 0.0
+
+    private class TestAdapter(
+        override val yliopisto: YliopistoEnum,
+        private val onSend: (ArkistointiDeliveryRequest) -> Unit = {}
+    ) : ArkistointiAdapter {
+        var receivedRequest: ArkistointiDeliveryRequest? = null
+            private set
+
+        override fun laheta(request: ArkistointiDeliveryRequest) {
+            receivedRequest = request
+            onSend(request)
+        }
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/impl/ArkistointiServiceImplTest.kt
@@ -216,7 +216,7 @@ class ArkistointiServiceImplTest {
     }
 
     @Test
-    fun `laheta universities without integration do not update error counter and do not publish alert`() {
+    fun `laheta universities without integration do not update metrics and do not publish alert`() {
         lahetaService.laheta(
             yliopisto = YliopistoEnum.OULUN_YLIOPISTO,
             filePath = "/tmp/oulu.zip",
@@ -225,7 +225,7 @@ class ArkistointiServiceImplTest {
         )
 
         verify(alertPublisherService, never()).publishAlert(any(), any())
-        assertThat(successCount(YliopistoEnum.OULUN_YLIOPISTO, CaseType.VALMISTUMINEN)).isEqualTo(1.0)
+        assertThat(successCount(YliopistoEnum.OULUN_YLIOPISTO, CaseType.VALMISTUMINEN)).isEqualTo(0.0)
         assertThat(errorCount(YliopistoEnum.OULUN_YLIOPISTO, CaseType.VALMISTUMINEN)).isEqualTo(0.0)
     }
 


### PR DESCRIPTION
This pull request improves the robustness and correctness of the `ArkistointiDispatcher` logic and its associated tests. The main focus is on ensuring that only one adapter per university is allowed, handling cases where an adapter is missing more safely, and improving the accuracy of metrics and alerting. Comprehensive unit tests have been added to cover these scenarios.

**Dispatcher logic improvements:**

* Enforces that only one `ArkistointiAdapter` can be registered per university (`YliopistoEnum`), throwing an exception if duplicates are found during dispatcher construction.
* Refactors the adapter resolution logic: if archiving is enabled for a university but no adapter is defined, an exception is thrown; if archiving is disabled, the request is ignored and no metrics or alerts are recorded.
* Simplifies and centralizes error handling and metric updates within the `laheta` method, ensuring that success is only recorded after a successful send, and errors are properly tracked and alerted.

**Testing improvements:**

* Adds a new test class `ArkistointiDispatcherTest` with comprehensive unit tests covering: missing adapters for enabled/disabled destinations, duplicate adapters, success/error metric recording, and correct alert publishing behavior.
* Updates `ArkistointiServiceImplTest` to ensure that universities without integration do not update metrics or publish alerts, and corrects the expected metric values. [[1]](diffhunk://#diff-7fc182f97be93716c70b0fb434207cf56c49da6435c71ad2a2ae680a4a572ffcL219-R219) [[2]](diffhunk://#diff-7fc182f97be93716c70b0fb434207cf56c49da6435c71ad2a2ae680a4a572ffcL228-R228)