### PR TITLE
chore: update Gradle wrapper to version 9.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,7 +202,7 @@ dependencies {
 
 
 wrapper {
-    gradleVersion = "9.6.1"
+    gradleVersion = "9.7.0"
 }
 
 detekt {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request updates the Gradle wrapper to use a newer version. The only change is an upgrade of the Gradle distribution from version 9.6.1 to 9.7.0 in the `gradle-wrapper.properties` file.
