### PR TITLE
enable deprecation checks in detekt configuration and remove unnecessary @Suppress annotation

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -56,3 +56,7 @@ exceptions:
 performance:
   SpreadOperator:
     active: false
+potential-bugs:
+  Deprecation:
+    active: true
+    excludes: ['**/build/generated/**']

--- a/src/main/kotlin/fi/elsapalvelu/elsa/security/SecurityUtils.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/security/SecurityUtils.kt
@@ -23,7 +23,6 @@ fun extractPrincipal(authentication: Authentication?): String? {
         return null
     }
 
-    @Suppress("CAST_NEVER_SUCCEEDS")
     return when (val principal = authentication.principal) {
         is Saml2AuthenticationToken -> principal.name
         is String -> principal

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/SuoritusarviointiQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/arviointi/SuoritusarviointiQueryService.kt
@@ -57,7 +57,6 @@ class SuoritusarviointiQueryService(
             .map(suoritusarviointiMapper::toDto)
     }
 
-    @Suppress("ComplexMethod")
     private fun createSpecification(criteria: SuoritusarviointiCriteria?, spec: Specification<Suoritusarviointi?>? = null): Specification<Suoritusarviointi?> {
         var specification: Specification<Suoritusarviointi?> = spec ?: Specification.unrestricted()
         if (criteria != null) {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/UserDTO.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/dto/kayttaja/UserDTO.kt
@@ -8,7 +8,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
-@Suppress("LongParameterList")
 open class UserDTO(
     var id: String? = null,
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/UserServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/UserServiceImpl.kt
@@ -324,7 +324,7 @@ class UserServiceImpl(
     ) {
         // Kutsutun käyttäjä etu- ja sukunimi tulee olla tarpeeksi lähellä
         // kutsussa syötettyjä tietoja
-        val distance = LevenshteinDistance()
+        val distance = LevenshteinDistance.getDefaultInstance()
         val firstNameDistFirst = distance.apply(tokenUser.firstName, firstName)
         val firstNameDistLast = distance.apply(tokenUser.firstName, lastName)
         val lastNameDistFirst = distance.apply(tokenUser.lastName, firstName)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoServiceImpl.kt
@@ -748,7 +748,6 @@ class ValmistumispyyntoServiceImpl(
         return null
     }
 
-    @Suppress("ComplexCondition")
     override fun getValmistumispyynnonTyoskentelyjaksoAsiakirja(
         userId: String,
         valmistumispyyntoId: Long,

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/seuranta/PaivakirjamerkintaQueryService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/seuranta/PaivakirjamerkintaQueryService.kt
@@ -46,7 +46,6 @@ class PaivakirjamerkintaQueryService(
             .map(paivakirjamerkintaMapper::toDto)
     }
 
-    @Suppress("ComplexMethod")
     private fun createSpecification(criteria: PaivakirjamerkintaCriteria?, spec: Specification<Paivakirjamerkinta?>? = null): Specification<Paivakirjamerkinta?> {
         var specification: Specification<Paivakirjamerkinta?> = spec ?: Specification.unrestricted()
         if (criteria != null) {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoejaksoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariKoejaksoResource.kt
@@ -46,7 +46,6 @@ private const val ENTITY_KOEJAKSON_KEHITTAMISTOIMENPITEET = "koejakson_kehittami
 private const val ENTITY_KOEJAKSON_LOPPUKESKUSTELU = "koejakson_loppukeskustelu"
 private const val ENTITY_KOEJAKSON_VASTUUHENKILON_ARVIO = "koejakson_vastuuhenkilon_arvio"
 
-@Suppress("TooManyFunctions")
 @RestController
 @RequestMapping("/api/erikoistuva-laakari")
 class ErikoistuvaLaakariKoejaksoResource(


### PR DESCRIPTION
This pull request primarily focuses on code cleanup by removing unnecessary `@Suppress` annotations and updating a method usage for Levenshtein distance calculation. Additionally, it introduces a new Detekt rule to detect deprecation issues and updates the exclusion pattern for generated code.

**Code cleanup and annotation removal:**
* Removed several redundant `@Suppress` annotations from service and DTO classes, including `@Suppress("ComplexMethod")`, `@Suppress("ComplexCondition")`, `@Suppress("LongParameterList")`, and `@Suppress("TooManyFunctions")`, to improve code readability and maintainability. [[1]](diffhunk://#diff-2c83137da7b06977f9820244fd2de74ffb426411f4dd7f2832c79335b45ed3a3L60) [[2]](diffhunk://#diff-419949a03f00b8bb938541ec60e9f3851e09b9e508ee20c1d36bbb5b57fa915aL49) [[3]](diffhunk://#diff-0fcb7223078d127cc0e94ef7aaf6abbb459732cc694b79c37ea09bde35a37b27L751) [[4]](diffhunk://#diff-4b1d5f1d56ec3f631fcd7ad5cbbc06a49a6eddc530f1e87e5fb00dab858edd0bL11) [[5]](diffhunk://#diff-c0d88b858747417c2fd0bf08eccded96bb94fe30a06c9fc073917de7d564bd02L49) [[6]](diffhunk://#diff-7a871611db886a42b9ea5f6027119be5ef90ee6eddda2a6024e7fce4ca34aee5L26)

**Static analysis and code quality:**
* Enabled the Detekt `Deprecation` rule under `potential-bugs` and excluded generated code from this check in `detekt-config.yml`, enhancing static analysis for deprecated API usage.

**Dependency and method usage update:**
* Updated the instantiation of `LevenshteinDistance` to use `LevenshteinDistance.getDefaultInstance()` for improved reliability and consistency with the latest API.