### PR TITLE
ValmistumispyyntoMapperTest

### DIFF
--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/mapper/arviointi/SuoritusarvioinninArviointityokalunVastausMapperTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/mapper/arviointi/SuoritusarvioinninArviointityokalunVastausMapperTest.kt
@@ -1,0 +1,90 @@
+package fi.elsapalvelu.elsa.service.mapper.arviointi
+
+import fi.elsapalvelu.elsa.domain.arviointi.Arviointityokalu
+import fi.elsapalvelu.elsa.domain.arviointi.ArviointityokaluKysymys
+import fi.elsapalvelu.elsa.domain.arviointi.ArviointityokaluKysymysVaihtoehto
+import fi.elsapalvelu.elsa.domain.arviointi.SuoritusarvioinninArviointityokalunVastaus
+import fi.elsapalvelu.elsa.domain.arviointi.Suoritusarviointi
+import fi.elsapalvelu.elsa.service.dto.arviointi.SuoritusarvioinninArviointityokalunVastausDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SuoritusarvioinninArviointityokalunVastausMapperTest {
+
+    private val mapper: SuoritusarvioinninArviointityokalunVastausMapper =
+        SuoritusarvioinninArviointityokalunVastausMapperImpl()
+
+    @Test
+    fun toDtoShouldFlattenNestedEntityIds() {
+        val entity = SuoritusarvioinninArviointityokalunVastaus(
+            id = 1L,
+            suoritusarviointi = Suoritusarviointi(id = 2L),
+            arviointityokalu = Arviointityokalu(id = 3L),
+            arviointityokaluKysymys = ArviointityokaluKysymys(id = 4L),
+            tekstiVastaus = "Free-form answer",
+            valittuVaihtoehto = ArviointityokaluKysymysVaihtoehto(id = 5L)
+        )
+
+        val dto = mapper.toDto(entity)
+
+        assertThat(dto).usingRecursiveComparison().isEqualTo(
+            SuoritusarvioinninArviointityokalunVastausDTO(
+                id = 1L,
+                suoritusarviointiId = 2L,
+                arviointityokaluId = 3L,
+                arviointityokaluKysymysId = 4L,
+                tekstiVastaus = "Free-form answer",
+                valittuVaihtoehtoId = 5L
+            )
+        )
+    }
+
+    @Test
+    fun toEntityShouldCreateNestedReferencesFromIds() {
+        val dto = SuoritusarvioinninArviointityokalunVastausDTO(
+            id = 1L,
+            suoritusarviointiId = 2L,
+            arviointityokaluId = 3L,
+            arviointityokaluKysymysId = 4L,
+            tekstiVastaus = "Free-form answer",
+            valittuVaihtoehtoId = 5L
+        )
+
+        val entity = mapper.toEntity(dto)
+
+        assertThat(entity.id).isEqualTo(1L)
+        assertThat(entity.suoritusarviointi?.id).isEqualTo(2L)
+        assertThat(entity.arviointityokalu?.id).isEqualTo(3L)
+        assertThat(entity.arviointityokaluKysymys?.id).isEqualTo(4L)
+        assertThat(entity.tekstiVastaus).isEqualTo("Free-form answer")
+        assertThat(entity.valittuVaihtoehto?.id).isEqualTo(5L)
+    }
+
+    @Test
+    fun partialUpdateShouldUpdateProvidedAnswerAndPreserveOmittedValues() {
+        val suoritusarviointi = Suoritusarviointi(id = 2L)
+        val arviointityokalu = Arviointityokalu(id = 3L)
+        val kysymys = ArviointityokaluKysymys(id = 4L)
+        val vaihtoehto = ArviointityokaluKysymysVaihtoehto(id = 5L)
+        val entity = SuoritusarvioinninArviointityokalunVastaus(
+            id = 1L,
+            suoritusarviointi = suoritusarviointi,
+            arviointityokalu = arviointityokalu,
+            arviointityokaluKysymys = kysymys,
+            tekstiVastaus = "Original answer",
+            valittuVaihtoehto = vaihtoehto
+        )
+
+        mapper.partialUpdate(
+            entity,
+            SuoritusarvioinninArviointityokalunVastausDTO(tekstiVastaus = "Updated answer")
+        )
+
+        assertThat(entity.id).isEqualTo(1L)
+        assertThat(entity.suoritusarviointi).isSameAs(suoritusarviointi)
+        assertThat(entity.arviointityokalu).isSameAs(arviointityokalu)
+        assertThat(entity.arviointityokaluKysymys).isSameAs(kysymys)
+        assertThat(entity.tekstiVastaus).isEqualTo("Updated answer")
+        assertThat(entity.valittuVaihtoehto).isSameAs(vaihtoehto)
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/mapper/arviointi/SuoritusarviointiMapperTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/mapper/arviointi/SuoritusarviointiMapperTest.kt
@@ -1,12 +1,41 @@
 package fi.elsapalvelu.elsa.service.mapper.arviointi
 
-import fi.elsapalvelu.elsa.web.rest.mapperVerifier as verifyMapper
+import fi.elsapalvelu.elsa.domain.arviointi.Suoritusarviointi
+import fi.elsapalvelu.elsa.service.dto.arviointi.SuoritusarviointiDTO
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class SuoritusarviointiMapperTest {
 
+    private val mapper: SuoritusarviointiMapper = SuoritusarviointiMapperImpl()
+
     @Test
-    fun mapperVerifier() {
-        verifyMapper<SuoritusarviointiMapperImpl>()
+    fun partialUpdateShouldUpdateProvidedValuesAndPreserveNullValues() {
+        val entity = Suoritusarviointi(
+            id = 1L,
+            arvioitavaTapahtuma = "Original event",
+            lisatiedot = "Original details",
+            lukittu = true,
+            keskenerainen = true
+        )
+        val dto = SuoritusarviointiDTO(
+            lisatiedot = "Updated details",
+            lukittu = true,
+            keskenerainen = true
+        )
+
+        mapper.partialUpdate(entity, dto)
+
+        assertThat(entity.id).isEqualTo(1L)
+        assertThat(entity.arvioitavaTapahtuma).isEqualTo("Original event")
+        assertThat(entity.lisatiedot).isEqualTo("Updated details")
+        assertThat(entity.lukittu).isTrue
+        assertThat(entity.keskenerainen).isTrue
+    }
+
+    @Test
+    fun fromIdShouldCreateReferenceOnlyForNonNullId() {
+        assertThat(mapper.fromId(1L)?.id).isEqualTo(1L)
+        assertThat(mapper.fromId(null)).isNull()
     }
 }

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/mapper/valmistuminen/ValmistumispyyntoMapperTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/mapper/valmistuminen/ValmistumispyyntoMapperTest.kt
@@ -1,0 +1,164 @@
+package fi.elsapalvelu.elsa.service.mapper.valmistuminen
+
+import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
+import fi.elsapalvelu.elsa.domain.kayttaja.AsiakirjaData
+import fi.elsapalvelu.elsa.domain.kayttaja.ErikoistuvaLaakari
+import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
+import fi.elsapalvelu.elsa.domain.kayttaja.User
+import fi.elsapalvelu.elsa.domain.perustiedot.Asetus
+import fi.elsapalvelu.elsa.domain.perustiedot.Erikoisala
+import fi.elsapalvelu.elsa.domain.perustiedot.Yliopisto
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoOsaamisenArviointiDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class ValmistumispyyntoMapperTest {
+
+    private val mapper: ValmistumispyyntoMapper = ValmistumispyyntoMapperImpl()
+    private val osaamisenArviointiMapper: ValmistumispyyntoOsaamisenArviointiMapper =
+        ValmistumispyyntoOsaamisenArviointiMapperImpl()
+
+    @Test
+    fun toDtoShouldMapNestedTraineeReviewersAndDocumentIds() {
+        val entity = createValmistumispyynto()
+
+        val dto = mapper.toDto(entity)
+
+        assertThat(dto.id).isEqualTo(1L)
+        assertThat(dto.erikoistujanNimi).isEqualTo("Erika Erikoistuja")
+        assertThat(dto.erikoistujanAvatar).containsExactly(1, 2, 3)
+        assertThat(dto.erikoistujanOpiskelijatunnus).isEqualTo("student-123")
+        assertThat(dto.erikoistujanSyntymaaika).isEqualTo(LocalDate.of(1990, 2, 3))
+        assertThat(dto.erikoistujanYliopisto).isEqualTo(YliopistoEnum.HELSINGIN_YLIOPISTO)
+        assertThat(dto.erikoistujanErikoisala).isEqualTo("Cardiology")
+        assertThat(dto.erikoistujanLaillistamispaiva).isEqualTo(LocalDate.of(2020, 4, 5))
+        assertThat(dto.erikoistujanLaillistamistodistus).containsExactly(4, 5, 6)
+        assertThat(dto.erikoistujanLaillistamistodistusNimi).isEqualTo("licence.pdf")
+        assertThat(dto.erikoistujanLaillistamistodistusTyyppi).isEqualTo("application/pdf")
+        assertThat(dto.erikoistujanAsetus).isEqualTo("Regulation 2020")
+        assertThat(dto.opintooikeusId).isEqualTo(2L)
+        assertThat(dto.opintooikeudenMyontamispaiva).isEqualTo(LocalDate.of(2021, 8, 1))
+        assertThat(dto.vastuuhenkiloOsaamisenArvioijaNimi).isEqualTo("Olivia Reviewer")
+        assertThat(dto.vastuuhenkiloOsaamisenArvioijaNimike).isEqualTo("Professor")
+        assertThat(dto.virkailijaNimi).isEqualTo("Victor Official")
+        assertThat(dto.vastuuhenkiloHyvaksyjaNimi).isEqualTo("Hanna Approver")
+        assertThat(dto.vastuuhenkiloHyvaksyjaNimike).isEqualTo("Chief physician")
+        assertThat(dto.yhteenvetoAsiakirjaId).isEqualTo(10L)
+        assertThat(dto.liitteetAsiakirjaId).isEqualTo(11L)
+        assertThat(dto.erikoistujanTiedotAsiakirjaId).isEqualTo(12L)
+    }
+
+    @Test
+    fun osaamisenArviointiToDtoShouldMapNestedFieldsAndFormatBirthDate() {
+        val entity = createValmistumispyynto()
+
+        val dto = osaamisenArviointiMapper.toDto(entity)
+
+        assertThat(dto.erikoistujanNimi).isEqualTo("Erika Erikoistuja")
+        assertThat(dto.erikoistujanAvatar).containsExactly(1, 2, 3)
+        assertThat(dto.erikoistujanSyntymaaika).isEqualTo("1990-02-03")
+        assertThat(dto.erikoistujanYliopisto).isEqualTo(YliopistoEnum.HELSINGIN_YLIOPISTO)
+        assertThat(dto.erikoistujanErikoisala).isEqualTo("Cardiology")
+        assertThat(dto.erikoistujanLaillistamistodistus).containsExactly(4, 5, 6)
+        assertThat(dto.erikoistujanAsetus).isEqualTo("Regulation 2020")
+        assertThat(dto.opintooikeusId).isEqualTo(2L)
+        assertThat(dto.vastuuhenkiloOsaamisenArvioijaNimi).isEqualTo("Olivia Reviewer")
+        assertThat(dto.vastuuhenkiloOsaamisenArvioijaNimike).isEqualTo("Professor")
+    }
+
+    @Test
+    fun partialUpdateShouldUpdateProvidedValuesAndPreserveOmittedAndNestedValues() {
+        val entity = createValmistumispyynto()
+        val originalOpintooikeus = entity.opintooikeus
+        val originalKuittausaika = entity.erikoistujanKuittausaika
+
+        mapper.partialUpdate(
+            entity,
+            ValmistumispyyntoDTO(
+                virkailijanSaate = "Updated cover note",
+                vastuuhenkiloHyvaksyjaKorjausehdotus = "Updated correction"
+            )
+        )
+
+        assertThat(entity.id).isEqualTo(1L)
+        assertThat(entity.opintooikeus).isSameAs(originalOpintooikeus)
+        assertThat(entity.selvitysVanhentuneistaSuorituksista).isEqualTo("Original explanation")
+        assertThat(entity.erikoistujanKuittausaika).isEqualTo(originalKuittausaika)
+        assertThat(entity.virkailijanSaate).isEqualTo("Updated cover note")
+        assertThat(entity.vastuuhenkiloHyvaksyjaKorjausehdotus).isEqualTo("Updated correction")
+    }
+
+    @Test
+    fun osaamisenArviointiPartialUpdateShouldPreserveNullValues() {
+        val entity = createValmistumispyynto()
+        val originalPalautusaika = entity.vastuuhenkiloOsaamisenArvioijaPalautusaika
+        val originalVirkailijanKorjausehdotus = entity.virkailijanKorjausehdotus
+
+        osaamisenArviointiMapper.partialUpdate(
+            entity,
+            ValmistumispyyntoOsaamisenArviointiDTO(
+                vastuuhenkiloOsaamisenArvioijaKorjausehdotus = "Updated reviewer correction"
+            )
+        )
+
+        assertThat(entity.id).isEqualTo(1L)
+        assertThat(entity.vastuuhenkiloOsaamisenArvioijaPalautusaika).isEqualTo(originalPalautusaika)
+        assertThat(entity.vastuuhenkiloOsaamisenArvioijaKorjausehdotus).isEqualTo("Updated reviewer correction")
+        assertThat(entity.virkailijanKorjausehdotus).isEqualTo(originalVirkailijanKorjausehdotus)
+    }
+
+    private fun createValmistumispyynto(): Valmistumispyynto {
+        val erikoistuvaLaakari = ErikoistuvaLaakari(
+            syntymaaika = LocalDate.of(1990, 2, 3),
+            kayttaja = createKayttaja("Erika", "Erikoistuja", avatar = byteArrayOf(1, 2, 3)),
+            laillistamispaiva = LocalDate.of(2020, 4, 5),
+            laillistamistodistus = AsiakirjaData(data = byteArrayOf(4, 5, 6)),
+            laillistamispaivanLiitetiedostonNimi = "licence.pdf",
+            laillistamispaivanLiitetiedostonTyyppi = "application/pdf"
+        )
+        val opintooikeus = Opintooikeus(
+            id = 2L,
+            opintooikeudenMyontamispaiva = LocalDate.of(2021, 8, 1),
+            opiskelijatunnus = "student-123",
+            erikoistuvaLaakari = erikoistuvaLaakari,
+            yliopisto = Yliopisto(nimi = YliopistoEnum.HELSINGIN_YLIOPISTO),
+            erikoisala = Erikoisala(nimi = "Cardiology"),
+            asetus = Asetus(nimi = "Regulation 2020")
+        )
+
+        return Valmistumispyynto(
+            id = 1L,
+            opintooikeus = opintooikeus,
+            selvitysVanhentuneistaSuorituksista = "Original explanation",
+            vastuuhenkiloOsaamisenArvioijaKuittausaika = LocalDate.of(2024, 1, 10),
+            vastuuhenkiloOsaamisenArvioijaPalautusaika = LocalDate.of(2024, 1, 11),
+            vastuuhenkiloOsaamisenArvioijaKorjausehdotus = "Original reviewer correction",
+            vastuuhenkiloOsaamisenArvioija = createKayttaja("Olivia", "Reviewer", "Professor"),
+            virkailijanKorjausehdotus = "Original official correction",
+            virkailija = createKayttaja("Victor", "Official"),
+            virkailijanSaate = "Original cover note",
+            vastuuhenkiloHyvaksyjaKorjausehdotus = "Original approver correction",
+            vastuuhenkiloHyvaksyja = createKayttaja("Hanna", "Approver", "Chief physician"),
+            erikoistujanKuittausaika = LocalDate.of(2024, 1, 9),
+            muokkauspaiva = LocalDate.of(2024, 1, 12),
+            yhteenvetoAsiakirja = Asiakirja(id = 10L),
+            liitteetAsiakirja = Asiakirja(id = 11L),
+            erikoistujanTiedotAsiakirja = Asiakirja(id = 12L)
+        )
+    }
+
+    private fun createKayttaja(
+        firstName: String,
+        lastName: String,
+        nimike: String? = null,
+        avatar: ByteArray? = null
+    ) = Kayttaja(
+        nimike = nimike,
+        user = User(firstName = firstName, lastName = lastName, avatar = avatar)
+    )
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for several mapper classes, improving test coverage and ensuring correct mapping logic between entities and DTOs. The new tests verify the mapping of nested fields, partial updates, and correct handling of IDs and null values.

### New Mapper Test Coverage

* Added `ValmistumispyyntoMapperTest` and `ValmistumispyyntoOsaamisenArviointiMapperTest` to cover mapping of nested fields, document IDs, and partial updates for the `Valmistumispyynto` domain and related DTOs.
* Added `SuoritusarvioinninArviointityokalunVastausMapperTest` to verify mapping logic, including flattening nested entity IDs, reconstructing entities from DTOs, and partial update behavior.
* Expanded `SuoritusarviointiMapperTest` to include tests for partial updates and reference creation from IDs, replacing the previous generic `mapperVerifier` call.

These changes strengthen the reliability of the mapping layer by ensuring that all important mapping scenarios are explicitly tested.