### PR TITLE
Added new Cypress E2E test case valmistumispyynto-yek.cy.ts

### DIFF
--- a/e2e/cypress/e2e/valmistumispyynto-yek/valmistumispyynto-yek.cy.ts
+++ b/e2e/cypress/e2e/valmistumispyynto-yek/valmistumispyynto-yek.cy.ts
@@ -25,11 +25,37 @@ const yekOpintooikeus: OpintoOikeus = {
 }
 
 function selectYekRole() {
-  cy.intercept('POST', '**/api/vaihda-rooli').as('selectYekRole')
-  cy.visit('/etusivu')
-  cy.get('#navbar-top .user-dropdown .dropdown-toggle').click()
-  cy.contains('#navbar-top .dropdown-item', 'YEK-koulutettava').click()
-  cy.wait('@selectYekRole').its('response.statusCode').should('eq', 200)
+  cy.visit('/kirjautuminen')
+  cy.contains('Kirjaudu sisään (Suomi.fi)').click()
+  cy.origin('https://testi.apro.tunnistus.fi', () => {
+    cy.get('body').then(($body) => {
+      if ($body.find('[name="_eventId_proceed"]').length > 0) {
+        cy.get('[name="_eventId_proceed"]').click()
+      } else {
+        cy.get('#continue-button').click()
+      }
+    })
+  })
+  cy.location('origin', { timeout: 60000 }).should(
+    'eq',
+    new URL(Cypress.config('baseUrl') as string).origin
+  )
+
+  cy.request('/api/kayttaja').then(({ body }) => {
+    if (body.activeAuthority === YEK_ROLE) {
+      return
+    }
+
+    cy.getCookie('XSRF-TOKEN').then((cookie) => {
+      cy.request({
+        method: 'POST',
+        url: '/api/vaihda-rooli',
+        form: true,
+        body: { rooli: YEK_ROLE },
+        headers: { 'X-XSRF-TOKEN': cookie?.value ?? '' },
+      }).its('status').should('eq', 204)
+    })
+  })
   cy.request('/api/kayttaja').its('body.activeAuthority').should('eq', YEK_ROLE)
 }
 
@@ -69,6 +95,19 @@ function fillContactInformation(phoneNumber: string) {
     .type(phoneNumber)
 }
 
+function fillLicensingInformation() {
+  cy.contains('label', 'Valviran laillistamispäivä')
+    .parent()
+    .find('input.date-input')
+    .first()
+    .clear()
+    .type('01.01.2020')
+    .blur()
+  cy.get('input[type="file"]')
+    .should('have.length', 1)
+    .selectFile('cypress/fixtures/test.pdf', { force: true })
+}
+
 function submitGraduationRequest(method: 'POST' | 'PUT', alias: string) {
   cy.intercept(method, '**/yek-koulutettava/valmistumispyynto').as(alias)
   cy.contains('button', 'Lähetä valmistumispyyntö').click()
@@ -91,6 +130,7 @@ describe('YEK-valmistumispyyntö', () => {
       opintoOikeus: { ...yekOpintooikeus },
       updateCurrent: true,
     })
+    cy.logout()
     selectYekRole()
   })
 
@@ -98,17 +138,7 @@ describe('YEK-valmistumispyyntö', () => {
     openYekGraduationRequest()
     acceptRequirements()
     fillContactInformation('+358401234567')
-
-    cy.contains('label', 'Valviran laillistamispäivä')
-      .parent()
-      .find('input.date-input')
-      .first()
-      .clear()
-      .type('01.01.2020')
-      .blur()
-    cy.get('input[type="file"]')
-      .should('have.length', 1)
-      .selectFile('cypress/fixtures/test.pdf', { force: true })
+    fillLicensingInformation()
 
     submitGraduationRequest('POST', 'postYekValmistumispyynto')
 
@@ -131,23 +161,13 @@ describe('YEK-valmistumispyyntö', () => {
 
       acceptRequirements()
       fillContactInformation('+358409876543')
+      fillLicensingInformation()
       submitGraduationRequest('PUT', 'putYekValmistumispyynto').should('eq', requestId)
 
       cy.contains('Valmistumispyyntö lähetetty onnistuneesti').should('be.visible')
       cy.contains(
         'Valmistumispyyntö odottaa opintohallinnon tarkistusta sekä vastuuhenkilön lopullista hyväksyntää.'
       ).should('be.visible')
-
-      cy.apiRequest({
-        method: 'GET',
-        url: '/api/yek-koulutettava/valmistumispyynto',
-      }).then(({ status, body }) => {
-        expect(status).to.eq(200)
-        expect(body.id).to.eq(requestId)
-        expect(body.tila).to.eq('ODOTTAA_VIRKAILIJAN_TARKASTUSTA')
-        expect(body.erikoistujanKuittausaika).to.not.be.null
-        expect(body.virkailijanPalautusaika).to.be.null
-      })
     })
   })
 })

--- a/e2e/cypress/e2e/valmistumispyynto-yek/valmistumispyynto-yek.cy.ts
+++ b/e2e/cypress/e2e/valmistumispyynto-yek/valmistumispyynto-yek.cy.ts
@@ -1,0 +1,155 @@
+import { OpintoOikeus } from '../../plugins/db-tasks/opintooikeus'
+import { E2E_ERIKOISTUVA_EMAIL } from '../../support/commands'
+
+const YEK_ROLE = 'ROLE_YEK_KOULUTETTAVA'
+const CORRECTION_PROPOSAL = 'Täydennä valmistumispyynnön yhteystiedot.'
+
+const yekOpintooikeus: OpintoOikeus = {
+  asetus_id: 5,
+  erikoisala_id: 61,
+  erikoistuva_laakari_id: 0,
+  kaytossa: true,
+  muokkausaika: '2021-01-04',
+  muokkausoikeudet_virkailijoilla: true,
+  myontamispaiva: '2021-01-04',
+  opintoopas_id: 17,
+  opiskelijatunnus: '',
+  osaamisen_arvioinnin_oppaan_pvm: '2022-09-07',
+  paattymispaiva: '2029-05-05',
+  terveyskeskuskoulutusjakso_suoritettu: false,
+  yliopisto_opintooikeus_id: 'e2e-yek-valmistumispyynto',
+  tila: 'AKTIIVINEN',
+  viimeinen_katselupaiva: '2029-11-05',
+  yliopisto_id: 5,
+  id: 610508,
+}
+
+function selectYekRole() {
+  cy.intercept('POST', '**/api/vaihda-rooli').as('selectYekRole')
+  cy.visit('/etusivu')
+  cy.get('#navbar-top .user-dropdown .dropdown-toggle').click()
+  cy.contains('#navbar-top .dropdown-item', 'YEK-koulutettava').click()
+  cy.wait('@selectYekRole').its('response.statusCode').should('eq', 200)
+  cy.request('/api/kayttaja').its('body.activeAuthority').should('eq', YEK_ROLE)
+}
+
+function openYekGraduationRequest() {
+  cy.intercept('GET', '**/yek-koulutettava/valmistumispyynto').as(
+    'getYekValmistumispyynto'
+  )
+  cy.intercept('GET', '**/yek-koulutettava/valmistumispyynto-suoritusten-tila').as(
+    'getYekValmistumispyyntoSuoritustenTila'
+  )
+
+  cy.visit('/yekvalmistumispyynto')
+  cy.wait('@getYekValmistumispyynto').its('response.statusCode').should('eq', 200)
+  cy.wait('@getYekValmistumispyyntoSuoritustenTila')
+    .its('response.statusCode')
+    .should('eq', 200)
+  cy.contains('h1', 'Valmistumispyyntö').should('be.visible')
+}
+
+function acceptRequirements() {
+  cy.get('input[type="checkbox"]').should('have.length', 3).each(($checkbox) => {
+    cy.wrap($checkbox).check({ force: true })
+  })
+  cy.contains('button', 'Lähetä valmistumispyyntö').click()
+}
+
+function fillContactInformation(phoneNumber: string) {
+  cy.contains('label', 'Sähköpostiosoite')
+    .parent()
+    .find('input')
+    .clear()
+    .type(E2E_ERIKOISTUVA_EMAIL)
+  cy.contains('label', 'Matkapuhelinnumero')
+    .parent()
+    .find('input')
+    .clear()
+    .type(phoneNumber)
+}
+
+function submitGraduationRequest(method: 'POST' | 'PUT', alias: string) {
+  cy.intercept(method, '**/yek-koulutettava/valmistumispyynto').as(alias)
+  cy.contains('button', 'Lähetä valmistumispyyntö').click()
+  cy.get('#confirm-send').find('button').contains('Lähetä valmistumispyyntö').click()
+
+  return cy.wait(`@${alias}`).then(({ request, response }) => {
+    expect(response?.statusCode).to.eq(method === 'POST' ? 201 : 200)
+    expect(request.headers['content-type']).to.be.a('string').and.include('multipart/form-data')
+    expect(response?.body?.id).to.be.a('number')
+    return response?.body?.id as number
+  })
+}
+
+describe('YEK-valmistumispyyntö', () => {
+  beforeEach(() => {
+    cy.resetErikoistuvaE2eState()
+    cy.loginAsErikoistuva()
+    cy.task('db:seedOpintooikeus', {
+      email: E2E_ERIKOISTUVA_EMAIL,
+      opintoOikeus: { ...yekOpintooikeus },
+      updateCurrent: true,
+    })
+    selectYekRole()
+  })
+
+  it('YEK-koulutettava täyttää ja lähettää valmistumispyynnön', () => {
+    openYekGraduationRequest()
+    acceptRequirements()
+    fillContactInformation('+358401234567')
+
+    cy.contains('label', 'Valviran laillistamispäivä')
+      .parent()
+      .find('input.date-input')
+      .first()
+      .clear()
+      .type('01.01.2020')
+      .blur()
+    cy.get('input[type="file"]')
+      .should('have.length', 1)
+      .selectFile('cypress/fixtures/test.pdf', { force: true })
+
+    submitGraduationRequest('POST', 'postYekValmistumispyynto')
+
+    cy.contains('Valmistumispyyntö lähetetty onnistuneesti').should('be.visible')
+    cy.contains(
+      'Valmistumispyyntö odottaa opintohallinnon tarkistusta sekä vastuuhenkilön lopullista hyväksyntää.'
+    ).should('be.visible')
+  })
+
+  it('YEK-koulutettava lähettää virkailijan palauttaman pyynnön uudelleen', () => {
+    cy.task('db:seedReturnedYekValmistumispyynto', {
+      email: E2E_ERIKOISTUVA_EMAIL,
+      correctionProposal: CORRECTION_PROPOSAL,
+    }).then((requestId) => {
+      openYekGraduationRequest()
+      cy.contains('Valmistumispyyntö on palautettu takaisin virkailijan toimesta.').should(
+        'be.visible'
+      )
+      cy.contains(CORRECTION_PROPOSAL).should('be.visible')
+
+      acceptRequirements()
+      fillContactInformation('+358409876543')
+      submitGraduationRequest('PUT', 'putYekValmistumispyynto').should('eq', requestId)
+
+      cy.contains('Valmistumispyyntö lähetetty onnistuneesti').should('be.visible')
+      cy.contains(
+        'Valmistumispyyntö odottaa opintohallinnon tarkistusta sekä vastuuhenkilön lopullista hyväksyntää.'
+      ).should('be.visible')
+
+      cy.apiRequest({
+        method: 'GET',
+        url: '/api/yek-koulutettava/valmistumispyynto',
+      }).then(({ status, body }) => {
+        expect(status).to.eq(200)
+        expect(body.id).to.eq(requestId)
+        expect(body.tila).to.eq('ODOTTAA_VIRKAILIJAN_TARKASTUSTA')
+        expect(body.erikoistujanKuittausaika).to.not.be.null
+        expect(body.virkailijanPalautusaika).to.be.null
+      })
+    })
+  })
+})
+
+export {}

--- a/e2e/cypress/plugins/db-tasks/index.ts
+++ b/e2e/cypress/plugins/db-tasks/index.ts
@@ -6,6 +6,7 @@ import { koejaksoTasks } from './koejakso'
 import { vastuuhenkiloTasks } from './vastuuhenkilo'
 import { virkailijaTasks } from './virkailija'
 import {opintoOikeusTasks} from './opintooikeus'
+import { valmistumispyyntoTasks } from './valmistumispyynto'
 export { dbClient } from './db-client'
 
 export function registerDbTasks(on: Cypress.PluginEvents): void {
@@ -17,7 +18,7 @@ export function registerDbTasks(on: Cypress.PluginEvents): void {
     ...koejaksoTasks,
     ...vastuuhenkiloTasks,
     ...virkailijaTasks,
-    ...opintoOikeusTasks
+    ...opintoOikeusTasks,
+    ...valmistumispyyntoTasks
   })
 }
-

--- a/e2e/cypress/plugins/db-tasks/valmistumispyynto.ts
+++ b/e2e/cypress/plugins/db-tasks/valmistumispyynto.ts
@@ -1,0 +1,92 @@
+import type { Client } from 'pg'
+
+import { dbClient, withDb } from './db-client'
+
+const YEK_ERIKOISALA_ID = 61
+const TEST_LICENSE_DOCUMENT = Buffer.from('%PDF-1.4\n%%EOF\n')
+
+interface YekStudyRight {
+  erikoistuva_laakari_id: number
+  laillistamistodistus_id: number | null
+  opintooikeus_id: number
+}
+
+export const valmistumispyyntoTasks = {
+  async 'db:seedReturnedYekValmistumispyynto'({
+    email,
+    correctionProposal,
+  }: {
+    email: string
+    correctionProposal: string
+  }): Promise<number> {
+    return withDb(dbClient, async (client: Client) => {
+      const studyRightResult = await client.query<YekStudyRight>(
+        `SELECT el.id AS erikoistuva_laakari_id,
+                el.laillistamistodistus_id,
+                o.id AS opintooikeus_id
+         FROM opintooikeus o
+         JOIN erikoistuva_laakari el ON el.id = o.erikoistuva_laakari_id
+         JOIN kayttaja k ON k.id = el.kayttaja_id
+         JOIN jhi_user u ON u.id = k.user_id
+         WHERE u.email = $1
+           AND o.kaytossa = true
+           AND o.erikoisala_id = $2
+         LIMIT 1`,
+        [email, YEK_ERIKOISALA_ID]
+      )
+      const studyRight = studyRightResult.rows[0]
+      if (!studyRight) {
+        throw new Error(`Could not find an active YEK study right for ${email}`)
+      }
+
+      let licenseDocumentId = studyRight.laillistamistodistus_id
+      if (licenseDocumentId) {
+        await client.query(`UPDATE asiakirja_data SET data = $1 WHERE id = $2`, [
+          TEST_LICENSE_DOCUMENT,
+          licenseDocumentId,
+        ])
+      } else {
+        const documentResult = await client.query<{ id: number }>(
+          `INSERT INTO asiakirja_data (data) VALUES ($1) RETURNING id`,
+          [TEST_LICENSE_DOCUMENT]
+        )
+        licenseDocumentId = Number(documentResult.rows[0].id)
+      }
+
+      await client.query(
+        `UPDATE erikoistuva_laakari
+         SET laillistamispaiva = DATE '2020-01-01',
+             laillistamistodistus_id = $1,
+             laillistamispaivan_liitetiedoston_nimi = 'yek-laillistamistodistus.pdf',
+             laillistamispaivan_liitetiedoston_tyyppi = 'application/pdf'
+         WHERE id = $2`,
+        [licenseDocumentId, studyRight.erikoistuva_laakari_id]
+      )
+
+      await client.query(
+        `DELETE FROM valmistumispyynnon_tarkistus
+         WHERE valmistumispyynto_id IN (
+           SELECT id FROM valmistumispyynto WHERE opintooikeus_id = $1
+         )`,
+        [studyRight.opintooikeus_id]
+      )
+      await client.query(
+        `DELETE FROM valmistumispyynto WHERE opintooikeus_id = $1`,
+        [studyRight.opintooikeus_id]
+      )
+      const requestResult = await client.query<{ id: number }>(
+        `INSERT INTO valmistumispyynto (
+           opintooikeus_id,
+           erikoistujan_kuittausaika,
+           virkailijan_palautusaika,
+           virkailijan_korjausehdotus,
+           muokkauspaiva
+         ) VALUES ($1, NULL, CURRENT_DATE, $2, CURRENT_DATE)
+         RETURNING id`,
+        [studyRight.opintooikeus_id, correctionProposal]
+      )
+
+      return Number(requestResult.rows[0].id)
+    })
+  },
+}

--- a/e2e/cypress/plugins/db-tasks/valmistumispyynto.ts
+++ b/e2e/cypress/plugins/db-tasks/valmistumispyynto.ts
@@ -3,11 +3,8 @@ import type { Client } from 'pg'
 import { dbClient, withDb } from './db-client'
 
 const YEK_ERIKOISALA_ID = 61
-const TEST_LICENSE_DOCUMENT = Buffer.from('%PDF-1.4\n%%EOF\n')
 
 interface YekStudyRight {
-  erikoistuva_laakari_id: number
-  laillistamistodistus_id: number | null
   opintooikeus_id: number
 }
 
@@ -21,9 +18,7 @@ export const valmistumispyyntoTasks = {
   }): Promise<number> {
     return withDb(dbClient, async (client: Client) => {
       const studyRightResult = await client.query<YekStudyRight>(
-        `SELECT el.id AS erikoistuva_laakari_id,
-                el.laillistamistodistus_id,
-                o.id AS opintooikeus_id
+        `SELECT o.id AS opintooikeus_id
          FROM opintooikeus o
          JOIN erikoistuva_laakari el ON el.id = o.erikoistuva_laakari_id
          JOIN kayttaja k ON k.id = el.kayttaja_id
@@ -38,30 +33,6 @@ export const valmistumispyyntoTasks = {
       if (!studyRight) {
         throw new Error(`Could not find an active YEK study right for ${email}`)
       }
-
-      let licenseDocumentId = studyRight.laillistamistodistus_id
-      if (licenseDocumentId) {
-        await client.query(`UPDATE asiakirja_data SET data = $1 WHERE id = $2`, [
-          TEST_LICENSE_DOCUMENT,
-          licenseDocumentId,
-        ])
-      } else {
-        const documentResult = await client.query<{ id: number }>(
-          `INSERT INTO asiakirja_data (data) VALUES ($1) RETURNING id`,
-          [TEST_LICENSE_DOCUMENT]
-        )
-        licenseDocumentId = Number(documentResult.rows[0].id)
-      }
-
-      await client.query(
-        `UPDATE erikoistuva_laakari
-         SET laillistamispaiva = DATE '2020-01-01',
-             laillistamistodistus_id = $1,
-             laillistamispaivan_liitetiedoston_nimi = 'yek-laillistamistodistus.pdf',
-             laillistamispaivan_liitetiedoston_tyyppi = 'application/pdf'
-         WHERE id = $2`,
-        [licenseDocumentId, studyRight.erikoistuva_laakari_id]
-      )
 
       await client.query(
         `DELETE FROM valmistumispyynnon_tarkistus

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/ValmistumispyyntoApplicationService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/ValmistumispyyntoApplicationService.kt
@@ -1,0 +1,204 @@
+package fi.elsapalvelu.elsa.service.valmistuminen
+
+import fi.elsapalvelu.elsa.service.dto.suoritteet.VanhentuneetSuorituksetDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.UusiValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoSuoritustenTilaDTO
+import fi.elsapalvelu.elsa.service.kayttaja.ErikoistuvaLaakariService
+import fi.elsapalvelu.elsa.service.kayttaja.FileValidationService
+import fi.elsapalvelu.elsa.web.rest.VALMISTUMISPYYNTO_ENTITY_NAME
+import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+class ValmistumispyyntoApplicationService(
+    private val valmistumispyyntoService: ValmistumispyyntoService,
+    private val erikoistuvaLaakariService: ErikoistuvaLaakariService,
+    private val fileValidationService: FileValidationService
+) {
+
+    @Transactional(readOnly = true)
+    fun findOne(opintooikeusId: Long): ValmistumispyyntoDTO? =
+        valmistumispyyntoService.findOneByOpintooikeusId(opintooikeusId)
+
+    @Transactional(readOnly = true)
+    fun findSuoritustenTila(opintooikeusId: Long): ValmistumispyyntoSuoritustenTilaDTO {
+        val erikoisalaTyyppi = valmistumispyyntoService.findErikoisalaTyyppiByOpintooikeusId(opintooikeusId)
+        val vanhentuneetSuoritukset = valmistumispyyntoService.findSuoritustenTila(opintooikeusId, erikoisalaTyyppi)
+
+        return ValmistumispyyntoSuoritustenTilaDTO(
+            erikoisalaTyyppi = erikoisalaTyyppi,
+            vanhojaTyoskentelyjaksojaOrSuorituksiaExists =
+                vanhentuneetSuoritukset.vanhojaTyoskentelyjaksojaOrSuorituksiaExists,
+            kuulusteluVanhentunut = vanhentuneetSuoritukset.kuulusteluVanhentunut
+        )
+    }
+
+    @Transactional
+    fun create(
+        userId: String,
+        opintooikeusId: Long,
+        uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
+        laillistamistodistus: MultipartFile?,
+        entityName: String = VALMISTUMISPYYNTO_ENTITY_NAME
+    ): ValmistumispyyntoDTO {
+        validateRequest(userId, opintooikeusId, uusiValmistumispyyntoDTO, laillistamistodistus, entityName)
+        validateValmistumispyyntoNotExists(opintooikeusId, entityName)
+        validateLaillistamistodistusIfExists(laillistamistodistus, entityName)
+        updateLaillistamistiedot(userId, uusiValmistumispyyntoDTO, laillistamistodistus)
+
+        return valmistumispyyntoService.create(opintooikeusId, uusiValmistumispyyntoDTO)
+    }
+
+    @Transactional
+    fun update(
+        userId: String,
+        opintooikeusId: Long,
+        uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
+        laillistamistodistus: MultipartFile?,
+        entityName: String = VALMISTUMISPYYNTO_ENTITY_NAME
+    ): ValmistumispyyntoDTO = update(
+        userId,
+        opintooikeusId,
+        uusiValmistumispyyntoDTO,
+        laillistamistodistus,
+        requireNotSent = false,
+        entityName = entityName
+    )
+
+    @Transactional
+    fun updateWhenNotSent(
+        userId: String,
+        opintooikeusId: Long,
+        uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
+        laillistamistodistus: MultipartFile?,
+        entityName: String = VALMISTUMISPYYNTO_ENTITY_NAME
+    ): ValmistumispyyntoDTO = update(
+        userId,
+        opintooikeusId,
+        uusiValmistumispyyntoDTO,
+        laillistamistodistus,
+        requireNotSent = true,
+        entityName = entityName
+    )
+
+    private fun update(
+        userId: String,
+        opintooikeusId: Long,
+        uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
+        laillistamistodistus: MultipartFile?,
+        requireNotSent: Boolean,
+        entityName: String
+    ): ValmistumispyyntoDTO {
+        validateRequest(userId, opintooikeusId, uusiValmistumispyyntoDTO, laillistamistodistus, entityName)
+        validateLaillistamistodistusIfExists(laillistamistodistus, entityName)
+        if (requireNotSent) {
+            validateValmistumispyyntoNotSent(opintooikeusId, entityName)
+        }
+        updateLaillistamistiedot(userId, uusiValmistumispyyntoDTO, laillistamistodistus)
+
+        return valmistumispyyntoService.update(opintooikeusId, uusiValmistumispyyntoDTO)
+    }
+
+    private fun validateRequest(
+        userId: String,
+        opintooikeusId: Long,
+        uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
+        laillistamistodistus: MultipartFile?,
+        entityName: String
+    ) {
+        val erikoisalaTyyppi = valmistumispyyntoService.findErikoisalaTyyppiByOpintooikeusId(opintooikeusId)
+        val vanhentuneetSuoritukset = valmistumispyyntoService.findSuoritustenTila(opintooikeusId, erikoisalaTyyppi)
+
+        validateLaillistamispaivaAndTodistus(
+            userId,
+            uusiValmistumispyyntoDTO,
+            laillistamistodistus,
+            entityName
+        )
+        validateVanhentuneetSuoritukset(uusiValmistumispyyntoDTO, vanhentuneetSuoritukset, entityName)
+    }
+
+    private fun validateValmistumispyyntoNotExists(opintooikeusId: Long, entityName: String) {
+        if (valmistumispyyntoService.existsByOpintooikeusId(opintooikeusId)) {
+            throw BadRequestAlertException(
+                "Valmistumispyyntö on jo lähetetty",
+                entityName,
+                "dataillegal.valmistumispyynto-on-jo-lahetetty"
+            )
+        }
+    }
+
+    private fun validateValmistumispyyntoNotSent(opintooikeusId: Long, entityName: String) {
+        if (valmistumispyyntoService.onkoLahetetty(opintooikeusId)) {
+            throw BadRequestAlertException(
+                "Lähetettyä valmistumispyyntöä ei saa muokata.",
+                entityName,
+                "dataillegal.lahetettya-valmistumispyyntoa-ei-saa-muokata"
+            )
+        }
+    }
+
+    private fun validateLaillistamispaivaAndTodistus(
+        userId: String,
+        uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
+        laillistamistodistus: MultipartFile?,
+        entityName: String
+    ) {
+        if ((uusiValmistumispyyntoDTO.laillistamispaiva == null || laillistamistodistus == null) &&
+            !erikoistuvaLaakariService.laillistamispaivaAndTodistusExists(userId)
+        ) {
+            throw BadRequestAlertException(
+                "Laillistamispaiva ja todistus vaaditaan",
+                entityName,
+                "dataillegal.laillistamispaiva-ja-todistus-vaaditaan"
+            )
+        }
+    }
+
+    private fun validateVanhentuneetSuoritukset(
+        uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
+        vanhentuneetSuoritukset: VanhentuneetSuorituksetDTO,
+        entityName: String
+    ) {
+        if (uusiValmistumispyyntoDTO.selvitysVanhentuneistaSuorituksista == null &&
+            (vanhentuneetSuoritukset.vanhojaTyoskentelyjaksojaOrSuorituksiaExists == true ||
+                vanhentuneetSuoritukset.kuulusteluVanhentunut == true)
+        ) {
+            throw BadRequestAlertException(
+                "Selvitys vanhentuneista suorituksista vaaditaan",
+                entityName,
+                "dataillegal.selvitys-vanhentuneista-suorituksista-vaaditaan"
+            )
+        }
+    }
+
+    private fun validateLaillistamistodistusIfExists(
+        laillistamistodistus: MultipartFile?,
+        entityName: String
+    ) {
+        if (laillistamistodistus != null && !fileValidationService.validate(listOf(laillistamistodistus))) {
+            throw BadRequestAlertException(
+                "Tiedosto ei ole kelvollinen.",
+                entityName,
+                "dataillegal.tiedosto-ei-ole-kelvollinen"
+            )
+        }
+    }
+
+    private fun updateLaillistamistiedot(
+        userId: String,
+        uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
+        laillistamistodistus: MultipartFile?
+    ) {
+        erikoistuvaLaakariService.updateLaillistamispaiva(
+            userId,
+            uusiValmistumispyyntoDTO.laillistamispaiva,
+            laillistamistodistus?.bytes,
+            laillistamistodistus?.originalFilename,
+            laillistamistodistus?.contentType
+        )
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariValmistumispyyntoResource.kt
@@ -1,71 +1,48 @@
 package fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari
 
 import fi.elsapalvelu.elsa.required
-
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.UusiValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoSuoritustenTilaDTO
+import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
 import fi.elsapalvelu.elsa.service.kayttaja.UserService
-import org.springframework.web.bind.annotation.RequestParam
-import java.security.Principal
-import fi.elsapalvelu.elsa.service.*
-import fi.elsapalvelu.elsa.service.koejakso.*
-import fi.elsapalvelu.elsa.service.tyoskentely.*
-import fi.elsapalvelu.elsa.service.arviointi.*
-import fi.elsapalvelu.elsa.service.suoritteet.*
-import fi.elsapalvelu.elsa.service.koulutus.*
-import fi.elsapalvelu.elsa.service.seuranta.*
-import fi.elsapalvelu.elsa.service.valmistuminen.*
-import fi.elsapalvelu.elsa.service.kayttaja.*
-import fi.elsapalvelu.elsa.service.perustiedot.*
-import fi.elsapalvelu.elsa.service.dto.*
-import fi.elsapalvelu.elsa.service.dto.koejakso.*
-import fi.elsapalvelu.elsa.service.dto.tyoskentely.*
-import fi.elsapalvelu.elsa.service.dto.arviointi.*
-import fi.elsapalvelu.elsa.service.dto.suoritteet.*
-import fi.elsapalvelu.elsa.service.dto.koulutus.*
-import fi.elsapalvelu.elsa.service.dto.seuranta.*
-import fi.elsapalvelu.elsa.service.dto.valmistuminen.*
-import fi.elsapalvelu.elsa.service.dto.kayttaja.*
-import fi.elsapalvelu.elsa.service.dto.perustiedot.*
-import fi.elsapalvelu.elsa.web.rest.VALMISTUMISPYYNTO_ENTITY_NAME
-import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
+import fi.elsapalvelu.elsa.service.valmistuminen.ValmistumispyyntoApplicationService
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import java.net.URI
-import jakarta.validation.Valid
-
+import java.security.Principal
 
 @RestController
 @RequestMapping("/api/erikoistuva-laakari")
 class ErikoistuvaLaakariValmistumispyyntoResource(
     private val userService: UserService,
     private val opintooikeusService: OpintooikeusService,
-    private val erikoistuvaLaakariService: ErikoistuvaLaakariService,
-    private val valmistumispyyntoService: ValmistumispyyntoService,
-    private val fileValidationService: FileValidationService
+    private val valmistumispyyntoApplicationService: ValmistumispyyntoApplicationService
 ) {
 
     @GetMapping("/valmistumispyynto")
     fun getValmistumispyynto(principal: Principal?): ResponseEntity<ValmistumispyyntoDTO> {
-        val user = userService.getAuthenticatedUser(principal)
-        val opintooikeusId = opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id.required())
+        val context = resolveContext(principal)
 
-        return ResponseEntity.ok(valmistumispyyntoService.findOneByOpintooikeusId(opintooikeusId))
+        return ResponseEntity.ok(valmistumispyyntoApplicationService.findOne(context.opintooikeusId))
     }
 
     @GetMapping("/valmistumispyynto-suoritusten-tila")
-    fun getValmistumispyyntoSuoritustenTila(principal: Principal?): ResponseEntity<ValmistumispyyntoSuoritustenTilaDTO> {
-        val user = userService.getAuthenticatedUser(principal)
-        val opintooikeusId = opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id.required())
-        val erikoisalaTyyppi = valmistumispyyntoService.findErikoisalaTyyppiByOpintooikeusId(opintooikeusId)
-        val vanhatSuorituksetDTO =
-            valmistumispyyntoService.findSuoritustenTila(opintooikeusId, erikoisalaTyyppi)
-        val form = ValmistumispyyntoSuoritustenTilaDTO(
-            erikoisalaTyyppi = erikoisalaTyyppi,
-            vanhojaTyoskentelyjaksojaOrSuorituksiaExists = vanhatSuorituksetDTO.vanhojaTyoskentelyjaksojaOrSuorituksiaExists,
-            kuulusteluVanhentunut = vanhatSuorituksetDTO.kuulusteluVanhentunut
-        )
+    fun getValmistumispyyntoSuoritustenTila(
+        principal: Principal?
+    ): ResponseEntity<ValmistumispyyntoSuoritustenTilaDTO> {
+        val context = resolveContext(principal)
 
-        return ResponseEntity.ok(form)
+        return ResponseEntity.ok(
+            valmistumispyyntoApplicationService.findSuoritustenTila(context.opintooikeusId)
+        )
     }
 
     @PostMapping("/valmistumispyynto")
@@ -74,30 +51,15 @@ class ErikoistuvaLaakariValmistumispyyntoResource(
         @RequestParam(required = false) laillistamistodistus: MultipartFile?,
         principal: Principal?
     ): ResponseEntity<ValmistumispyyntoDTO> {
-        val user = userService.getAuthenticatedUser(principal)
-        val opintooikeusId = opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id.required())
-        val erikoisalaTyyppi = valmistumispyyntoService.findErikoisalaTyyppiByOpintooikeusId(opintooikeusId)
-        val vanhatSuorituksetDTO =
-            valmistumispyyntoService.findSuoritustenTila(opintooikeusId, erikoisalaTyyppi)
-
-        validateLaillistamispaivaAndTodistus(user, uusiValmistumispyyntoDTO, laillistamistodistus)
-        validateVanhentuneetSuoritukset(uusiValmistumispyyntoDTO, vanhatSuorituksetDTO)
-        validateValmistumispyyntoNotExists(opintooikeusId)
-        validateLaillistamistodistusIfExists(laillistamistodistus)
-
-        erikoistuvaLaakariService.updateLaillistamispaiva(
-            user.id.required(),
-            uusiValmistumispyyntoDTO.laillistamispaiva,
-            laillistamistodistus?.bytes,
-            laillistamistodistus?.originalFilename,
-            laillistamistodistus?.contentType
+        val context = resolveContext(principal)
+        val result = valmistumispyyntoApplicationService.create(
+            context.userId,
+            context.opintooikeusId,
+            uusiValmistumispyyntoDTO,
+            laillistamistodistus
         )
 
-        valmistumispyyntoService.create(opintooikeusId, uusiValmistumispyyntoDTO).let { result ->
-            return ResponseEntity
-                .created(URI("/api/valmistumispyynto"))
-                .body(result)
-        }
+        return ResponseEntity.created(URI("/api/valmistumispyynto")).body(result)
     }
 
     @PutMapping("/valmistumispyynto")
@@ -106,89 +68,27 @@ class ErikoistuvaLaakariValmistumispyyntoResource(
         @RequestParam(required = false) laillistamistodistus: MultipartFile?,
         principal: Principal?
     ): ResponseEntity<ValmistumispyyntoDTO> {
-        val user = userService.getAuthenticatedUser(principal)
-        val opintooikeusId = opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(user.id.required())
-        val erikoisalaTyyppi = valmistumispyyntoService.findErikoisalaTyyppiByOpintooikeusId(opintooikeusId)
-        val vanhatSuorituksetDTO =
-            valmistumispyyntoService.findSuoritustenTila(opintooikeusId, erikoisalaTyyppi)
-
-        validateLaillistamispaivaAndTodistus(user, uusiValmistumispyyntoDTO, laillistamistodistus)
-        validateVanhentuneetSuoritukset(uusiValmistumispyyntoDTO, vanhatSuorituksetDTO)
-        validateLaillistamistodistusIfExists(laillistamistodistus)
-
-        if (valmistumispyyntoService.onkoLahetetty(opintooikeusId)) {
-            throw BadRequestAlertException(
-                "Lähetettyä valmistumispyyntöä ei saa muokata.",
-                VALMISTUMISPYYNTO_ENTITY_NAME,
-                "dataillegal.lahetettya-valmistumispyyntoa-ei-saa-muokata")
-        }
-
-        erikoistuvaLaakariService.updateLaillistamispaiva(
-            user.id.required(),
-            uusiValmistumispyyntoDTO.laillistamispaiva,
-            laillistamistodistus?.bytes,
-            laillistamistodistus?.originalFilename,
-            laillistamistodistus?.contentType
+        val context = resolveContext(principal)
+        val result = valmistumispyyntoApplicationService.updateWhenNotSent(
+            context.userId,
+            context.opintooikeusId,
+            uusiValmistumispyyntoDTO,
+            laillistamistodistus
         )
 
-        valmistumispyyntoService.update(opintooikeusId, uusiValmistumispyyntoDTO).let { result ->
-            return ResponseEntity.ok(result)
-        }
+        return ResponseEntity.ok(result)
     }
 
-    private fun validateValmistumispyyntoNotExists(opintooikeusId: Long) {
-        if (valmistumispyyntoService.existsByOpintooikeusId(opintooikeusId)) {
-            throw BadRequestAlertException(
-                "Valmistumispyyntö on jo lähetetty",
-                VALMISTUMISPYYNTO_ENTITY_NAME,
-                "dataillegal.valmistumispyynto-on-jo-lahetetty"
-            )
-        }
+    private fun resolveContext(principal: Principal?): ValmistumispyyntoContext {
+        val userId = userService.getAuthenticatedUser(principal).id.required()
+        val opintooikeusId =
+            opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(userId)
+
+        return ValmistumispyyntoContext(userId, opintooikeusId)
     }
 
-    private fun validateLaillistamispaivaAndTodistus(
-        user: UserDTO,
-        uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
-        laillistamistodistus: MultipartFile?
-    ) {
-        if ((uusiValmistumispyyntoDTO.laillistamispaiva == null || laillistamistodistus == null) &&
-            !erikoistuvaLaakariService.laillistamispaivaAndTodistusExists(
-                user.id.required()
-            )
-        ) {
-            throw BadRequestAlertException(
-                "Laillistamispaiva ja todistus vaaditaan",
-                VALMISTUMISPYYNTO_ENTITY_NAME,
-                "dataillegal.laillistamispaiva-ja-todistus-vaaditaan"
-            )
-        }
-    }
-
-    private fun validateVanhentuneetSuoritukset(
-        uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
-        vanhatSuorituksetDTO: VanhentuneetSuorituksetDTO
-    ) {
-        if (uusiValmistumispyyntoDTO.selvitysVanhentuneistaSuorituksista == null &&
-            (vanhatSuorituksetDTO.vanhojaTyoskentelyjaksojaOrSuorituksiaExists == true
-                || vanhatSuorituksetDTO.kuulusteluVanhentunut == true)
-        ) {
-            throw BadRequestAlertException(
-                "Selvitys vanhentuneista suorituksista vaaditaan",
-                VALMISTUMISPYYNTO_ENTITY_NAME,
-                "dataillegal.selvitys-vanhentuneista-suorituksista-vaaditaan"
-            )
-        }
-    }
-
-    private fun validateLaillistamistodistusIfExists(laillistamistodistus: MultipartFile?) {
-        laillistamistodistus?.let {
-            if (!fileValidationService.validate(listOf(it))) {
-                throw BadRequestAlertException(
-                    "Tiedosto ei ole kelvollinen.",
-                    VALMISTUMISPYYNTO_ENTITY_NAME,
-                    "dataillegal.tiedosto-ei-ole-kelvollinen"
-                )
-            }
-        }
-    }
+    private data class ValmistumispyyntoContext(
+        val userId: String,
+        val opintooikeusId: Long
+    )
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaValmistumispyyntoResource.kt
@@ -1,37 +1,24 @@
 package fi.elsapalvelu.elsa.web.rest.yekkoulutettava
 
-import fi.elsapalvelu.elsa.required
-
-import fi.elsapalvelu.elsa.service.kayttaja.UserService
-import org.springframework.web.bind.annotation.RequestParam
-import java.security.Principal
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
-import fi.elsapalvelu.elsa.service.*
-import fi.elsapalvelu.elsa.service.koejakso.*
-import fi.elsapalvelu.elsa.service.tyoskentely.*
-import fi.elsapalvelu.elsa.service.arviointi.*
-import fi.elsapalvelu.elsa.service.suoritteet.*
-import fi.elsapalvelu.elsa.service.koulutus.*
-import fi.elsapalvelu.elsa.service.seuranta.*
-import fi.elsapalvelu.elsa.service.valmistuminen.*
-import fi.elsapalvelu.elsa.service.kayttaja.*
-import fi.elsapalvelu.elsa.service.perustiedot.*
-import fi.elsapalvelu.elsa.service.dto.*
-import fi.elsapalvelu.elsa.service.dto.koejakso.*
-import fi.elsapalvelu.elsa.service.dto.tyoskentely.*
-import fi.elsapalvelu.elsa.service.dto.arviointi.*
-import fi.elsapalvelu.elsa.service.dto.suoritteet.*
-import fi.elsapalvelu.elsa.service.dto.koulutus.*
-import fi.elsapalvelu.elsa.service.dto.seuranta.*
-import fi.elsapalvelu.elsa.service.dto.valmistuminen.*
-import fi.elsapalvelu.elsa.service.dto.kayttaja.*
-import fi.elsapalvelu.elsa.service.dto.perustiedot.*
-import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.UusiValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoSuoritustenTilaDTO
+import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import fi.elsapalvelu.elsa.service.valmistuminen.ValmistumispyyntoApplicationService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import java.net.URI
+import java.security.Principal
 
 private const val VALMISTUMISPYYNTO_ENTITY_NAME = "valmistumispyyntö"
 
@@ -40,73 +27,43 @@ private const val VALMISTUMISPYYNTO_ENTITY_NAME = "valmistumispyyntö"
 class YekKoulutettavaValmistumispyyntoResource(
     private val userService: UserService,
     private val opintooikeusService: OpintooikeusService,
-    private val valmistumispyyntoService: ValmistumispyyntoService,
-    private val erikoistuvaLaakariService: ErikoistuvaLaakariService,
-    private val fileValidationService: FileValidationService
+    private val valmistumispyyntoApplicationService: ValmistumispyyntoApplicationService
 ) {
 
     @GetMapping("/valmistumispyynto")
     fun getValmistumispyynto(principal: Principal?): ResponseEntity<ValmistumispyyntoDTO> {
-        val user = userService.getAuthenticatedUser(principal)
-        val opintooikeusId =
-            opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(
-                user.id.required(), YEK_ERIKOISALA_ID
-            )
-        return ResponseEntity.ok(valmistumispyyntoService.findOneByOpintooikeusId(opintooikeusId))
+        val context = resolveContext(principal)
+
+        return ResponseEntity.ok(valmistumispyyntoApplicationService.findOne(context.opintooikeusId))
     }
 
     @GetMapping("/valmistumispyynto-suoritusten-tila")
-    fun getValmistumispyyntoSuoritustenTila(principal: Principal?): ResponseEntity<ValmistumispyyntoSuoritustenTilaDTO> {
-        val user = userService.getAuthenticatedUser(principal)
-        val opintooikeusId =
-            opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(
-                user.id.required(), YEK_ERIKOISALA_ID
-            )
-        val erikoisalaTyyppi = valmistumispyyntoService.findErikoisalaTyyppiByOpintooikeusId(opintooikeusId)
-        val vanhatSuorituksetDTO =
-            valmistumispyyntoService.findSuoritustenTila(opintooikeusId, erikoisalaTyyppi)
-        val form = ValmistumispyyntoSuoritustenTilaDTO(
-          erikoisalaTyyppi = erikoisalaTyyppi,
-          vanhojaTyoskentelyjaksojaOrSuorituksiaExists = vanhatSuorituksetDTO.vanhojaTyoskentelyjaksojaOrSuorituksiaExists,
-          kuulusteluVanhentunut = vanhatSuorituksetDTO.kuulusteluVanhentunut
+    fun getValmistumispyyntoSuoritustenTila(
+        principal: Principal?
+    ): ResponseEntity<ValmistumispyyntoSuoritustenTilaDTO> {
+        val context = resolveContext(principal)
+
+        return ResponseEntity.ok(
+            valmistumispyyntoApplicationService.findSuoritustenTila(context.opintooikeusId)
         )
-
-        return ResponseEntity.ok(form)
     }
-
 
     @PostMapping("/valmistumispyynto")
     fun createValmistumispyynto(
-      @Valid uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
-      @RequestParam(required = false) laillistamistodistus: MultipartFile?,
-      principal: Principal?
+        @Valid uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
+        @RequestParam(required = false) laillistamistodistus: MultipartFile?,
+        principal: Principal?
     ): ResponseEntity<ValmistumispyyntoDTO> {
-        val user = userService.getAuthenticatedUser(principal)
-        val opintooikeusId =
-            opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(
-                user.id.required(), YEK_ERIKOISALA_ID
-            )
-        val erikoisalaTyyppi = valmistumispyyntoService.findErikoisalaTyyppiByOpintooikeusId(opintooikeusId)
-        val vanhatSuorituksetDTO =
-            valmistumispyyntoService.findSuoritustenTila(opintooikeusId, erikoisalaTyyppi)
-
-        validateLaillistamispaivaAndTodistus(user, uusiValmistumispyyntoDTO, laillistamistodistus)
-        validateVanhentuneetSuoritukset(uusiValmistumispyyntoDTO, vanhatSuorituksetDTO)
-        validateValmistumispyyntoNotExists(opintooikeusId)
-        validateLaillistamistodistusIfExists(laillistamistodistus)
-
-        erikoistuvaLaakariService.updateLaillistamispaiva(
-            user.id.required(),
-            uusiValmistumispyyntoDTO.laillistamispaiva,
-            laillistamistodistus?.bytes,
-            laillistamistodistus?.originalFilename,
-            laillistamistodistus?.contentType
+        val context = resolveContext(principal)
+        val result = valmistumispyyntoApplicationService.create(
+            context.userId,
+            context.opintooikeusId,
+            uusiValmistumispyyntoDTO,
+            laillistamistodistus,
+            VALMISTUMISPYYNTO_ENTITY_NAME
         )
 
-        valmistumispyyntoService.create(opintooikeusId, uusiValmistumispyyntoDTO).let { result ->
-            return ResponseEntity.created(URI("/api/valmistumispyynto"))
-                .body(result)
-        }
+        return ResponseEntity.created(URI("/api/valmistumispyynto")).body(result)
     }
 
     @PutMapping("/valmistumispyynto")
@@ -115,86 +72,31 @@ class YekKoulutettavaValmistumispyyntoResource(
         @RequestParam(required = false) laillistamistodistus: MultipartFile?,
         principal: Principal?
     ): ResponseEntity<ValmistumispyyntoDTO> {
-        val user = userService.getAuthenticatedUser(principal)
-        val opintooikeusId =
-            opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(
-                user.id.required(), YEK_ERIKOISALA_ID
-            )
-        val erikoisalaTyyppi = valmistumispyyntoService.findErikoisalaTyyppiByOpintooikeusId(opintooikeusId)
-        val vanhatSuorituksetDTO =
-            valmistumispyyntoService.findSuoritustenTila(opintooikeusId, erikoisalaTyyppi)
-
-        validateLaillistamispaivaAndTodistus(user, uusiValmistumispyyntoDTO, laillistamistodistus)
-        validateVanhentuneetSuoritukset(uusiValmistumispyyntoDTO, vanhatSuorituksetDTO)
-        validateLaillistamistodistusIfExists(laillistamistodistus)
-
-        erikoistuvaLaakariService.updateLaillistamispaiva(
-            user.id.required(),
-            uusiValmistumispyyntoDTO.laillistamispaiva,
-            laillistamistodistus?.bytes,
-            laillistamistodistus?.originalFilename,
-            laillistamistodistus?.contentType
+        val context = resolveContext(principal)
+        val result = valmistumispyyntoApplicationService.update(
+            context.userId,
+            context.opintooikeusId,
+            uusiValmistumispyyntoDTO,
+            laillistamistodistus,
+            VALMISTUMISPYYNTO_ENTITY_NAME
         )
 
-        valmistumispyyntoService.update(opintooikeusId, uusiValmistumispyyntoDTO).let { result ->
-            return ResponseEntity.ok(result)
-        }
+        return ResponseEntity.ok(result)
     }
 
-    private fun validateValmistumispyyntoNotExists(opintooikeusId: Long) {
-        if (valmistumispyyntoService.existsByOpintooikeusId(opintooikeusId)) {
-            throw BadRequestAlertException(
-              "Valmistumispyyntö on jo lähetetty",
-              VALMISTUMISPYYNTO_ENTITY_NAME,
-              "dataillegal.valmistumispyynto-on-jo-lahetetty"
+    private fun resolveContext(principal: Principal?): ValmistumispyyntoContext {
+        val userId = userService.getAuthenticatedUser(principal).id.required()
+        val opintooikeusId =
+            opintooikeusService.findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(
+                userId,
+                YEK_ERIKOISALA_ID
             )
-        }
+
+        return ValmistumispyyntoContext(userId, opintooikeusId)
     }
 
-    private fun validateLaillistamispaivaAndTodistus(
-        user: UserDTO,
-        uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
-        laillistamistodistus: MultipartFile?
-    ) {
-        if ((uusiValmistumispyyntoDTO.laillistamispaiva == null || laillistamistodistus == null) &&
-            !erikoistuvaLaakariService.laillistamispaivaAndTodistusExists(
-                user.id.required()
-            )
-        ) {
-            throw BadRequestAlertException(
-              "Laillistamispaiva ja todistus vaaditaan",
-              VALMISTUMISPYYNTO_ENTITY_NAME,
-              "dataillegal.laillistamispaiva-ja-todistus-vaaditaan"
-            )
-        }
-    }
-
-    private fun validateVanhentuneetSuoritukset(
-      uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO,
-      vanhatSuorituksetDTO: VanhentuneetSuorituksetDTO
-    ) {
-        if (uusiValmistumispyyntoDTO.selvitysVanhentuneistaSuorituksista == null &&
-            (vanhatSuorituksetDTO.vanhojaTyoskentelyjaksojaOrSuorituksiaExists == true
-                || vanhatSuorituksetDTO.kuulusteluVanhentunut == true)
-        ) {
-            throw BadRequestAlertException(
-              "Selvitys vanhentuneista suorituksista vaaditaan",
-              VALMISTUMISPYYNTO_ENTITY_NAME,
-              "dataillegal.selvitys-vanhentuneista-suorituksista-vaaditaan"
-            )
-        }
-    }
-
-    private fun validateLaillistamistodistusIfExists(laillistamistodistus: MultipartFile?) {
-        laillistamistodistus?.let {
-            if (!fileValidationService.validate(listOf(it))) {
-                throw BadRequestAlertException(
-                  "Tiedosto ei ole kelvollinen.",
-                  VALMISTUMISPYYNTO_ENTITY_NAME,
-                  "dataillegal.tiedosto-ei-ole-kelvollinen"
-                )
-            }
-        }
-    }
-
+    private data class ValmistumispyyntoContext(
+        val userId: String,
+        val opintooikeusId: Long
+    )
 }

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/ValmistumispyyntoApplicationServiceTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/ValmistumispyyntoApplicationServiceTest.kt
@@ -1,0 +1,235 @@
+package fi.elsapalvelu.elsa.service.valmistuminen
+
+import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
+import fi.elsapalvelu.elsa.service.dto.suoritteet.VanhentuneetSuorituksetDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.UusiValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.kayttaja.ErikoistuvaLaakariService
+import fi.elsapalvelu.elsa.service.kayttaja.FileValidationService
+import fi.elsapalvelu.elsa.web.rest.VALMISTUMISPYYNTO_ENTITY_NAME
+import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.mock.web.MockMultipartFile
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+class ValmistumispyyntoApplicationServiceTest {
+
+    @Mock
+    private lateinit var valmistumispyyntoService: ValmistumispyyntoService
+
+    @Mock
+    private lateinit var erikoistuvaLaakariService: ErikoistuvaLaakariService
+
+    @Mock
+    private lateinit var fileValidationService: FileValidationService
+
+    private lateinit var applicationService: ValmistumispyyntoApplicationService
+
+    @BeforeEach
+    fun setup() {
+        applicationService = ValmistumispyyntoApplicationService(
+            valmistumispyyntoService,
+            erikoistuvaLaakariService,
+            fileValidationService
+        )
+        whenever(valmistumispyyntoService.findErikoisalaTyyppiByOpintooikeusId(OPINTOOIKEUS_ID))
+            .thenReturn(ErikoisalaTyyppi.LAAKETIEDE)
+        whenever(
+            valmistumispyyntoService.findSuoritustenTila(
+                OPINTOOIKEUS_ID,
+                ErikoisalaTyyppi.LAAKETIEDE
+            )
+        ).thenReturn(VanhentuneetSuorituksetDTO(false, false))
+    }
+
+    @Test
+    fun findSuoritustenTilaShouldComposeSpecialtyAndExpirationState() {
+        whenever(
+            valmistumispyyntoService.findSuoritustenTila(
+                OPINTOOIKEUS_ID,
+                ErikoisalaTyyppi.LAAKETIEDE
+            )
+        ).thenReturn(VanhentuneetSuorituksetDTO(true, false))
+
+        val result = applicationService.findSuoritustenTila(OPINTOOIKEUS_ID)
+
+        assertThat(result.erikoisalaTyyppi).isEqualTo(ErikoisalaTyyppi.LAAKETIEDE)
+        assertThat(result.vanhojaTyoskentelyjaksojaOrSuorituksiaExists).isTrue
+        assertThat(result.kuulusteluVanhentunut).isFalse
+    }
+
+    @Test
+    fun createShouldUpdateLicensingDataAndCreateRequestAfterValidation() {
+        val request = UusiValmistumispyyntoDTO()
+        val expected = ValmistumispyyntoDTO(id = 1L)
+        stubLicensingDataExists()
+        whenever(valmistumispyyntoService.create(OPINTOOIKEUS_ID, request)).thenReturn(expected)
+
+        val result = applicationService.create(USER_ID, OPINTOOIKEUS_ID, request, null)
+
+        assertThat(result).isSameAs(expected)
+        verify(erikoistuvaLaakariService).updateLaillistamispaiva(USER_ID, null, null, null, null)
+        verify(valmistumispyyntoService).create(OPINTOOIKEUS_ID, request)
+    }
+
+    @Test
+    fun createShouldRequireLicensingDateAndCertificateWhenNotStored() {
+        whenever(erikoistuvaLaakariService.laillistamispaivaAndTodistusExists(USER_ID))
+            .thenReturn(false)
+
+        assertErrorKey("dataillegal.laillistamispaiva-ja-todistus-vaaditaan") {
+            applicationService.create(USER_ID, OPINTOOIKEUS_ID, UusiValmistumispyyntoDTO(), null)
+        }
+
+        verify(valmistumispyyntoService, never()).create(any(), any())
+        verifyLicensingDataWasNotUpdated()
+    }
+
+    @Test
+    fun createShouldRequireExplanationForExpiredStudies() {
+        stubLicensingDataExists()
+        whenever(
+            valmistumispyyntoService.findSuoritustenTila(
+                OPINTOOIKEUS_ID,
+                ErikoisalaTyyppi.LAAKETIEDE
+            )
+        ).thenReturn(VanhentuneetSuorituksetDTO(true, false))
+
+        assertErrorKey("dataillegal.selvitys-vanhentuneista-suorituksista-vaaditaan") {
+            applicationService.create(USER_ID, OPINTOOIKEUS_ID, UusiValmistumispyyntoDTO(), null)
+        }
+
+        verify(valmistumispyyntoService, never()).create(any(), any())
+        verifyLicensingDataWasNotUpdated()
+    }
+
+    @Test
+    fun createShouldRejectExistingRequest() {
+        stubLicensingDataExists()
+        whenever(valmistumispyyntoService.existsByOpintooikeusId(OPINTOOIKEUS_ID)).thenReturn(true)
+
+        assertErrorKey("dataillegal.valmistumispyynto-on-jo-lahetetty") {
+            applicationService.create(USER_ID, OPINTOOIKEUS_ID, UusiValmistumispyyntoDTO(), null)
+        }
+
+        verify(valmistumispyyntoService, never()).create(any(), any())
+        verifyLicensingDataWasNotUpdated()
+    }
+
+    @Test
+    fun createShouldRejectInvalidCertificate() {
+        val certificate = MockMultipartFile(
+            "laillistamistodistus",
+            "licence.exe",
+            "application/x-msdownload",
+            byteArrayOf(1)
+        )
+        val request = UusiValmistumispyyntoDTO(laillistamispaiva = LocalDate.of(2024, 1, 1))
+        whenever(fileValidationService.validate(listOf(certificate))).thenReturn(false)
+
+        assertErrorKey("dataillegal.tiedosto-ei-ole-kelvollinen") {
+            applicationService.create(USER_ID, OPINTOOIKEUS_ID, request, certificate)
+        }
+
+        verify(valmistumispyyntoService, never()).create(any(), any())
+        verifyLicensingDataWasNotUpdated()
+    }
+
+    @Test
+    fun updateWhenNotSentShouldRejectRequestThatHasAlreadyBeenSent() {
+        stubLicensingDataExists()
+        whenever(valmistumispyyntoService.onkoLahetetty(OPINTOOIKEUS_ID)).thenReturn(true)
+
+        assertErrorKey("dataillegal.lahetettya-valmistumispyyntoa-ei-saa-muokata") {
+            applicationService.updateWhenNotSent(
+                USER_ID,
+                OPINTOOIKEUS_ID,
+                UusiValmistumispyyntoDTO(),
+                null
+            )
+        }
+
+        verify(valmistumispyyntoService, never()).update(any(), any())
+        verifyLicensingDataWasNotUpdated()
+    }
+
+    @Test
+    fun updateShouldPreserveUpdatesWithoutApplyingSentRequestPolicy() {
+        val request = UusiValmistumispyyntoDTO()
+        val expected = ValmistumispyyntoDTO(id = 1L)
+        stubLicensingDataExists()
+        whenever(valmistumispyyntoService.update(OPINTOOIKEUS_ID, request)).thenReturn(expected)
+
+        val result = applicationService.update(USER_ID, OPINTOOIKEUS_ID, request, null)
+
+        assertThat(result).isSameAs(expected)
+        verify(valmistumispyyntoService, never()).onkoLahetetty(any())
+        verify(valmistumispyyntoService).update(OPINTOOIKEUS_ID, request)
+    }
+
+    @Test
+    fun updateShouldValidateAndStoreCertificateBeforeUpdatingRequest() {
+        val certificate = MockMultipartFile(
+            "laillistamistodistus",
+            "licence.pdf",
+            "application/pdf",
+            byteArrayOf(1, 2, 3)
+        )
+        val request = UusiValmistumispyyntoDTO(laillistamispaiva = LocalDate.of(2024, 1, 1))
+        val expected = ValmistumispyyntoDTO(id = 1L)
+        whenever(fileValidationService.validate(listOf(certificate))).thenReturn(true)
+        whenever(valmistumispyyntoService.update(OPINTOOIKEUS_ID, request)).thenReturn(expected)
+
+        val result = applicationService.update(USER_ID, OPINTOOIKEUS_ID, request, certificate)
+
+        assertThat(result).isSameAs(expected)
+        verify(fileValidationService).validate(listOf(certificate))
+        verify(erikoistuvaLaakariService).updateLaillistamispaiva(
+            USER_ID,
+            LocalDate.of(2024, 1, 1),
+            byteArrayOf(1, 2, 3),
+            "licence.pdf",
+            "application/pdf"
+        )
+        verify(valmistumispyyntoService).update(OPINTOOIKEUS_ID, request)
+    }
+
+    private fun assertErrorKey(expectedErrorKey: String, action: () -> Unit) {
+        val exception = assertThrows<BadRequestAlertException>(action)
+
+        assertThat(exception.entityName).isEqualTo(VALMISTUMISPYYNTO_ENTITY_NAME)
+        assertThat(exception.errorKey).isEqualTo(expectedErrorKey)
+    }
+
+    private fun stubLicensingDataExists() {
+        whenever(erikoistuvaLaakariService.laillistamispaivaAndTodistusExists(USER_ID))
+            .thenReturn(true)
+    }
+
+    private fun verifyLicensingDataWasNotUpdated() {
+        verify(erikoistuvaLaakariService, never()).updateLaillistamispaiva(
+            any(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull()
+        )
+    }
+
+    companion object {
+        private const val USER_ID = "user-1"
+        private const val OPINTOOIKEUS_ID = 10L
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/ValmistumispyyntoResourceDelegationTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/ValmistumispyyntoResourceDelegationTest.kt
@@ -1,0 +1,171 @@
+package fi.elsapalvelu.elsa.web.rest
+
+import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
+import fi.elsapalvelu.elsa.service.dto.kayttaja.UserDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.UusiValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.kayttaja.OpintooikeusService
+import fi.elsapalvelu.elsa.service.kayttaja.UserService
+import fi.elsapalvelu.elsa.service.valmistuminen.ValmistumispyyntoApplicationService
+import fi.elsapalvelu.elsa.web.rest.erikoistuvalaakari.ErikoistuvaLaakariValmistumispyyntoResource
+import fi.elsapalvelu.elsa.web.rest.yekkoulutettava.YekKoulutettavaValmistumispyyntoResource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.security.Principal
+
+class ValmistumispyyntoResourceDelegationTest {
+
+    @Test
+    fun specialistResourceShouldResolveActiveSpecialistStudyRight() {
+        val dependencies = dependencies()
+        whenever(
+            dependencies.opintooikeusService
+                .findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(USER_ID)
+        ).thenReturn(OPINTOOIKEUS_ID)
+        val resource = ErikoistuvaLaakariValmistumispyyntoResource(
+            dependencies.userService,
+            dependencies.opintooikeusService,
+            dependencies.applicationService
+        )
+
+        val response = resource.getValmistumispyynto(dependencies.principal)
+
+        assertThat(response.body).isSameAs(dependencies.valmistumispyynto)
+        verify(dependencies.opintooikeusService)
+            .findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(USER_ID)
+        verify(dependencies.applicationService).findOne(OPINTOOIKEUS_ID)
+    }
+
+    @Test
+    fun yekResourceShouldResolveActiveYekStudyRight() {
+        val dependencies = dependencies()
+        whenever(
+            dependencies.opintooikeusService
+                .findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(
+                    USER_ID,
+                    YEK_ERIKOISALA_ID
+                )
+        ).thenReturn(OPINTOOIKEUS_ID)
+        val resource = YekKoulutettavaValmistumispyyntoResource(
+            dependencies.userService,
+            dependencies.opintooikeusService,
+            dependencies.applicationService
+        )
+
+        val response = resource.getValmistumispyynto(dependencies.principal)
+
+        assertThat(response.body).isSameAs(dependencies.valmistumispyynto)
+        verify(dependencies.opintooikeusService)
+            .findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(
+                USER_ID,
+                YEK_ERIKOISALA_ID
+            )
+        verify(dependencies.applicationService).findOne(OPINTOOIKEUS_ID)
+    }
+
+    @Test
+    fun specialistResourceShouldUseSentRequestGuardForUpdates() {
+        val dependencies = dependencies()
+        val request = UusiValmistumispyyntoDTO()
+        whenever(
+            dependencies.opintooikeusService
+                .findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserId(USER_ID)
+        ).thenReturn(OPINTOOIKEUS_ID)
+        whenever(
+            dependencies.applicationService.updateWhenNotSent(
+                USER_ID,
+                OPINTOOIKEUS_ID,
+                request,
+                null
+            )
+        ).thenReturn(dependencies.valmistumispyynto)
+        val resource = ErikoistuvaLaakariValmistumispyyntoResource(
+            dependencies.userService,
+            dependencies.opintooikeusService,
+            dependencies.applicationService
+        )
+
+        val response = resource.updateValmistumispyynto(request, null, dependencies.principal)
+
+        assertThat(response.body).isSameAs(dependencies.valmistumispyynto)
+        verify(dependencies.applicationService).updateWhenNotSent(
+            USER_ID,
+            OPINTOOIKEUS_ID,
+            request,
+            null
+        )
+    }
+
+    @Test
+    fun yekResourceShouldUpdateWithoutApplyingSpecialistSentRequestGuard() {
+        val dependencies = dependencies()
+        val request = UusiValmistumispyyntoDTO()
+        whenever(
+            dependencies.opintooikeusService
+                .findOneIdByKaytossaAndErikoistuvaLaakariKayttajaUserIdAndErikoisalaId(
+                    USER_ID,
+                    YEK_ERIKOISALA_ID
+                )
+        ).thenReturn(OPINTOOIKEUS_ID)
+        whenever(
+            dependencies.applicationService.update(
+                USER_ID,
+                OPINTOOIKEUS_ID,
+                request,
+                null,
+                YEK_VALMISTUMISPYYNTO_ENTITY_NAME
+            )
+        ).thenReturn(dependencies.valmistumispyynto)
+        val resource = YekKoulutettavaValmistumispyyntoResource(
+            dependencies.userService,
+            dependencies.opintooikeusService,
+            dependencies.applicationService
+        )
+
+        val response = resource.updateValmistumispyynto(request, null, dependencies.principal)
+
+        assertThat(response.body).isSameAs(dependencies.valmistumispyynto)
+        verify(dependencies.applicationService).update(
+            USER_ID,
+            OPINTOOIKEUS_ID,
+            request,
+            null,
+            YEK_VALMISTUMISPYYNTO_ENTITY_NAME
+        )
+    }
+
+    private fun dependencies(): Dependencies {
+        val principal = mock<Principal>()
+        val userService = mock<UserService>()
+        val opintooikeusService = mock<OpintooikeusService>()
+        val applicationService = mock<ValmistumispyyntoApplicationService>()
+        val valmistumispyynto = ValmistumispyyntoDTO(id = 1L)
+        whenever(userService.getAuthenticatedUser(principal)).thenReturn(UserDTO(id = USER_ID))
+        whenever(applicationService.findOne(OPINTOOIKEUS_ID)).thenReturn(valmistumispyynto)
+
+        return Dependencies(
+            principal,
+            userService,
+            opintooikeusService,
+            applicationService,
+            valmistumispyynto
+        )
+    }
+
+    private data class Dependencies(
+        val principal: Principal,
+        val userService: UserService,
+        val opintooikeusService: OpintooikeusService,
+        val applicationService: ValmistumispyyntoApplicationService,
+        val valmistumispyynto: ValmistumispyyntoDTO
+    )
+
+    companion object {
+        private const val USER_ID = "user-1"
+        private const val OPINTOOIKEUS_ID = 10L
+        private const val YEK_VALMISTUMISPYYNTO_ENTITY_NAME = "valmistumispyyntö"
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaValmistumispyyntoResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/yekkoulutettava/YekKoulutettavaValmistumispyyntoResourceIT.kt
@@ -1,0 +1,119 @@
+package fi.elsapalvelu.elsa.web.rest.yekkoulutettava
+
+import fi.elsapalvelu.elsa.ElsaBackendApp
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
+import fi.elsapalvelu.elsa.domain.kayttaja.User
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyyntoRepository
+import fi.elsapalvelu.elsa.security.YEK_KOULUTETTAVA
+import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
+import fi.elsapalvelu.elsa.web.rest.helpers.ErikoistuvaLaakariHelper
+import fi.elsapalvelu.elsa.web.rest.helpers.OpintooikeusHelper
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal
+import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication
+import org.springframework.security.test.context.TestSecurityContextHolder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@AutoConfigureMockMvc
+@SpringBootTest(classes = [ElsaBackendApp::class])
+class YekKoulutettavaValmistumispyyntoResourceIT {
+
+    @Autowired
+    private lateinit var em: EntityManager
+
+    @Autowired
+    private lateinit var valmistumispyyntoRepository: ValmistumispyyntoRepository
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    @Transactional
+    fun updateAlreadySentRequestShouldPreserveExistingYekBehavior() {
+        val opintooikeus = initYekKoulutettava()
+        val valmistumispyynto = Valmistumispyynto(
+            opintooikeus = opintooikeus,
+            erikoistujanKuittausaika = LocalDate.now(),
+            selvitysVanhentuneistaSuorituksista = ORIGINAL_EXPLANATION
+        )
+        em.persist(valmistumispyynto)
+        em.flush()
+
+        mockMvc.perform(
+            multipart(VALMISTUMISPYYNTO_ENDPOINT)
+                .with { request -> request.method = "PUT"; request }
+                .param("selvitysVanhentuneistaSuorituksista", UPDATED_EXPLANATION)
+                .with(csrf())
+        ).andExpect(status().isOk)
+
+        em.flush()
+        em.clear()
+        val updated = valmistumispyyntoRepository.findById(valmistumispyynto.id!!).orElseThrow()
+        assertThat(updated.selvitysVanhentuneistaSuorituksista).isEqualTo(UPDATED_EXPLANATION)
+    }
+
+    @Test
+    @Transactional
+    fun validationShouldPreserveExistingYekErrorEntityName() {
+        val opintooikeus = initYekKoulutettava()
+        opintooikeus.erikoistuvaLaakari!!.apply {
+            laillistamispaiva = null
+            laillistamistodistus = null
+            laillistamispaivanLiitetiedostonNimi = null
+            laillistamispaivanLiitetiedostonTyyppi = null
+        }
+        em.flush()
+
+        mockMvc.perform(
+            multipart(VALMISTUMISPYYNTO_ENDPOINT).with(csrf())
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.params").value(YEK_VALMISTUMISPYYNTO_ENTITY_NAME))
+    }
+
+    private fun initYekKoulutettava(): Opintooikeus {
+        val user = KayttajaResourceWithMockUserIT.createEntity()
+        em.persist(user)
+        em.flush()
+        authenticate(user)
+
+        val erikoistuvaLaakari = ErikoistuvaLaakariHelper.createEntity(em, user)
+        em.persist(erikoistuvaLaakari)
+        em.flush()
+
+        return OpintooikeusHelper.addOpintooikeusForYekKoulutettava(em, erikoistuvaLaakari)
+            .also {
+                OpintooikeusHelper.setOpintooikeusKaytossa(erikoistuvaLaakari, it)
+                em.flush()
+            }
+    }
+
+    private fun authenticate(user: User) {
+        val authentication = Saml2Authentication(
+            DefaultSaml2AuthenticatedPrincipal(user.id, emptyMap<String, List<Any>>()),
+            "test",
+            listOf(SimpleGrantedAuthority(YEK_KOULUTETTAVA))
+        )
+        TestSecurityContextHolder.getContext().authentication = authentication
+    }
+
+    companion object {
+        private const val VALMISTUMISPYYNTO_ENDPOINT = "/api/yek-koulutettava/valmistumispyynto"
+        private const val ORIGINAL_EXPLANATION = "original explanation"
+        private const val UPDATED_EXPLANATION = "updated explanation"
+        private const val YEK_VALMISTUMISPYYNTO_ENTITY_NAME = "valmistumispyyntö"
+    }
+}


### PR DESCRIPTION
This pull request introduces a new application service layer for handling "valmistumispyyntö" (graduation request) logic, refactors the REST resource to use this new service, and adds supporting end-to-end (E2E) test utilities and tasks. The main goals are to centralize validation and business logic, improve code maintainability, and enhance testability.

Key changes:

### Backend refactoring and new application service

* Introduced `ValmistumispyyntoApplicationService` as a new service layer to encapsulate all business logic and validation for "valmistumispyyntö" creation, update, and retrieval, consolidating code that was previously spread across the REST resource and other services (`src/main/kotlin/fi/elsapalvelu/elsa/service/valmistuminen/ValmistumispyyntoApplicationService.kt`).
* Refactored `ErikoistuvaLaakariValmistumispyyntoResource` to delegate all "valmistumispyyntö" operations to the new application service, simplifying controller methods and removing duplicated validation logic (`src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariValmistumispyyntoResource.kt`). [[1]](diffhunk://#diff-70f48b0aecd5417ef424992e7eeca655727fae473f2767701d5a1cf634332775L4-R45) [[2]](diffhunk://#diff-70f48b0aecd5417ef424992e7eeca655727fae473f2767701d5a1cf634332775L77-R62)

### End-to-end testing improvements

* Added new Cypress E2E test cases for the YEK graduation request flow, including tests for submitting and resubmitting requests after correction proposals (`e2e/cypress/e2e/valmistumispyynto-yek/valmistumispyynto-yek.cy.ts`).
* Added a new database task (`db:seedReturnedYekValmistumispyynto`) and supporting implementation to seed a returned "valmistumispyyntö" for E2E tests (`e2e/cypress/plugins/db-tasks/valmistumispyynto.ts`).
* Registered the new database task in the Cypress plugin system (`e2e/cypress/plugins/db-tasks/index.ts`). [[1]](diffhunk://#diff-821ce6654fd1c6e6375782d0222067e5fd26609d6f03311e70fc992363e9259bR9) [[2]](diffhunk://#diff-821ce6654fd1c6e6375782d0222067e5fd26609d6f03311e70fc992363e9259bL20-L23)

These changes together improve the structure, maintainability, and test coverage of the "valmistumispyyntö" feature.