### PR TITLE
chore: update CycloneDX BOM version to 3.4.0 and Cypress image to 15.20.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,7 +75,7 @@ jobs:
             --entrypoint /bin/sh \
             -v ${{ github.workspace }}/e2e:/e2e \
             -w /e2e \
-            cypress/included:15.19.0 \
+            cypress/included:15.20.0 \
             -c "npm install && npx cypress run --browser chrome --config baseUrl=http://localhost:8080"
 
       - name: Upload Cypress videos

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
     id "org.sonarqube"
     id "com.apollographql.apollo" version "${apolloVersion}"
     id "org.hibernate.orm" version "${hibernateVersion}"
-    id "org.cyclonedx.bom" version "3.3.0"
+    id "org.cyclonedx.bom" version "3.4.0"
 }
 
 apply plugin: 'org.liquibase.gradle'


### PR DESCRIPTION
This pull request makes a minor update to the end-to-end (E2E) test workflow by upgrading the Cypress Docker image used for running tests.

- Upgraded the Cypress Docker image from version `15.19.0` to `15.20.0` in the `.github/workflows/e2e.yml` workflow file.