### PR TITLE
Testikattavuuden lisääminen

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/criteria/ErikoistujanEteneminenCriteria.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/criteria/ErikoistujanEteneminenCriteria.kt
@@ -21,7 +21,8 @@ data class ErikoistujanEteneminenCriteria(
         this(
             other.nimi?.copy(),
             other.erikoisalaId?.copy(),
-            other.asetusId?.copy()
+            other.asetusId?.copy(),
+            other.naytaPaattyneet
         )
 
     override fun copy() = ErikoistujanEteneminenCriteria(this)

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/criteria/ErikoistujanEteneminenCriteriaTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/criteria/ErikoistujanEteneminenCriteriaTest.kt
@@ -1,0 +1,30 @@
+package fi.elsapalvelu.elsa.service.criteria
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import tech.jhipster.service.filter.LongFilter
+import tech.jhipster.service.filter.StringFilter
+
+class ErikoistujanEteneminenCriteriaTest {
+
+    @Test
+    fun `copy preserves every criterion and creates independent filters`() {
+        val criteria = ErikoistujanEteneminenCriteria(
+            nimi = StringFilter().apply { contains = "Matti" },
+            erikoisalaId = LongFilter().apply { equals = 1L },
+            asetusId = LongFilter().apply { equals = 2L },
+            naytaPaattyneet = true
+        )
+
+        val copy = criteria.copy()
+
+        assertThat(copy).isNotSameAs(criteria)
+        assertThat(copy.nimi).isNotSameAs(criteria.nimi)
+        assertThat(copy.erikoisalaId).isNotSameAs(criteria.erikoisalaId)
+        assertThat(copy.asetusId).isNotSameAs(criteria.asetusId)
+        assertThat(copy.nimi?.contains).isEqualTo("Matti")
+        assertThat(copy.erikoisalaId?.equals).isEqualTo(1L)
+        assertThat(copy.asetusId?.equals).isEqualTo(2L)
+        assertThat(copy.naytaPaattyneet).isTrue()
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariPaivakirjamerkintaResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariPaivakirjamerkintaResourceIT.kt
@@ -2,6 +2,7 @@ package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
 import fi.elsapalvelu.elsa.ElsaBackendApp
 import fi.elsapalvelu.elsa.domain.kayttaja.ErikoistuvaLaakari
+import fi.elsapalvelu.elsa.domain.seuranta.PaivakirjaAihekategoria
 import fi.elsapalvelu.elsa.domain.seuranta.Paivakirjamerkinta
 import fi.elsapalvelu.elsa.domain.kayttaja.User
 import fi.elsapalvelu.elsa.repository.kayttaja.ErikoistuvaLaakariRepository
@@ -272,6 +273,52 @@ class ErikoistuvaLaakariPaivakirjamerkintaResourceIT {
 
         defaultPaivakirjamerkintaShouldBeFound("paivamaara.greaterThanOrEqual=$DEFAULT_PAIVAMAARA")
         defaultPaivakirjamerkintaShouldNotBeFound("paivamaara.greaterThanOrEqual=$UPDATED_PAIVAMAARA")
+    }
+
+    @Test
+    @Transactional
+    fun combinedFiltersShouldReturnOnlyMatchingEntryFromActiveOpintooikeus() {
+        initTest()
+        val category = PaivakirjaAihekategoria(nimi = "combined-filter-category")
+        em.persist(category)
+
+        paivakirjamerkinta.aihekategoriat = mutableSetOf(category)
+        em.persist(paivakirjamerkinta)
+
+        val erikoistuvaLaakari = erikoistuvaLaakariRepository.findOneByKayttajaUserId(user.id!!)
+        requireNotNull(erikoistuvaLaakari)
+        val activeOpintooikeus =
+            OpintooikeusHelper.addOpintooikeusForErikoistuvaLaakari(em, erikoistuvaLaakari)
+        OpintooikeusHelper.setOpintooikeusKaytossa(erikoistuvaLaakari, activeOpintooikeus)
+
+        val matchingEntry = createEntity(em, user).apply {
+            aihekategoriat = mutableSetOf(category)
+        }
+        em.persist(matchingEntry)
+
+        em.persist(
+            createEntity(em, user).apply {
+                aihekategoriat = mutableSetOf(category)
+                paivamaara = UPDATED_PAIVAMAARA
+            }
+        )
+        em.persist(
+            createEntity(em, user).apply {
+                aihekategoriat = mutableSetOf(category)
+                yksityinen = true
+            }
+        )
+        em.persist(createEntity(em, user))
+        em.flush()
+
+        val query = "?sort=id,desc&paivamaara.equals=$DEFAULT_PAIVAMAARA" +
+            "&aihekategoriaId.equals=${category.id}&yksityinen.equals=false"
+
+        restPaivakirjamerkintaMockMvc.perform(get(ENTITY_API_URL + query))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.content").value(Matchers.hasSize<Any>(1)))
+            .andExpect(jsonPath("$.content[0].id").value(matchingEntry.id))
     }
 
     @Throws(Exception::class)

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/errors/BadRequestExceptionAdviceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/errors/BadRequestExceptionAdviceIT.kt
@@ -1,0 +1,84 @@
+package fi.elsapalvelu.elsa.web.rest.errors
+
+import fi.elsapalvelu.elsa.ElsaBackendApp
+import fi.elsapalvelu.elsa.security.ADMIN
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@AutoConfigureMockMvc
+@SpringBootTest(classes = [ElsaBackendApp::class])
+@WithMockUser(authorities = [ADMIN])
+class BadRequestExceptionAdviceIT {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun validationFailureReturnsProblemDetailContract() {
+        mockMvc.perform(
+            post("$ENDPOINT_BASE_URL/method-argument")
+                .with(csrf())
+                .contentType(APPLICATION_JSON)
+                .content("{}")
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(content().contentTypeCompatibleWith(APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.type").value("about:blank"))
+            .andExpect(jsonPath("$.title").value("Bad Request"))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.detail").value("Invalid request content."))
+            .andExpect(jsonPath("$.instance").value("$ENDPOINT_BASE_URL/method-argument"))
+    }
+
+    @Test
+    fun accessDeniedReturnsProblemDetailContract() {
+        mockMvc.perform(get("$ENDPOINT_BASE_URL/access-denied"))
+            .andExpect(status().isForbidden)
+            .andExpect(content().contentTypeCompatibleWith(APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.type").value("about:blank"))
+            .andExpect(jsonPath("$.title").value("Forbidden"))
+            .andExpect(jsonPath("$.status").value(403))
+            .andExpect(jsonPath("$.detail").value("test access denied!"))
+            .andExpect(jsonPath("$.instance").value("$ENDPOINT_BASE_URL/access-denied"))
+    }
+
+    @Test
+    fun unsupportedMethodReturnsProblemDetailContract() {
+        mockMvc.perform(get("$ENDPOINT_BASE_URL/method-argument"))
+            .andExpect(status().isMethodNotAllowed)
+            .andExpect(content().contentTypeCompatibleWith(APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.type").value("about:blank"))
+            .andExpect(jsonPath("$.title").value("Method Not Allowed"))
+            .andExpect(jsonPath("$.status").value(405))
+            .andExpect(jsonPath("$.detail").value("Method 'GET' is not supported."))
+            .andExpect(jsonPath("$.instance").value("$ENDPOINT_BASE_URL/method-argument"))
+    }
+
+    @Test
+    fun unexpectedExceptionReturnsProblemDetailContract() {
+        mockMvc.perform(get("$ENDPOINT_BASE_URL/internal-server-error"))
+            .andExpect(status().isInternalServerError)
+            .andExpect(content().contentTypeCompatibleWith(APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.type").value("about:blank"))
+            .andExpect(jsonPath("$.title").value("Internal Server Error"))
+            .andExpect(jsonPath("$.status").value(500))
+            .andExpect(jsonPath("$.detail").doesNotExist())
+            .andExpect(jsonPath("$.instance").value("$ENDPOINT_BASE_URL/internal-server-error"))
+    }
+
+    companion object {
+        private const val ENDPOINT_BASE_URL = "/api/exception-translator-test"
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/errors/ExceptionTranslatorTestController.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/errors/ExceptionTranslatorTestController.kt
@@ -6,9 +6,11 @@ import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotNull
 
 @RestController
@@ -19,7 +21,7 @@ class ExceptionTranslatorTestController {
     fun concurrencyFailure(): Unit = throw ConcurrencyFailureException("test concurrency failure")
 
     @PostMapping("/method-argument")
-    fun methodArgument() = Unit
+    fun methodArgument(@Valid @RequestBody testDTO: TestDTO) = testDTO
 
     @GetMapping("/missing-servlet-request-part")
     fun missingServletRequestPartException() = Unit

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaEtusivuResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/virkailija/VirkailijaEtusivuResourceIT.kt
@@ -341,6 +341,33 @@ class VirkailijaEtusivuResourceIT {
 
     @Test
     @Transactional
+    fun combinedFiltersShouldRequireNameErikoisalaAndAsetusToMatchSameOpintooikeus() {
+        initTest()
+
+        val matchingQuery = "?nimi.contains=john&erikoisalaId.equals=${erikoisala1.id}" +
+            "&asetusId.equals=${asetus1.id}"
+
+        restEtusivuMockMvc.perform(get(ERIKOISTUJIEN_SEURANTA_ENDPOINT_URL + matchingQuery))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.content").value(hasSize<Int>(1)))
+            .andExpect(
+                jsonPath("$.content[0].opintooikeusId").value(
+                    erikoistuvaLaakari1.getOpintooikeusKaytossa()?.id
+                )
+            )
+
+        val conflictingQuery = "?nimi.contains=john doe&erikoisalaId.equals=${erikoisala2.id}" +
+            "&asetusId.equals=${asetus2.id}"
+
+        restEtusivuMockMvc.perform(get(ERIKOISTUJIEN_SEURANTA_ENDPOINT_URL + conflictingQuery))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.content").isEmpty)
+    }
+
+    @Test
+    @Transactional
     fun getErikoistujienSeurantaRajaimet() {
         initTest()
         val erikoisalatCountByLiittynytElsaan =


### PR DESCRIPTION
This pull request introduces several new and improved integration and unit tests to strengthen filter logic and error handling, as well as minor enhancements to the criteria copying logic. The main focus is on ensuring that combined filters work correctly in resource endpoints and that error responses conform to the expected Problem Detail contract.

**Filter logic improvements:**

* Added integration test to `VirkailijaEtusivuResourceIT` to verify that combined filters for `nimi`, `erikoisalaId`, and `asetusId` require all criteria to match the same `opintooikeus` (`combinedFiltersShouldRequireNameErikoisalaAndAsetusToMatchSameOpintooikeus`).
* Added integration test to `ErikoistuvaLaakariPaivakirjamerkintaResourceIT` to ensure that combined filters on `paivamaara`, `aihekategoriaId`, and `yksityinen` return only the matching entry from an active `opintooikeus` (`combinedFiltersShouldReturnOnlyMatchingEntryFromActiveOpintooikeus`).

**Criteria and filter copying:**

* Updated `ErikoistujanEteneminenCriteria` to ensure that the `naytaPaattyneet` property is copied in the copy constructor, and added a unit test to verify that all filter criteria are preserved and copied as independent objects (`ErikoistujanEteneminenCriteriaTest`). [[1]](diffhunk://#diff-9f17cade27f2d3e3b34197deb660f4c8cbad8bca672459b779aa3ab2161106d4L24-R25) [[2]](diffhunk://#diff-061603cccf7527f83eaf220b89f634d455e3cca4e7055ae08a4c5b1e2a04cf04R1-R30)

**Error handling and API contract:**

* Added new integration tests in `BadRequestExceptionAdviceIT` to verify that various error scenarios (validation failure, access denied, unsupported method, and unexpected exceptions) return responses conforming to the Problem Detail (RFC 7807) contract.
* Modified `ExceptionTranslatorTestController` so that the `/method-argument` endpoint now validates and binds a request body, enabling proper testing of validation errors. [[1]](diffhunk://#diff-624346aaebbccbe3aa2dfcdd3f8b8d2ada79a1a5938ddd6c59e78decfbd83ffdR9-R13) [[2]](diffhunk://#diff-624346aaebbccbe3aa2dfcdd3f8b8d2ada79a1a5938ddd6c59e78decfbd83ffdL22-R24)