### PR TITLE
ValmistumispyyntoServiceImpl yksinkertaisempi

### DIFF
--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonArviointiPdfService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonArviointiPdfService.kt
@@ -1,0 +1,126 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.domain.arviointi.Suoritusarviointi
+import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.repository.arviointi.SuoritusarviointiRepository
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.mapper.arviointi.SuoritusarviointiMapper
+import fi.elsapalvelu.elsa.service.valmistuminen.PdfService
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.thymeleaf.context.Context
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.Locale
+
+@Service
+class ValmistumispyynnonArviointiPdfService(
+    private val pdfService: PdfService,
+    private val suoritusarviointiRepository: SuoritusarviointiRepository,
+    private val suoritusarviointiMapper: SuoritusarviointiMapper,
+    private val arviointitietoService: ValmistumispyynnonArviointitietoService
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun lisaa(
+        opintooikeusId: Long,
+        valmistumispyynto: Valmistumispyynto,
+        outputStream: ByteArrayOutputStream
+    ) {
+        val arviointiasteikko = valmistumispyynto.opintooikeus?.opintoopas?.arviointiasteikko
+        val arviointiasteikonTasot = arviointiasteikko?.tasot?.associateBy { it.taso }
+        val locale = Locale.forLanguageTag("fi")
+        val yhteenvetoStream = ByteArrayOutputStream()
+        pdfService.luoPdf(
+            "pdf/erikoistujantiedot/arvioinnit.html",
+            Context(locale).apply {
+                setVariable(
+                    "arvioinninKategoriat",
+                    arviointitietoService.haeKategoriat(opintooikeusId, false)
+                )
+                setVariable("arviointiasteikko", arviointiasteikko)
+                setVariable("arviointiasteikonTasot", arviointiasteikonTasot)
+            },
+            yhteenvetoStream
+        )
+        lisaaPdf(yhteenvetoStream, outputStream)
+
+        suoritusarviointiRepository.findAllByTyoskentelyjaksoOpintooikeusId(opintooikeusId)
+            .sortedWith(arviointiComparator())
+            .forEach { arviointi ->
+                val arviointiStream = ByteArrayOutputStream()
+                pdfService.luoPdf(
+                    "pdf/erikoistujantiedot/arviointi.html",
+                    Context(locale).apply {
+                        setVariable("arviointi", suoritusarviointiMapper.toDto(arviointi))
+                        setVariable("arviointiasteikonTasot", arviointiasteikonTasot)
+                        setVariable("vaativuusTasot", VALMISTUMISPYYNNON_VAATIVUUSTASOT)
+                    },
+                    arviointiStream
+                )
+                lisaaPdf(arviointiStream, outputStream)
+
+                yhdistaPdfAsiakirjat(
+                    arviointi.arviointiAsiakirjat,
+                    outputStream,
+                    "Arviointiasiakirja"
+                )
+                yhdistaPdfAsiakirjat(
+                    arviointi.itsearviointiAsiakirjat,
+                    outputStream,
+                    "Itsearviointiasiakirja"
+                )
+            }
+    }
+
+    private fun arviointiComparator() = compareBy<Suoritusarviointi>(
+        {
+            it.arvioitavatKokonaisuudet.minOf { kokonaisuus ->
+                kokonaisuus.arvioitavaKokonaisuus?.kategoria?.nimi.required()
+            }
+        },
+        {
+            it.arvioitavatKokonaisuudet.minOf { kokonaisuus ->
+                kokonaisuus.arvioitavaKokonaisuus?.nimi.required()
+            }
+        }
+    ).thenByDescending { it.tapahtumanAjankohta }
+
+    private fun lisaaPdf(
+        newDocument: ByteArrayOutputStream,
+        outputStream: ByteArrayOutputStream
+    ) {
+        val existingPdf = ByteArrayInputStream(outputStream.toByteArray())
+        val newPdf = ByteArrayInputStream(newDocument.toByteArray())
+        outputStream.reset()
+        pdfService.yhdistaPdf(existingPdf, newPdf, outputStream)
+    }
+
+    private fun yhdistaPdfAsiakirjat(
+        asiakirjat: Collection<Asiakirja>,
+        outputStream: ByteArrayOutputStream,
+        label: String
+    ) {
+        asiakirjat.forEach { asiakirja ->
+            if (asiakirja.tyyppi != MediaType.APPLICATION_PDF_VALUE) {
+                log.warn(
+                    "$label ${asiakirja.id} (${asiakirja.nimi}) tyyppiä " +
+                        "'${asiakirja.tyyppi}' ei tueta PDF-yhdistelyyn – ohitetaan"
+                )
+                return@forEach
+            }
+            val data = asiakirja.asiakirjaData?.data
+            if (data == null || data.isEmpty()) {
+                log.warn(
+                    "$label ${asiakirja.id} (${asiakirja.nimi}) data on tyhjä tai null – ohitetaan"
+                )
+                return@forEach
+            }
+            val existingPdf = ByteArrayInputStream(outputStream.toByteArray())
+            outputStream.reset()
+            pdfService.yhdistaPdf(existingPdf, ByteArrayInputStream(data), outputStream)
+        }
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonArviointienTilaService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonArviointienTilaService.kt
@@ -1,0 +1,48 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.repository.arviointi.ArvioitavaKokonaisuusRepository
+import fi.elsapalvelu.elsa.repository.arviointi.SuoritusarviointiRepository
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoArviointienTilaDTO
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class ValmistumispyynnonArviointienTilaService(
+    private val arvioitavaKokonaisuusRepository: ArvioitavaKokonaisuusRepository,
+    private val suoritusarviointiRepository: SuoritusarviointiRepository
+) {
+
+    fun haeArviointienTila(
+        valmistumispyynto: Valmistumispyynto
+    ): ValmistumispyyntoArviointienTilaDTO {
+        val opintooikeus = valmistumispyynto.opintooikeus
+        val arvioitavatKokonaisuudet =
+            arvioitavaKokonaisuusRepository.findAllByErikoisalaIdAndValid(
+            opintooikeus?.erikoisala?.id,
+            opintooikeus?.osaamisenArvioinninOppaanPvm ?: LocalDate.now()
+        )
+        val arvioinnit = suoritusarviointiRepository.findAllByTyoskentelyjaksoOpintooikeusId(
+            opintooikeus?.id.required()
+        )
+        val arvioitujenKokonaisuuksienIds = arvioinnit
+            .flatMap { it.arvioitavatKokonaisuudet }
+            .map { it.arvioitavaKokonaisuus?.id.required() }
+            .distinct()
+
+        return ValmistumispyyntoArviointienTilaDTO(
+            hasArvioitaviaKokonaisuuksiaWithArviointiLowerThanFour = arvioinnit
+                .flatMap { it.arvioitavatKokonaisuudet }
+                .filter { it.arviointiasteikonTaso != null }
+                .any { it.arviointiasteikonTaso.required() < MINIMUM_ASSESSMENT },
+            hasArvioitaviaKokonaisuuksiaWithoutArviointi = arvioitavatKokonaisuudet.any {
+                it.id.required() !in arvioitujenKokonaisuuksienIds
+            }
+        )
+    }
+
+    private companion object {
+        const val MINIMUM_ASSESSMENT = 4
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonArviointitietoService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonArviointitietoService.kt
@@ -1,0 +1,136 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.domain.arviointi.ArvioitavaKokonaisuus
+import fi.elsapalvelu.elsa.domain.arviointi.ArvioitavanKokonaisuudenKategoria
+import fi.elsapalvelu.elsa.domain.arviointi.SuoritusarvioinninArvioitavaKokonaisuus
+import fi.elsapalvelu.elsa.repository.arviointi.SuoritusarviointiRepository
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.dto.arviointi.ArvioitavanKokonaisuudenKategoriaWithArvioinnitDTO
+import fi.elsapalvelu.elsa.service.dto.arviointi.ArvioitavaKokonaisuusWithArvioinnitDTO
+import fi.elsapalvelu.elsa.service.dto.arviointi.SuoritusarviointiByKokonaisuusDTO
+import fi.elsapalvelu.elsa.service.mapper.kayttaja.AsiakirjaMapper
+import fi.elsapalvelu.elsa.service.mapper.kayttaja.KayttajaMapper
+import fi.elsapalvelu.elsa.service.mapper.tyoskentely.TyoskentelyjaksoMapper
+import org.springframework.stereotype.Service
+
+@Service
+class ValmistumispyynnonArviointitietoService(
+    private val suoritusarviointiRepository: SuoritusarviointiRepository,
+    private val kayttajaMapper: KayttajaMapper,
+    private val tyoskentelyjaksoMapper: TyoskentelyjaksoMapper,
+    private val asiakirjaMapper: AsiakirjaMapper
+) {
+
+    fun haeKategoriat(
+        opintooikeusId: Long,
+        vainKorkeinArviointi: Boolean
+    ): List<ArvioitavanKokonaisuudenKategoriaWithArvioinnitDTO> {
+        var arvioinnit = suoritusarviointiRepository
+            .findAllByTyoskentelyjaksoOpintooikeusId(opintooikeusId)
+            .flatMap { it.arvioitavatKokonaisuudet }
+        if (vainKorkeinArviointi) {
+            arvioinnit = arvioinnit.filter { it.arviointiasteikonTaso != null }
+        }
+
+        val arvioinnitKokonaisuuksittain = arvioinnit.groupBy { it.arvioitavaKokonaisuus }
+        val kokonaisuudetKategorioittain = arvioinnitKokonaisuuksittain.keys
+            .sortedBy { it?.kategoria?.nimi }
+            .groupBy { it?.kategoria }
+
+        return kokonaisuudetKategorioittain.map { (kategoria, kokonaisuudet) ->
+            mapKategoria(
+                kategoria,
+                kokonaisuudet,
+                arvioinnitKokonaisuuksittain,
+                vainKorkeinArviointi
+            )
+        }
+    }
+
+    private fun mapKategoria(
+        kategoria: ArvioitavanKokonaisuudenKategoria?,
+        kokonaisuudet: List<ArvioitavaKokonaisuus?>,
+        arvioinnitKokonaisuuksittain:
+            Map<ArvioitavaKokonaisuus?, List<SuoritusarvioinninArvioitavaKokonaisuus>>,
+        vainKorkeinArviointi: Boolean
+    ) = ArvioitavanKokonaisuudenKategoriaWithArvioinnitDTO(
+        id = kategoria?.id,
+        nimi = kategoria?.nimi,
+        nimiSv = kategoria?.nimiSv,
+        jarjestysnumero = kategoria?.jarjestysnumero,
+        arviointejaYhteensa = if (vainKorkeinArviointi) {
+            kokonaisuudet.size
+        } else {
+            kokonaisuudet.sumOf { arvioinnitKokonaisuuksittain[it]?.size ?: 0 }
+        },
+        arvioitavatKokonaisuudet = kokonaisuudet.sortedBy { it?.nimi }.map { kokonaisuus ->
+            mapKokonaisuus(
+                kokonaisuus,
+                arvioinnitKokonaisuuksittain[kokonaisuus],
+                vainKorkeinArviointi
+            )
+        }
+    )
+
+    private fun mapKokonaisuus(
+        kokonaisuus: ArvioitavaKokonaisuus?,
+        arvioinnit: List<SuoritusarvioinninArvioitavaKokonaisuus>?,
+        vainKorkeinArviointi: Boolean
+    ) = ArvioitavaKokonaisuusWithArvioinnitDTO(
+        id = kokonaisuus?.id,
+        nimi = kokonaisuus?.nimi,
+        nimiSv = kokonaisuus?.nimiSv,
+        kuvaus = kokonaisuus?.kuvaus,
+        kuvausSv = kokonaisuus?.kuvausSv,
+        voimassaoloAlkaa = kokonaisuus?.voimassaoloAlkaa,
+        voimassaoloLoppuu = kokonaisuus?.voimassaoloLoppuu,
+        suoritusarvioinnit = if (vainKorkeinArviointi) {
+            listOf(
+                arvioinnit?.sortedByDescending {
+                    it.suoritusarviointi?.tapahtumanAjankohta
+                }?.maxByOrNull { it.arviointiasteikonTaso.required() }
+            ).map { mapKorkeinArviointi(it) }
+        } else {
+            arvioinnit?.sortedByDescending {
+                it.suoritusarviointi?.tapahtumanAjankohta
+            }?.map { it.toDto() }
+        }
+    )
+
+    private fun mapKorkeinArviointi(
+        arviointi: SuoritusarvioinninArvioitavaKokonaisuus?
+    ) = SuoritusarviointiByKokonaisuusDTO(
+        id = arviointi?.suoritusarviointi?.id,
+        tapahtumanAjankohta = arviointi?.suoritusarviointi?.tapahtumanAjankohta,
+        arvioitavaTapahtuma = arviointi?.suoritusarviointi?.arvioitavaTapahtuma,
+        arviointiasteikonTaso = arviointi?.arviointiasteikonTaso,
+        arvioinninAntaja = kayttajaMapper.toDto(
+            arviointi?.suoritusarviointi?.arvioinninAntaja.required()
+        ),
+        tyoskentelyjakso = tyoskentelyjaksoMapper.toDto(
+            requireNotNull(arviointi).suoritusarviointi?.tyoskentelyjakso.required()
+        )
+    )
+
+    private fun SuoritusarvioinninArvioitavaKokonaisuus.toDto() =
+        SuoritusarviointiByKokonaisuusDTO(
+            id = suoritusarviointi?.id,
+            tapahtumanAjankohta = suoritusarviointi?.tapahtumanAjankohta,
+            arvioitavaTapahtuma = suoritusarviointi?.arvioitavaTapahtuma,
+            arviointiasteikonTaso = arviointiasteikonTaso,
+            itsearviointiArviointiasteikonTaso = itsearviointiArviointiasteikonTaso,
+            arvioinninAntaja = kayttajaMapper.toDto(
+                suoritusarviointi?.arvioinninAntaja.required()
+            ),
+            arvioinninSaaja = kayttajaMapper.toDto(
+                suoritusarviointi?.tyoskentelyjakso?.opintooikeus
+                    ?.erikoistuvaLaakari?.kayttaja.required()
+            ),
+            tyoskentelyjakso = tyoskentelyjaksoMapper.toDto(
+                suoritusarviointi?.tyoskentelyjakso.required()
+            ),
+            arviointiAsiakirjat = suoritusarviointi?.arviointiAsiakirjat?.map(asiakirjaMapper::toDto),
+            itsearviointiAsiakirjat =
+            suoritusarviointi?.itsearviointiAsiakirjat?.map(asiakirjaMapper::toDto)
+        )
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonAsiakirjaService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonAsiakirjaService.kt
@@ -1,0 +1,118 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
+import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
+import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
+import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.repository.kayttaja.AsiakirjaRepository
+import fi.elsapalvelu.elsa.repository.kayttaja.KayttajaRepository
+import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyyntoRepository
+import fi.elsapalvelu.elsa.service.constants.KAYTTAJA_NOT_FOUND_ERROR
+import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
+import fi.elsapalvelu.elsa.service.mapper.kayttaja.AsiakirjaMapper
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.io.ByteArrayInputStream
+
+@Service
+class ValmistumispyynnonAsiakirjaService(
+    private val valmistumispyyntoRepository: ValmistumispyyntoRepository,
+    private val asiakirjaRepository: AsiakirjaRepository,
+    private val kayttajaRepository: KayttajaRepository,
+    private val asiakirjaMapper: AsiakirjaMapper
+) {
+
+    @Transactional(readOnly = true)
+    fun haeValmistumispyynnonAsiakirja(
+        userId: String,
+        valmistumispyyntoId: Long,
+        asiakirjaId: Long
+    ): AsiakirjaDTO? {
+        val valmistumispyynto = valmistumispyyntoRepository.findByIdOrNull(valmistumispyyntoId)
+            ?: return null
+        val onkoKayttajaOsapuoli = listOf(
+            valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja,
+            valmistumispyynto.vastuuhenkiloOsaamisenArvioija,
+            valmistumispyynto.vastuuhenkiloHyvaksyja,
+            valmistumispyynto.virkailija
+        ).any { it?.user?.id == userId }
+        val kuuluukoAsiakirjaValmistumispyyntoon =
+            valmistumispyynto.yhteenvetoAsiakirja?.id == asiakirjaId ||
+                valmistumispyynto.liitteetAsiakirja?.id == asiakirjaId
+
+        return if (onkoKayttajaOsapuoli && kuuluukoAsiakirjaValmistumispyyntoon) {
+            asiakirjaRepository.findByIdOrNull(asiakirjaId)?.toLadattavaDto()
+        } else {
+            null
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun haeValmistumispyynnonAsiakirjaVirkailijalle(
+        valmistumispyyntoId: Long,
+        yliopistoId: Long?,
+        asiakirjaId: Long
+    ): AsiakirjaDTO? {
+        val valmistumispyynto = valmistumispyyntoRepository.findByIdOrNull(valmistumispyyntoId)
+            ?: return null
+        val onkoSamaYliopisto = valmistumispyynto.opintooikeus?.yliopisto?.id == yliopistoId
+        val kuuluukoAsiakirjaValmistumispyyntoon =
+            valmistumispyynto.yhteenvetoAsiakirja?.id == asiakirjaId ||
+                valmistumispyynto.liitteetAsiakirja?.id == asiakirjaId
+
+        return if (onkoSamaYliopisto && kuuluukoAsiakirjaValmistumispyyntoon) {
+            asiakirjaRepository.findByIdOrNull(asiakirjaId)?.toLadattavaDto()
+        } else {
+            null
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun haeTyoskentelyjaksonAsiakirja(
+        userId: String,
+        valmistumispyyntoId: Long,
+        asiakirjaId: Long
+    ): AsiakirjaDTO? {
+        val vastuuhenkilo = haeKayttaja(userId)
+        val valmistumispyynto = valmistumispyyntoRepository.findByIdOrNull(valmistumispyyntoId)
+            ?: return null
+        if (!vastuuhenkilo.voiHyvaksya(valmistumispyynto)) {
+            return null
+        }
+
+        val asiakirja = asiakirjaRepository.findByIdOrNull(asiakirjaId) ?: return null
+        if (asiakirja.tyoskentelyjakso?.opintooikeus?.id != valmistumispyynto.opintooikeus?.id) {
+            return null
+        }
+        return asiakirja.toLadattavaDto()
+    }
+
+    private fun haeKayttaja(userId: String) =
+        kayttajaRepository.findOneByUserId(userId)
+            .orElseThrow { EntityNotFoundException(KAYTTAJA_NOT_FOUND_ERROR) }
+
+    private fun Kayttaja.voiHyvaksya(valmistumispyynto: Valmistumispyynto): Boolean =
+        yliopistotAndErikoisalat.any { yliopistoErikoisala ->
+            val onkoSamaYliopisto =
+                yliopistoErikoisala.yliopisto?.id == valmistumispyynto.opintooikeus?.yliopisto?.id
+            val tehtavat = yliopistoErikoisala.vastuuhenkilonTehtavat.map { it.nimi }
+            val onkoOikeaTehtava =
+                if (valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID) {
+                tehtavat.contains(VastuuhenkilonTehtavatyyppiEnum.YEK_VALMISTUMINEN)
+            } else {
+                yliopistoErikoisala.erikoisala?.id ==
+                    valmistumispyynto.opintooikeus?.erikoisala?.id &&
+                    tehtavat.contains(
+                        VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA
+                    )
+            }
+            onkoSamaYliopisto && onkoOikeaTehtava
+        }
+
+    private fun Asiakirja.toLadattavaDto(): AsiakirjaDTO = asiakirjaMapper.toDto(this).apply {
+        asiakirjaData?.fileInputStream = ByteArrayInputStream(this@toLadattavaDto.asiakirjaData?.data)
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonAsiakirjojenLuontiService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonAsiakirjojenLuontiService.kt
@@ -1,0 +1,43 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
+import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
+import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType.LIITE
+import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType.YHTEENVETO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyynnonTarkistusDTO
+import org.springframework.stereotype.Service
+
+@Service
+class ValmistumispyynnonAsiakirjojenLuontiService(
+    private val yhteenvetoPdfService: ValmistumispyynnonYhteenvetoPdfService,
+    private val liitteetPdfService: ValmistumispyynnonLiitteetPdfService,
+    private val erikoistujanTiedotPdfService: ValmistumispyynnonErikoistujanTiedotPdfService
+) {
+
+    fun luo(
+        tarkistus: ValmistumispyynnonTarkistusDTO,
+        valmistumispyynto: Valmistumispyynto
+    ): List<RecordProperties> {
+        val yek = valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID
+        if (yek) {
+            val yhteenveto = yhteenvetoPdfService.luoYek(tarkistus, valmistumispyynto)
+            val liitteet = liitteetPdfService.luo(valmistumispyynto)
+            return luoArkistointitiedot(yhteenveto, liitteet)
+        }
+
+        val liitteet = liitteetPdfService.luo(valmistumispyynto)
+        erikoistujanTiedotPdfService.luo(valmistumispyynto)
+        val yhteenveto = yhteenvetoPdfService.luo(tarkistus, valmistumispyynto)
+        return luoArkistointitiedot(yhteenveto, liitteet)
+    }
+
+    private fun luoArkistointitiedot(
+        yhteenveto: Asiakirja,
+        liitteet: Asiakirja
+    ) = listOf(
+            RecordProperties(yhteenveto, YHTEENVETO),
+            RecordProperties(liitteet, LIITE)
+        )
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonErikoistujanTiedotPdfService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonErikoistujanTiedotPdfService.kt
@@ -1,0 +1,150 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
+import fi.elsapalvelu.elsa.domain.kayttaja.AsiakirjaData
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.repository.kayttaja.AsiakirjaRepository
+import fi.elsapalvelu.elsa.repository.koulutus.KoulutussuunnitelmaRepository
+import fi.elsapalvelu.elsa.repository.seuranta.PaivakirjamerkintaRepository
+import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyyntoRepository
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.seuranta.SeurantajaksoService
+import fi.elsapalvelu.elsa.service.valmistuminen.PdfService
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.thymeleaf.context.Context
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@Service
+class ValmistumispyynnonErikoistujanTiedotPdfService(
+    private val pdfService: PdfService,
+    private val asiakirjaRepository: AsiakirjaRepository,
+    private val valmistumispyyntoRepository: ValmistumispyyntoRepository,
+    private val koulutussuunnitelmaRepository: KoulutussuunnitelmaRepository,
+    private val paivakirjamerkintaRepository: PaivakirjamerkintaRepository,
+    private val seurantajaksoService: SeurantajaksoService,
+    private val arviointiPdfService: ValmistumispyynnonArviointiPdfService,
+    private val suoritemerkintaPdfService: ValmistumispyynnonSuoritemerkintaPdfService
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun luo(valmistumispyynto: Valmistumispyynto) {
+        val opintooikeus = valmistumispyynto.opintooikeus ?: return
+        val opintooikeusId = opintooikeus.id.required()
+        val outputStream = ByteArrayOutputStream()
+
+        lisaaKoulutussuunnitelma(opintooikeusId, outputStream)
+        arviointiPdfService.lisaa(opintooikeusId, valmistumispyynto, outputStream)
+        suoritemerkintaPdfService.lisaa(opintooikeusId, valmistumispyynto, outputStream)
+        lisaaPaivakirjamerkinnat(opintooikeusId, outputStream)
+        lisaaSeurantajaksot(opintooikeusId, valmistumispyynto, outputStream)
+
+        val aikaleima =
+            LocalDate.now().format(DateTimeFormatter.ofPattern(PAIVAMAARAFORMAATTI))
+        val asiakirja = asiakirjaRepository.save(
+            Asiakirja(
+                opintooikeus = opintooikeus,
+                nimi = "koulutussuunnitelma_ja_osaaminen_${aikaleima}.pdf",
+                tyyppi = MediaType.APPLICATION_PDF_VALUE,
+                lisattypvm = LocalDateTime.now(),
+                asiakirjaData = AsiakirjaData(data = outputStream.toByteArray())
+            )
+        )
+        valmistumispyynto.erikoistujanTiedotAsiakirja = asiakirja
+        valmistumispyyntoRepository.save(valmistumispyynto)
+    }
+
+    private fun lisaaKoulutussuunnitelma(
+        opintooikeusId: Long,
+        outputStream: ByteArrayOutputStream
+    ) {
+        val koulutussuunnitelma =
+            koulutussuunnitelmaRepository.findOneByOpintooikeusId(opintooikeusId)
+        pdfService.luoPdf(
+            "pdf/erikoistujantiedot/koulutussuunnitelma.html",
+            Context(SUOMEN_LOCALE).apply {
+                setVariable("koulutussuunnitelma", koulutussuunnitelma)
+            },
+            outputStream
+        )
+
+        val motivaatiokirje = koulutussuunnitelma?.motivaatiokirjeAsiakirja ?: return
+        val data = motivaatiokirje.asiakirjaData?.data
+        if (data == null || data.isEmpty()) {
+            log.warn(
+                "Motivaatiokirjeasiakirja ${motivaatiokirje.id} data on tyhjä tai null – ohitetaan"
+            )
+            return
+        }
+        val existingPdf = ByteArrayInputStream(outputStream.toByteArray())
+        outputStream.reset()
+        pdfService.yhdistaPdf(existingPdf, ByteArrayInputStream(data), outputStream)
+    }
+
+    private fun lisaaPaivakirjamerkinnat(
+        opintooikeusId: Long,
+        outputStream: ByteArrayOutputStream
+    ) {
+        val paivakirjamerkinnat =
+            paivakirjamerkintaRepository.findAllByOpintooikeusId(opintooikeusId)
+        val paivakirjamerkinnatStream = ByteArrayOutputStream()
+        pdfService.luoPdf(
+            "pdf/erikoistujantiedot/paivittaisetmerkinnat.html",
+            Context(SUOMEN_LOCALE).apply {
+                setVariable("paivakirjamerkinnat", paivakirjamerkinnat)
+            },
+            paivakirjamerkinnatStream
+        )
+        lisaaPdf(paivakirjamerkinnatStream, outputStream)
+    }
+
+    private fun lisaaSeurantajaksot(
+        opintooikeusId: Long,
+        valmistumispyynto: Valmistumispyynto,
+        outputStream: ByteArrayOutputStream
+    ) {
+        val arviointiasteikko = valmistumispyynto.opintooikeus?.opintoopas?.arviointiasteikko
+        val arviointiasteikonTasot = arviointiasteikko?.tasot?.associateBy { it.taso }
+        seurantajaksoService.findByOpintooikeusId(opintooikeusId).forEach { seurantajakso ->
+            val seurantajaksonTiedot = seurantajaksoService.findSeurantajaksonTiedot(
+                seurantajakso.opintooikeusId.required(),
+                seurantajakso.alkamispaiva.required(),
+                seurantajakso.paattymispaiva.required(),
+                seurantajakso.koulutusjaksot?.map { it.id.required() }.orEmpty()
+            )
+            val seurantajaksoStream = ByteArrayOutputStream()
+            pdfService.luoPdf(
+                "pdf/erikoistujantiedot/seurantajakso.html",
+                Context(SUOMEN_LOCALE).apply {
+                    setVariable("seurantajakso", seurantajakso)
+                    setVariable("seurantajaksonTiedot", seurantajaksonTiedot)
+                    setVariable("arviointiasteikko", arviointiasteikko)
+                    setVariable("arviointiasteikonTasot", arviointiasteikonTasot)
+                },
+                seurantajaksoStream
+            )
+            lisaaPdf(seurantajaksoStream, outputStream)
+        }
+    }
+
+    private fun lisaaPdf(
+        newDocument: ByteArrayOutputStream,
+        outputStream: ByteArrayOutputStream
+    ) {
+        val existingPdf = ByteArrayInputStream(outputStream.toByteArray())
+        val newPdf = ByteArrayInputStream(newDocument.toByteArray())
+        outputStream.reset()
+        pdfService.yhdistaPdf(existingPdf, newPdf, outputStream)
+    }
+
+    private companion object {
+        const val PAIVAMAARAFORMAATTI = "yyyyMMdd"
+        val SUOMEN_LOCALE: Locale = Locale.forLanguageTag("fi")
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonIlmoitusService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonIlmoitusService.kt
@@ -1,0 +1,169 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.config.ApplicationProperties
+import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
+import fi.elsapalvelu.elsa.domain.kayttaja.User
+import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.repository.kayttaja.KayttajaRepository
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.security.VASTUUHENKILO
+import fi.elsapalvelu.elsa.service.kayttaja.MailProperty
+import fi.elsapalvelu.elsa.service.mail.TransactionalMailService
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class ValmistumispyynnonIlmoitusService(
+    private val transactionalMailService: TransactionalMailService,
+    private val applicationProperties: ApplicationProperties,
+    private val kayttajaRepository: KayttajaRepository
+) {
+
+    fun lahetaIlmoitusUudestaValmistumispyynnosta(
+        osaamisenArvioija: User,
+        valmistumispyynto: Valmistumispyynto
+    ) {
+        transactionalMailService.sendEmailFromTemplate(
+            osaamisenArvioija,
+            templateName = "uusivalmistumispyynto.html",
+            titleKey = "email.uusivalmistumispyynto.title",
+            properties = mapOf(
+                MailProperty.NAME to haeErikoistujanNimi(valmistumispyynto),
+                MailProperty.ID to valmistumispyynto.id.required().toString()
+            )
+        )
+    }
+
+    fun lahetaIlmoitusVirkailijanTarkastuksesta(valmistumispyynto: Valmistumispyynto) {
+        val yek = valmistumispyynto.onYek()
+        transactionalMailService.sendEmailFromTemplate(
+            to = haeYliopisto(valmistumispyynto)
+                .getOpintohallintoEmailAddress(applicationProperties),
+            templateName = if (yek) {
+                "valmistumispyyntoTarkastettavissaYek.html"
+            } else {
+                "valmistumispyyntoTarkastettavissa.html"
+            },
+            titleKey = if (yek) {
+                "email.yekValmistumispyyntoTarkastettavissa.title"
+            } else {
+                "email.valmistumispyyntoTarkastettavissa.title"
+            },
+            properties = mapOf(MailProperty.ID to valmistumispyynto.id.required().toString())
+        )
+    }
+
+    fun lahetaIlmoitusHyvaksyjalle(valmistumispyynto: Valmistumispyynto) {
+        val yek = valmistumispyynto.onYek()
+        transactionalMailService.sendEmailFromTemplate(
+            haeHyvaksyja(valmistumispyynto),
+            templateName = if (yek) {
+                "valmistumispyyntoTarkastettavissaYek.html"
+            } else {
+                "valmistumispyyntoTarkastettavissaVastuuhenkilo.html"
+            },
+            titleKey = if (yek) {
+                "email.yekValmistumispyyntoTarkastettavissa.title"
+            } else {
+                "email.valmistumispyyntoTarkastettavissaVastuuhenkilo.title"
+            },
+            properties = mapOf(MailProperty.ID to valmistumispyynto.id.toString())
+        )
+    }
+
+    fun lahetaIlmoitusPalautuksesta(
+        valmistumispyynto: Valmistumispyynto,
+        ilmoitaYliopistolle: Boolean = false
+    ) {
+        transactionalMailService.sendEmailFromTemplate(
+            haeErikoistuja(valmistumispyynto),
+            templateName = "valmistumispyyntoPalautettuErikoistuja.html",
+            titleKey = "email.valmistumispyyntoPalautettuErikoistuja.title",
+            properties = emptyMap()
+        )
+        if (ilmoitaYliopistolle) {
+            val nimi = haeErikoistujanNimi(valmistumispyynto)
+            transactionalMailService.sendEmailFromTemplate(
+                haeYliopisto(valmistumispyynto)
+                    .getOpintohallintoEmailAddress(applicationProperties),
+                templateName = if (valmistumispyynto.onYek()) {
+                    "valmistumispyyntoPalautettuMuutYek.html"
+                } else {
+                    "valmistumispyyntoPalautettuMuut.html"
+                },
+                titleKey = "email.valmistumispyyntoPalautettuMuut.title",
+                titleProperties = arrayOf(nimi),
+                properties = mapOf(MailProperty.NAME to nimi)
+            )
+        }
+    }
+
+    fun lahetaIlmoitusHyvaksynnasta(valmistumispyynto: Valmistumispyynto) {
+        val yek = valmistumispyynto.onYek()
+        val titleKey = if (yek) {
+            "email.yekValmistumispyyntoHyvaksytty.title"
+        } else {
+            "email.valmistumispyyntoHyvaksytty.title"
+        }
+        transactionalMailService.sendEmailFromTemplate(
+            haeErikoistuja(valmistumispyynto),
+            templateName = if (yek) {
+                "valmistumispyyntoHyvaksyttyYek.html"
+            } else {
+                "valmistumispyyntoHyvaksytty.html"
+            },
+            titleKey = titleKey,
+            properties = emptyMap()
+        )
+        transactionalMailService.sendEmailFromTemplate(
+            haeYliopisto(valmistumispyynto)
+                .getOpintohallintoEmailAddress(applicationProperties),
+            templateName = if (yek) {
+                "valmistumispyyntoHyvaksyttyYekVirkailija.html"
+            } else {
+                "valmistumispyyntoHyvaksyttyVirkailija.html"
+            },
+            titleKey = titleKey,
+            properties = mapOf(MailProperty.ID to valmistumispyynto.id.toString())
+        )
+    }
+
+    private fun haeHyvaksyja(valmistumispyynto: Valmistumispyynto): User {
+        val opintooikeus = valmistumispyynto.opintooikeus.required()
+        val yliopistoId = opintooikeus.yliopisto?.id.required()
+        val erikoisalaId = opintooikeus.erikoisala?.id.required()
+        val hyvaksyja = if (valmistumispyynto.onYek()) {
+            kayttajaRepository.findOneByAuthoritiesYliopistoAndVastuuhenkilonTehtavatyyppi(
+                listOf(VASTUUHENKILO),
+                yliopistoId,
+                VastuuhenkilonTehtavatyyppiEnum.YEK_VALMISTUMINEN
+            )
+        } else {
+            kayttajaRepository.findOneByAuthoritiesYliopistoErikoisalaAndVastuuhenkilonTehtavatyyppi(
+                listOf(VASTUUHENKILO),
+                yliopistoId,
+                erikoisalaId,
+                VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA
+            )
+        }
+        return hyvaksyja?.user
+            ?: throw EntityNotFoundException(
+                "Vastuuhenkilöä, joka hyväksyisi valmistumispyynnon, ei löydy."
+            )
+    }
+
+    private fun haeErikoistuja(valmistumispyynto: Valmistumispyynto) =
+        valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user.required()
+
+    private fun haeErikoistujanNimi(valmistumispyynto: Valmistumispyynto) =
+        valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user
+            ?.getName().toString()
+
+    private fun haeYliopisto(valmistumispyynto: Valmistumispyynto): YliopistoEnum =
+        valmistumispyynto.opintooikeus?.yliopisto?.nimi.required()
+
+    private fun Valmistumispyynto.onYek() =
+        opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonLiitteetPdfService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonLiitteetPdfService.kt
@@ -1,0 +1,64 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
+import fi.elsapalvelu.elsa.domain.kayttaja.AsiakirjaData
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.repository.kayttaja.AsiakirjaRepository
+import fi.elsapalvelu.elsa.repository.tyoskentely.TyoskentelyjaksoRepository
+import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyyntoRepository
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.valmistuminen.PdfService
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import java.io.ByteArrayOutputStream
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Service
+class ValmistumispyynnonLiitteetPdfService(
+    private val pdfService: PdfService,
+    private val asiakirjaRepository: AsiakirjaRepository,
+    private val valmistumispyyntoRepository: ValmistumispyyntoRepository,
+    private val tyoskentelyjaksoRepository: TyoskentelyjaksoRepository
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun luo(valmistumispyynto: Valmistumispyynto): Asiakirja {
+        val opintooikeus = valmistumispyynto.opintooikeus.required()
+        val tyoskentelyjaksot = tyoskentelyjaksoRepository.findAllByOpintooikeusId(
+            opintooikeus.id.required()
+        )
+        val outputStream = ByteArrayOutputStream()
+        try {
+            pdfService.yhdistaAsiakirjat(
+                tyoskentelyjaksot.flatMap { it.asiakirjat },
+                outputStream
+            )
+        } catch (exception: Exception) {
+            log.error(
+                "Virhe yhdistäessä asiakirjoja valmistumispyynnölle: ${valmistumispyynto.id}",
+                exception
+            )
+        }
+
+        val timestamp = LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT))
+        val asiakirja = asiakirjaRepository.save(
+            Asiakirja(
+                opintooikeus = opintooikeus,
+                nimi = "valmistumisen_yhteenvedon_liitteet_${timestamp}.pdf",
+                tyyppi = MediaType.APPLICATION_PDF_VALUE,
+                lisattypvm = LocalDateTime.now(),
+                asiakirjaData = AsiakirjaData(data = outputStream.toByteArray())
+            )
+        )
+        valmistumispyynto.liitteetAsiakirja = asiakirja
+        valmistumispyyntoRepository.save(valmistumispyynto)
+        return asiakirja
+    }
+
+    private companion object {
+        const val DATE_FORMAT = "yyyyMMdd"
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonOsapuoliService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonOsapuoliService.kt
@@ -1,0 +1,163 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
+import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
+import fi.elsapalvelu.elsa.domain.kayttaja.User
+import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.repository.kayttaja.KayttajaRepository
+import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
+import fi.elsapalvelu.elsa.repository.kayttaja.UserRepository
+import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyynnonTarkistusRepository
+import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyyntoRepository
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.security.VASTUUHENKILO
+import fi.elsapalvelu.elsa.service.constants.KAYTTAJA_NOT_FOUND_ERROR
+import fi.elsapalvelu.elsa.service.constants.KAYTTAJA_YLIOPISTO_ERIKOISALA_NOT_FOUND_ERROR
+import fi.elsapalvelu.elsa.service.constants.OPINTOOIKEUS_NOT_FOUND_ERROR
+import fi.elsapalvelu.elsa.service.constants.VALMISTUMISPYYNTO_NOT_FOUND_ERROR
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class ValmistumispyynnonOsapuoliService(
+    private val kayttajaRepository: KayttajaRepository,
+    private val opintooikeusRepository: OpintooikeusRepository,
+    private val userRepository: UserRepository,
+    private val valmistumispyyntoRepository: ValmistumispyyntoRepository,
+    private val tarkistusRepository: ValmistumispyynnonTarkistusRepository
+) {
+
+    fun haeKayttaja(userId: String): Kayttaja = kayttajaRepository.findOneByUserId(userId)
+        .orElseThrow { EntityNotFoundException(KAYTTAJA_NOT_FOUND_ERROR) }
+
+    fun haeOpintooikeus(id: Long): Opintooikeus = opintooikeusRepository.findByIdOrNull(id)
+        ?: throw EntityNotFoundException(OPINTOOIKEUS_NOT_FOUND_ERROR)
+
+    fun haeYliopisto(kayttaja: Kayttaja) =
+        kayttaja.yliopistotAndErikoisalat.firstOrNull()?.yliopisto
+        ?: throw EntityNotFoundException(KAYTTAJA_YLIOPISTO_ERIKOISALA_NOT_FOUND_ERROR)
+
+    fun haeErikoisalaIds(kayttaja: Kayttaja) =
+        kayttaja.yliopistotAndErikoisalat.map { it.erikoisala?.id.required() }
+
+    fun paivitaYhteystiedot(kayttajatili: User?, sahkoposti: String?, puhelinnumero: String?) {
+        kayttajatili?.let {
+            it.email = sahkoposti
+            it.phoneNumber = puhelinnumero
+            userRepository.save(it)
+        }
+    }
+
+    fun haeValmistumispyynto(
+        id: Long,
+        kayttaja: Kayttaja,
+        yliopistoId: Long,
+        tehtava: VastuuhenkilonTehtavatyyppiEnum
+    ): Valmistumispyynto {
+        val valmistumispyynto = valmistumispyyntoRepository.findByIdAndOpintooikeusYliopistoId(
+            id,
+            yliopistoId
+        ) ?: throw valmistumispyyntoaEiLoydy()
+        val yek = valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID
+        val onkoTehtava = kayttaja.yliopistotAndErikoisalat.any { yliopistoErikoisala ->
+            val tehtavat = yliopistoErikoisala.vastuuhenkilonTehtavat.map { it.nimi }
+            if (yek) {
+                tehtavat.contains(VastuuhenkilonTehtavatyyppiEnum.YEK_VALMISTUMINEN)
+            } else {
+                yliopistoErikoisala.erikoisala?.id ==
+                    valmistumispyynto.opintooikeus?.erikoisala?.id &&
+                    tehtavat.contains(tehtava)
+            }
+        }
+        return valmistumispyynto.takeIf { onkoTehtava } ?: throw valmistumispyyntoaEiLoydy()
+    }
+
+    fun haeValmistumispyyntoOpintooikeudella(opintooikeusId: Long): Valmistumispyynto =
+        valmistumispyyntoRepository.findByOpintooikeusId(opintooikeusId)
+            ?: throw EntityNotFoundException(VALMISTUMISPYYNTO_NOT_FOUND_ERROR)
+
+    fun haeOsaamisenArvioija(yliopistoId: Long, erikoisalaId: Long): Kayttaja =
+        kayttajaRepository
+            .findOneByAuthoritiesYliopistoErikoisalaAndVastuuhenkilonTehtavatyyppi(
+                listOf(VASTUUHENKILO),
+                yliopistoId,
+                erikoisalaId,
+                VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_OSAAMISEN_ARVIOINTI
+            ) ?: throw EntityNotFoundException(COMPETENCE_REVIEWER_NOT_FOUND)
+
+    fun haeHyvaksyja(yliopistoId: Long, erikoisalaId: Long): Kayttaja {
+        if (erikoisalaId == YEK_ERIKOISALA_ID) {
+            return kayttajaRepository
+                .findOneByAuthoritiesYliopistoAndVastuuhenkilonTehtavatyyppi(
+                    listOf(VASTUUHENKILO),
+                    yliopistoId,
+                    VastuuhenkilonTehtavatyyppiEnum.YEK_VALMISTUMINEN
+                ) ?: throw EntityNotFoundException(FINAL_APPROVER_NOT_FOUND)
+        }
+        return kayttajaRepository
+            .findOneByAuthoritiesYliopistoErikoisalaAndVastuuhenkilonTehtavatyyppi(
+                listOf(VASTUUHENKILO),
+                yliopistoId,
+                erikoisalaId,
+                VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA
+            ) ?: throw EntityNotFoundException(FINAL_APPROVER_NOT_FOUND)
+    }
+
+    fun onkoOsaamisenArviointiAvoin(userId: String, valmistumispyyntoId: Long): Boolean {
+        val kayttaja = haeKayttaja(userId)
+        val valmistumispyynto = haeValmistumispyynto(
+            valmistumispyyntoId,
+            kayttaja,
+            haeYliopisto(kayttaja).id.required(),
+            VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_OSAAMISEN_ARVIOINTI
+        )
+        return valmistumispyynto.erikoistujanKuittausaika != null &&
+            valmistumispyynto.vastuuhenkiloOsaamisenArvioijaKuittausaika == null
+    }
+
+    fun onkoVirkailijanTarkistusAvoin(userId: String, valmistumispyyntoId: Long): Boolean {
+        val kayttaja = haeKayttaja(userId)
+        val yliopistoId = kayttaja.yliopistot.first().id.required()
+        val tarkistus = tarkistusRepository
+            .findByValmistumispyyntoIdAndValmistumispyyntoOpintooikeusYliopistoId(
+                valmistumispyyntoId,
+                yliopistoId
+            )
+        val valmistumispyynto = tarkistus?.valmistumispyynto
+            ?: valmistumispyyntoRepository.findByIdAndOpintooikeusYliopistoId(
+                valmistumispyyntoId,
+                yliopistoId
+            )
+        return valmistumispyynto?.erikoistujanKuittausaika != null &&
+            (valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID ||
+                valmistumispyynto.vastuuhenkiloOsaamisenArvioijaKuittausaika != null) &&
+            valmistumispyynto.virkailijanKuittausaika == null
+    }
+
+    fun onkoLopullinenHyvaksyntaAvoin(userId: String, valmistumispyyntoId: Long): Boolean {
+        val kayttaja = haeKayttaja(userId)
+        val valmistumispyynto = haeValmistumispyynto(
+            valmistumispyyntoId,
+            kayttaja,
+            haeYliopisto(kayttaja).id.required(),
+            VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA
+        )
+        return valmistumispyynto.virkailijanKuittausaika != null &&
+            valmistumispyynto.vastuuhenkiloHyvaksyjaKuittausaika == null
+    }
+
+    fun valmistumispyyntoaEiLoydy() = EntityNotFoundException(
+        "Valmistumispyyntöä ei löydy tai sinulla ei ole oikeuksia tarkastella " +
+            "kyseistä valmistumispyyntöä."
+    )
+
+    private companion object {
+        const val COMPETENCE_REVIEWER_NOT_FOUND =
+            "Vastuuhenkilöä, joka hyväksyisi osaamisen arvioinnin, ei löydy."
+        const val FINAL_APPROVER_NOT_FOUND =
+            "Vastuuhenkilöä, joka hyväksyisi valmistumispyynnon, ei löydy."
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonPdfArvot.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonPdfArvot.kt
@@ -1,0 +1,9 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+internal val VALMISTUMISPYYNNON_VAATIVUUSTASOT = mapOf(
+    1 to "ERITTAIN_HELPPO",
+    2 to "MELKO_HELPPO",
+    3 to "TAVANOMAINEN",
+    4 to "MELKO_VAATIVA",
+    5 to "ERITTAIN_VAATIVA"
+)

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonSuoritemerkintaPdfService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonSuoritemerkintaPdfService.kt
@@ -1,0 +1,128 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.domain.arviointi.Arviointiasteikko
+import fi.elsapalvelu.elsa.domain.arviointi.ArviointiasteikonTaso
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.repository.suoritteet.SuoritemerkintaRepository
+import fi.elsapalvelu.elsa.repository.suoritteet.SuoritteenKategoriaRepository
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.dto.suoritteet.SuoriteWithSuoritemerkinnatDTO
+import fi.elsapalvelu.elsa.service.dto.suoritteet.SuoritteenKategoriaWithSuoritemerkinnatDTO
+import fi.elsapalvelu.elsa.service.mapper.suoritteet.SuoritemerkintaMapper
+import fi.elsapalvelu.elsa.service.valmistuminen.PdfService
+import org.springframework.stereotype.Service
+import org.thymeleaf.context.Context
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.Locale
+
+@Service
+class ValmistumispyynnonSuoritemerkintaPdfService(
+    private val pdfService: PdfService,
+    private val suoritemerkintaRepository: SuoritemerkintaRepository,
+    private val suoritteenKategoriaRepository: SuoritteenKategoriaRepository,
+    private val suoritemerkintaMapper: SuoritemerkintaMapper
+) {
+
+    fun lisaa(
+        opintooikeusId: Long,
+        valmistumispyynto: Valmistumispyynto,
+        outputStream: ByteArrayOutputStream
+    ) {
+        val arviointiasteikko = valmistumispyynto.opintooikeus?.opintoopas?.arviointiasteikko
+        val arviointiasteikonTasot = arviointiasteikko?.tasot?.associateBy { it.taso }
+        val kategoriat = luoKategoriat(opintooikeusId, valmistumispyynto)
+        lisaaYhteenveto(kategoriat, arviointiasteikko, arviointiasteikonTasot, outputStream)
+        lisaaSuoritemerkinnat(kategoriat, arviointiasteikonTasot, outputStream)
+    }
+
+    private fun luoKategoriat(
+        opintooikeusId: Long,
+        valmistumispyynto: Valmistumispyynto
+    ): List<SuoritteenKategoriaWithSuoritemerkinnatDTO> {
+        val suoritemerkinnatSuoritteittain = suoritemerkintaRepository
+            .findAllByTyoskentelyjaksoOpintooikeusId(opintooikeusId)
+            .groupBy { it.suorite?.id }
+        return suoritteenKategoriaRepository.findAllByErikoisalaId(
+            valmistumispyynto.opintooikeus?.erikoisala?.id.required()
+        ).sortedBy { it.nimi }.map { kategoria ->
+            SuoritteenKategoriaWithSuoritemerkinnatDTO(
+                id = kategoria.id,
+                nimi = kategoria.nimi,
+                nimiSv = kategoria.nimiSv,
+                arviointiasteikko =
+                valmistumispyynto.opintooikeus?.opintoopas?.arviointiasteikko?.nimi,
+                suoritteet = kategoria.suoritteet.sortedBy { it.nimi }.map { suorite ->
+                    SuoriteWithSuoritemerkinnatDTO(
+                        id = suorite.id,
+                        nimi = suorite.nimi,
+                        nimiSv = suorite.nimiSv,
+                        voimassaolonAlkamispaiva = suorite.voimassaolonAlkamispaiva,
+                        voimassaolonPaattymispaiva = suorite.voimassaolonPaattymispaiva,
+                        vaadittulkm = suorite.vaadittulkm,
+                        suoritemerkinnat = suoritemerkinnatSuoritteittain[suorite.id]
+                            ?.sortedByDescending { it.suorituspaiva }
+                            ?.map(suoritemerkintaMapper::toDto)
+                            .orEmpty()
+                    )
+                },
+                jarjestysnumero = kategoria.jarjestysnumero
+            )
+        }
+    }
+
+    private fun lisaaYhteenveto(
+        kategoriat: List<SuoritteenKategoriaWithSuoritemerkinnatDTO>,
+        arviointiasteikko: Arviointiasteikko?,
+        arviointiasteikonTasot: Map<Int?, ArviointiasteikonTaso>?,
+        outputStream: ByteArrayOutputStream
+    ) {
+        val locale = Locale.forLanguageTag("fi")
+        val yhteenvetoStream = ByteArrayOutputStream()
+        pdfService.luoPdf(
+            "pdf/erikoistujantiedot/suoritemerkinnat.html",
+            Context(locale).apply {
+                setVariable("suoritteenKategoriat", kategoriat)
+                setVariable("arviointiasteikko", arviointiasteikko)
+                setVariable("arviointiasteikonTasot", arviointiasteikonTasot)
+            },
+            yhteenvetoStream
+        )
+        lisaaPdf(yhteenvetoStream, outputStream)
+    }
+
+    private fun lisaaSuoritemerkinnat(
+        kategoriat: List<SuoritteenKategoriaWithSuoritemerkinnatDTO>,
+        arviointiasteikonTasot: Map<Int?, ArviointiasteikonTaso>?,
+        outputStream: ByteArrayOutputStream
+    ) {
+        val locale = Locale.forLanguageTag("fi")
+        kategoriat.forEach { kategoria ->
+            kategoria.suoritteet?.forEach { suorite ->
+                suorite.suoritemerkinnat?.forEach { suoritemerkinta ->
+                    val suoritemerkintaStream = ByteArrayOutputStream()
+                    pdfService.luoPdf(
+                        "pdf/erikoistujantiedot/suoritemerkinta.html",
+                        Context(locale).apply {
+                            setVariable("suoritemerkinta", suoritemerkinta)
+                            setVariable("arviointiasteikonTasot", arviointiasteikonTasot)
+                            setVariable("vaativuusTasot", VALMISTUMISPYYNNON_VAATIVUUSTASOT)
+                        },
+                        suoritemerkintaStream
+                    )
+                    lisaaPdf(suoritemerkintaStream, outputStream)
+                }
+            }
+        }
+    }
+
+    private fun lisaaPdf(
+        newDocument: ByteArrayOutputStream,
+        outputStream: ByteArrayOutputStream
+    ) {
+        val existingPdf = ByteArrayInputStream(outputStream.toByteArray())
+        val newPdf = ByteArrayInputStream(newDocument.toByteArray())
+        outputStream.reset()
+        pdfService.yhdistaPdf(existingPdf, newPdf, outputStream)
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonTarkistusService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonTarkistusService.kt
@@ -1,0 +1,218 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
+import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
+import fi.elsapalvelu.elsa.domain.koulutus.Opintosuoritus
+import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusTyyppiEnum
+import fi.elsapalvelu.elsa.domain.kayttaja.Opintooikeus
+import fi.elsapalvelu.elsa.domain.tyoskentely.TyoskentelyjaksoTyyppi
+import fi.elsapalvelu.elsa.repository.koejakso.KoejaksonVastuuhenkilonArvioRepository
+import fi.elsapalvelu.elsa.repository.koulutus.OpintosuoritusRepository
+import fi.elsapalvelu.elsa.repository.koulutus.TeoriakoulutusRepository
+import fi.elsapalvelu.elsa.repository.kayttaja.OpintooikeusRepository
+import fi.elsapalvelu.elsa.repository.valmistuminen.TerveyskeskuskoulutusjaksonHyvaksyntaRepository
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.constants.ERIKOISALA_NOT_FOUND_ERROR
+import fi.elsapalvelu.elsa.service.constants.OPINTOOIKEUS_NOT_FOUND_ERROR
+import fi.elsapalvelu.elsa.service.dto.tyoskentely.TyoskentelyjaksotKoulutustyypitDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyynnonTarkistusDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoSuoritustenTilaDTO
+import fi.elsapalvelu.elsa.service.mapper.koulutus.OpintosuoritusMapper
+import fi.elsapalvelu.elsa.service.tyoskentely.TyoskentelyjaksoService
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+private val YEK_OPINTOSUORITUSTYYPIT = setOf(
+    OpintosuoritusTyyppiEnum.YEK_TEORIAKOULUTUS,
+    OpintosuoritusTyyppiEnum.YEK_TERVEYSKESKUSKOULUTUSJAKSO,
+    OpintosuoritusTyyppiEnum.YEK_PATEVYYS
+)
+
+@Component
+class ValmistumispyynnonTarkistusService(
+    private val tyoskentelyjaksoService: TyoskentelyjaksoService,
+    private val terveyskeskuskoulutusjaksonHyvaksyntaRepository:
+        TerveyskeskuskoulutusjaksonHyvaksyntaRepository,
+    private val opintooikeusRepository: OpintooikeusRepository,
+    private val opintosuoritusRepository: OpintosuoritusRepository,
+    private val teoriakoulutusRepository: TeoriakoulutusRepository,
+    private val opintosuoritusMapper: OpintosuoritusMapper,
+    private val koejaksonVastuuhenkilonArvioRepository: KoejaksonVastuuhenkilonArvioRepository,
+    private val vanhentumisService: ValmistumispyynnonVanhentumisService
+) {
+
+    fun taydenna(dto: ValmistumispyynnonTarkistusDTO): ValmistumispyynnonTarkistusDTO {
+        val opintooikeusId = dto.valmistumispyynto?.opintooikeusId ?: return dto
+        val opintooikeus = haeOpintooikeus(opintooikeusId)
+        val opintosuoritukset = haeOlennaisetOpintosuoritukset(opintooikeus)
+
+        lisaaTyoskentelytiedot(dto, opintooikeus, opintosuoritukset)
+        lisaaOpintosuoritustiedot(dto, opintooikeus, opintosuoritukset)
+        lisaaKoejaksotiedot(dto, opintooikeusId, opintosuoritukset)
+        lisaaVanhentumistiedot(dto, opintooikeus)
+        return dto
+    }
+
+    private fun lisaaTyoskentelytiedot(
+        dto: ValmistumispyynnonTarkistusDTO,
+        opintooikeus: Opintooikeus,
+        opintosuoritukset: OlennaisetOpintosuoritukset
+    ) {
+        val id = opintooikeus.id.required()
+        dto.tyoskentelyjaksotTilastot = tyoskentelyjaksoService.getTilastot(id).koulutustyypit
+        terveyskeskuskoulutusjaksonHyvaksyntaRepository.findByOpintooikeusId(id)
+            ?.let { approval ->
+                if (approval.vastuuhenkiloHyvaksynyt) {
+                    dto.terveyskeskustyoHyvaksyttyPvm = approval.vastuuhenkilonKuittausaika
+                }
+                dto.terveyskeskustyoHyvaksyntaId = approval.id
+            }
+
+        (opintosuoritukset.nykyiset + opintosuoritukset.yek)
+            .firstOrNull {
+                it.tyyppi?.nimi in setOf(
+                    OpintosuoritusTyyppiEnum.TERVEYSKESKUSKOULUTUSJAKSO,
+                    OpintosuoritusTyyppiEnum.YEK_TERVEYSKESKUSKOULUTUSJAKSO
+                )
+            }
+            ?.let { dto.terveyskeskustyoOpintosuoritusId = it.id }
+
+        dto.tutkimustyotaTehty = tyoskentelyjaksoService.existsByKaytannonKoulutus(
+            id,
+            KaytannonKoulutusTyyppi.TUTKIMUSTYO
+        )
+        if (opintooikeus.onYek()) {
+            val tyoskentelyjaksot =
+                tyoskentelyjaksoService.findAllByOpintooikeusIdWithKeskeytykset(id)
+            dto.tyoskentelyjaksot = TyoskentelyjaksotKoulutustyypitDTO(
+                terveyskeskus = tyoskentelyjaksot.filter {
+                    it.tyoskentelypaikka?.tyyppi == TyoskentelyjaksoTyyppi.TERVEYSKESKUS
+                },
+                yliopistosairaala = tyoskentelyjaksot.filter {
+                    it.tyoskentelypaikka?.tyyppi in setOf(
+                        TyoskentelyjaksoTyyppi.YLIOPISTOLLINEN_SAIRAALA,
+                        TyoskentelyjaksoTyyppi.KESKUSSAIRAALA
+                    )
+                },
+                yliopistosairaaloidenUlkopuolinen = tyoskentelyjaksot.filter {
+                    it.tyoskentelypaikka?.tyyppi in setOf(
+                        TyoskentelyjaksoTyyppi.YKSITYINEN,
+                        TyoskentelyjaksoTyyppi.MUU
+                    )
+                }
+            )
+        }
+    }
+
+    private fun lisaaOpintosuoritustiedot(
+        dto: ValmistumispyynnonTarkistusDTO,
+        opintooikeus: Opintooikeus,
+        opintosuoritukset: OlennaisetOpintosuoritukset
+    ) {
+        opintosuoritukset.yek
+            .firstOrNull { it.tyyppi?.nimi == OpintosuoritusTyyppiEnum.YEK_PATEVYYS }
+            ?.let {
+                dto.yekSuoritettu = true
+                dto.yekSuorituspaiva = it.suorituspaiva
+            }
+
+        val opintoopas = opintooikeus.opintoopas
+        dto.teoriakoulutusSuoritettu = if (opintooikeus.onYek()) {
+            if (opintosuoritukset.nykyiset.any {
+                    it.tyyppi?.nimi == OpintosuoritusTyyppiEnum.YEK_TEORIAKOULUTUS
+                }
+            ) {
+                opintoopas?.erikoisalanVaatimaTeoriakoulutustenVahimmaismaara
+            } else {
+                0.0
+            }
+        } else {
+            teoriakoulutusRepository.findAllByOpintooikeusId(opintooikeus.id.required())
+                .mapNotNull { it.erikoistumiseenHyvaksyttavaTuntimaara }
+                .sum()
+        }
+        dto.teoriakoulutusVaadittu =
+            opintoopas?.erikoisalanVaatimaTeoriakoulutustenVahimmaismaara
+        dto.sateilusuojakoulutusSuoritettu = opintosuoritukset.nykyiset
+            .filter { it.tyyppi?.nimi == OpintosuoritusTyyppiEnum.SATEILYSUOJAKOULUTUS }
+            .mapNotNull { it.opintopisteet }
+            .sum()
+        dto.sateilusuojakoulutusVaadittu =
+            opintoopas?.erikoisalanVaatimaSateilysuojakoulutustenVahimmaismaara
+        dto.johtamiskoulutusSuoritettu = opintosuoritukset.nykyiset
+            .filter { it.tyyppi?.nimi == OpintosuoritusTyyppiEnum.JOHTAMISOPINTO }
+            .mapNotNull { it.opintopisteet }
+            .sum()
+        dto.johtamiskoulutusVaadittu =
+            opintoopas?.erikoisalanVaatimaJohtamisopintojenVahimmaismaara
+        dto.kuulustelut = opintosuoritukset.nykyiset
+            .filter { it.tyyppi?.nimi == OpintosuoritusTyyppiEnum.VALTAKUNNALLINEN_KUULUSTELU }
+            .map(opintosuoritusMapper::toDto)
+    }
+
+    private fun lisaaKoejaksotiedot(
+        dto: ValmistumispyynnonTarkistusDTO,
+        opintooikeusId: Long,
+        opintosuoritukset: OlennaisetOpintosuoritukset
+    ) {
+        opintosuoritukset.nykyiset.firstOrNull {
+            it.tyyppi?.nimi == OpintosuoritusTyyppiEnum.KOEJAKSO && it.hyvaksytty
+        }?.let { dto.koejaksoHyvaksyttyPvm = it.suorituspaiva }
+        koejaksonVastuuhenkilonArvioRepository.findByOpintooikeusId(opintooikeusId)
+            .orElse(null)
+            ?.takeIf { it.vastuuhenkiloHyvaksynyt }
+            ?.let { dto.koejaksoHyvaksyttyPvm = it.vastuuhenkilonKuittausaika }
+    }
+
+    private fun lisaaVanhentumistiedot(
+        dto: ValmistumispyynnonTarkistusDTO,
+        opintooikeus: Opintooikeus
+    ) {
+        val erikoisalaTyyppi = opintooikeus.erikoisala?.tyyppi
+            ?: throw EntityNotFoundException(ERIKOISALA_NOT_FOUND_ERROR)
+        val vanhentuneetSuoritukset = vanhentumisService.haeVanhentuneetSuoritukset(
+            opintooikeus.id.required(),
+            erikoisalaTyyppi
+        )
+        dto.suoritustenTila = ValmistumispyyntoSuoritustenTilaDTO(
+            erikoisalaTyyppi = erikoisalaTyyppi,
+            vanhojaTyoskentelyjaksojaOrSuorituksiaExists =
+                vanhentuneetSuoritukset.vanhojaTyoskentelyjaksojaOrSuorituksiaExists,
+            kuulusteluVanhentunut = vanhentuneetSuoritukset.kuulusteluVanhentunut
+        )
+    }
+
+    private fun haeOlennaisetOpintosuoritukset(
+        opintooikeus: Opintooikeus
+    ): OlennaisetOpintosuoritukset {
+        val nykyisetOpintosuoritukset = opintosuoritusRepository
+            .findAllByOpintooikeusId(opintooikeus.id.required())
+            .filter {
+                if (opintooikeus.onYek()) {
+                    it.tyyppi?.nimi in YEK_OPINTOSUORITUSTYYPIT
+                } else {
+                    it.tyyppi?.nimi !in YEK_OPINTOSUORITUSTYYPIT
+                }
+            }
+        val yekOpintosuoritukset = if (opintooikeus.onYek()) {
+            emptyList()
+        } else {
+            opintosuoritusRepository.findAllByErikoistuvaLaakariIdAndErikoisalaId(
+                opintooikeus.erikoistuvaLaakari?.id.required(),
+                YEK_ERIKOISALA_ID
+            )
+        }
+        return OlennaisetOpintosuoritukset(nykyisetOpintosuoritukset, yekOpintosuoritukset)
+    }
+
+    private fun haeOpintooikeus(id: Long) = opintooikeusRepository.findByIdOrNull(id)
+        ?: throw EntityNotFoundException(OPINTOOIKEUS_NOT_FOUND_ERROR)
+
+    private fun Opintooikeus.onYek() = erikoisala?.id == YEK_ERIKOISALA_ID
+
+    private data class OlennaisetOpintosuoritukset(
+        val nykyiset: List<Opintosuoritus>,
+        val yek: List<Opintosuoritus>
+    )
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonTilaService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonTilaService.kt
@@ -1,0 +1,149 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
+import fi.elsapalvelu.elsa.domain.kayttaja.Kayttaja
+import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto.Companion.fromValmistumispyyntoArvioija
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto.Companion.fromValmistumispyyntoArvioijaHyvaksyja
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto.Companion.fromValmistumispyyntoHyvaksyja
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto.Companion.fromValmistumispyyntoVirkailija
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonHyvaksyjaRole
+import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoListItemDTO
+import org.springframework.stereotype.Component
+
+@Component
+class ValmistumispyynnonTilaService {
+
+    fun haeTilaOsaamisenArvioijalle(
+        valmistumispyynto: Valmistumispyynto
+    ): ValmistumispyynnonTila {
+        val avoin = valmistumispyynto.erikoistujanKuittausaika != null &&
+            valmistumispyynto.vastuuhenkiloOsaamisenArvioijaKuittausaika == null &&
+            valmistumispyynto.vastuuhenkiloOsaamisenArvioijaPalautusaika == null
+        return fromValmistumispyyntoArvioija(valmistumispyynto, avoin)
+    }
+
+    fun haeTilaVirkailijalle(valmistumispyynto: Valmistumispyynto): ValmistumispyynnonTila {
+        val avoin = valmistumispyynto.erikoistujanKuittausaika != null &&
+            (valmistumispyynto.isYek() ||
+                valmistumispyynto.vastuuhenkiloOsaamisenArvioijaKuittausaika != null) &&
+            valmistumispyynto.virkailijanKuittausaika == null &&
+            valmistumispyynto.virkailijanPalautusaika == null
+        return fromValmistumispyyntoVirkailija(valmistumispyynto, avoin)
+    }
+
+    fun haeTilaHyvaksyjalle(valmistumispyynto: Valmistumispyynto): ValmistumispyynnonTila {
+        val avoin = valmistumispyynto.virkailijanKuittausaika != null &&
+            valmistumispyynto.vastuuhenkiloHyvaksyjaKuittausaika == null &&
+            valmistumispyynto.vastuuhenkiloHyvaksyjaPalautusaika == null
+        return fromValmistumispyyntoHyvaksyja(valmistumispyynto, avoin)
+    }
+
+    fun mapVastuuhenkilonListItem(
+        valmistumispyynto: Valmistumispyynto,
+        roolit: List<Pair<Long, ValmistumispyynnonHyvaksyjaRole>>,
+        avoin: Boolean
+    ): ValmistumispyyntoListItemDTO {
+        val rooli = if (valmistumispyynto.isYek()) {
+            ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_HYVAKSYJA
+        } else {
+            roolit.first { it.first == valmistumispyynto.opintooikeus?.erikoisala?.id }.second
+        }
+        return mapListItem(valmistumispyynto, rooli, avoin)
+    }
+
+    fun mapVirkailijanListItem(
+        valmistumispyynto: Valmistumispyynto,
+        avoin: Boolean
+    ): ValmistumispyyntoListItemDTO = mapListItem(
+        valmistumispyynto,
+        ValmistumispyynnonHyvaksyjaRole.VIRKAILIJA,
+        avoin
+    )
+
+    fun haeVastuuhenkilonRoolit(
+        kayttaja: Kayttaja,
+        yek: Boolean = false
+    ): List<Pair<Long, ValmistumispyynnonHyvaksyjaRole>> =
+        kayttaja.yliopistotAndErikoisalat.mapNotNull { yliopistoErikoisala ->
+            val tehtavat = yliopistoErikoisala.vastuuhenkilonTehtavat.map { it.nimi }
+            val rooli = when {
+                yek && tehtavat.contains(VastuuhenkilonTehtavatyyppiEnum.YEK_VALMISTUMINEN) ->
+                    ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_OSAAMISEN_ARVIOIJA_HYVAKSYJA
+
+                yek -> null
+                tehtavat.containsAll(
+                    listOf(
+                        VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_OSAAMISEN_ARVIOINTI,
+                        VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA
+                    )
+                ) -> ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_OSAAMISEN_ARVIOIJA_HYVAKSYJA
+
+                tehtavat.contains(VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_OSAAMISEN_ARVIOINTI) ->
+                    ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_OSAAMISEN_ARVIOIJA
+
+                tehtavat.contains(VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA) ->
+                    ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_HYVAKSYJA
+
+                else -> null
+            }
+            rooli?.let {
+                Pair(
+                    if (yek) YEK_ERIKOISALA_ID else yliopistoErikoisala.erikoisala?.id.required(),
+                    it
+                )
+            }
+        }
+
+    private fun mapListItem(
+        valmistumispyynto: Valmistumispyynto,
+        rooli: ValmistumispyynnonHyvaksyjaRole,
+        avoin: Boolean
+    ): ValmistumispyyntoListItemDTO {
+        val tila = when (rooli) {
+            ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_OSAAMISEN_ARVIOIJA ->
+                fromValmistumispyyntoArvioija(valmistumispyynto, avoin)
+
+            ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_HYVAKSYJA ->
+                fromValmistumispyyntoHyvaksyja(valmistumispyynto, avoin)
+
+            ValmistumispyynnonHyvaksyjaRole.VIRKAILIJA ->
+                fromValmistumispyyntoVirkailija(valmistumispyynto, avoin)
+
+            ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_OSAAMISEN_ARVIOIJA_HYVAKSYJA ->
+                fromValmistumispyyntoArvioijaHyvaksyja(valmistumispyynto, avoin)
+        }
+        return ValmistumispyyntoListItemDTO(
+            id = valmistumispyynto.id,
+            erikoistujanNimi =
+                valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.getNimi(),
+            tila = tila,
+            tapahtumanAjankohta = haePalautusaika(valmistumispyynto, tila)
+                ?: valmistumispyynto.muokkauspaiva,
+            isAvoinForCurrentKayttaja = avoin,
+            rooli = rooli
+        )
+    }
+
+    private fun haePalautusaika(
+        valmistumispyynto: Valmistumispyynto,
+        tila: ValmistumispyynnonTila
+    ) = when (tila) {
+        ValmistumispyynnonTila.VASTUUHENKILON_TARKASTUS_PALAUTETTU ->
+            valmistumispyynto.vastuuhenkiloOsaamisenArvioijaPalautusaika
+
+        ValmistumispyynnonTila.VIRKAILIJAN_TARKASTUS_PALAUTETTU ->
+            valmistumispyynto.virkailijanPalautusaika
+
+        ValmistumispyynnonTila.VASTUUHENKILON_HYVAKSYNTA_PALAUTETTU ->
+            valmistumispyynto.vastuuhenkiloHyvaksyjaPalautusaika
+
+        else -> null
+    }
+
+    private fun Valmistumispyynto.isYek() =
+        opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonVanhentumisService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonVanhentumisService.kt
@@ -1,0 +1,59 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusTyyppiEnum
+import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
+import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
+import fi.elsapalvelu.elsa.repository.koulutus.OpintosuoritusRepository
+import fi.elsapalvelu.elsa.repository.tyoskentely.TyoskentelyjaksoRepository
+import fi.elsapalvelu.elsa.service.dto.suoritteet.VanhentuneetSuorituksetDTO
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDate
+
+private const val KUULUSTELUN_VOIMASSAOLO_VUODET = 4L
+private const val LAAKETIETEEN_KOULUTUKSEN_VOIMASSAOLO_VUODET = 10L
+private const val HAMMASLAAKETIETEEN_KOULUTUKSEN_VOIMASSAOLO_VUODET = 6L
+
+@Service
+class ValmistumispyynnonVanhentumisService(
+    private val tyoskentelyjaksoRepository: TyoskentelyjaksoRepository,
+    private val opintosuoritusRepository: OpintosuoritusRepository,
+    private val clock: Clock
+) {
+
+    @Transactional(readOnly = true)
+    fun haeVanhentuneetSuoritukset(
+        opintooikeusId: Long,
+        erikoisalaTyyppi: ErikoisalaTyyppi
+    ): VanhentuneetSuorituksetDTO {
+        val voimassaoloVuodet = when (erikoisalaTyyppi) {
+            ErikoisalaTyyppi.LAAKETIEDE -> LAAKETIETEEN_KOULUTUKSEN_VOIMASSAOLO_VUODET
+            else -> HAMMASLAAKETIETEEN_KOULUTUKSEN_VOIMASSAOLO_VUODET
+        }
+        val vanhentumispaiva = LocalDate.now(clock).minusYears(voimassaoloVuodet)
+        val onkoVanhentuneitaTyoskentelyjaksoja = tyoskentelyjaksoRepository
+            .findAllByOpintooikeusId(opintooikeusId)
+            .asSequence()
+            .filter { it.kaytannonKoulutus != KaytannonKoulutusTyyppi.TERVEYSKESKUSTYO }
+            .any { it.alkamispaiva?.isBefore(vanhentumispaiva) == true }
+
+        val opintosuoritukset = opintosuoritusRepository.findAllByOpintooikeusId(opintooikeusId)
+        val onkoVanhentuneitaSuorituksia = opintosuoritukset
+            .asSequence()
+            .filter { it.tyyppi?.nimi != OpintosuoritusTyyppiEnum.VALTAKUNNALLINEN_KUULUSTELU }
+            .any { it.suorituspaiva?.isBefore(vanhentumispaiva) == true }
+        val kuulustelunVanhentumispaiva =
+            LocalDate.now(clock).minusYears(KUULUSTELUN_VOIMASSAOLO_VUODET)
+        val onkoKuulusteluVanhentunut = opintosuoritukset
+            .asSequence()
+            .filter { it.tyyppi?.nimi == OpintosuoritusTyyppiEnum.VALTAKUNNALLINEN_KUULUSTELU }
+            .any { it.suorituspaiva?.isBefore(kuulustelunVanhentumispaiva) == true }
+
+        return VanhentuneetSuorituksetDTO(
+            vanhojaTyoskentelyjaksojaOrSuorituksiaExists =
+                onkoVanhentuneitaTyoskentelyjaksoja || onkoVanhentuneitaSuorituksia,
+            kuulusteluVanhentunut = onkoKuulusteluVanhentunut
+        )
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonViimeistelyService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonViimeistelyService.kt
@@ -1,0 +1,73 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
+import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
+import fi.elsapalvelu.elsa.domain.valmistuminen.ValmistumispyynnonTarkistus
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiService
+import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
+import fi.elsapalvelu.elsa.service.mapper.valmistuminen.ValmistumispyynnonTarkistusMapper
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class ValmistumispyynnonViimeistelyService(
+    private val asiakirjojenLuontiService: ValmistumispyynnonAsiakirjojenLuontiService,
+    private val tarkistusService: ValmistumispyynnonTarkistusService,
+    private val tarkistusMapper: ValmistumispyynnonTarkistusMapper,
+    private val ilmoitusService: ValmistumispyynnonIlmoitusService,
+    private val arkistointiService: ArkistointiService
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun viimeistele(
+        valmistumispyyntoId: Long,
+        tarkistus: ValmistumispyynnonTarkistus,
+        valmistumispyynto: Valmistumispyynto,
+        yliopisto: YliopistoEnum?
+    ) {
+        log.info("Luodaan PDF:t [valmistumispyyntoId=$valmistumispyyntoId]")
+        val tarkistusDTO = tarkistusService.taydenna(tarkistusMapper.toDto(tarkistus))
+        val asiakirjat = asiakirjojenLuontiService.luo(tarkistusDTO, valmistumispyynto)
+        log.info("PDF:t luotu [valmistumispyyntoId=$valmistumispyyntoId]")
+        ilmoitusService.lahetaIlmoitusHyvaksynnasta(valmistumispyynto)
+        log.info("Hyvaksynta-sahkoposti lahetetty [valmistumispyyntoId=$valmistumispyyntoId]")
+
+        log.info("Tarkistetaan arkistointi [valmistumispyyntoId=$valmistumispyyntoId, yliopisto=$yliopisto]")
+        if (!onkoArkistointiKaytossa(yliopisto)) {
+            log.info(
+                "Arkistointi ei kaytossa " +
+                    "[valmistumispyyntoId=$valmistumispyyntoId, yliopisto=$yliopisto]"
+            )
+            return
+        }
+
+        log.info("Arkistointi kaytossa, muodostetaan sahke [valmistumispyyntoId=$valmistumispyyntoId]")
+        val sahke = arkistointiService.muodostaSahke(
+            valmistumispyynto.opintooikeus,
+            asiakirjat,
+            caseId = valmistumispyynto.id.required().toString(),
+            tarkastaja = valmistumispyynto.virkailija?.user?.getName(),
+            tarkastusPaiva = valmistumispyynto.virkailijanKuittausaika,
+            hyvaksyja = valmistumispyynto.vastuuhenkiloHyvaksyja?.user?.getName(),
+            hyvaksymisPaiva = valmistumispyynto.vastuuhenkiloHyvaksyjaKuittausaika,
+            yliopisto = yliopisto,
+            caseType = CaseType.VALMISTUMINEN
+        )
+        val yek = valmistumispyynto.opintooikeus?.erikoisala.required().id == YEK_ERIKOISALA_ID
+        arkistointiService.laheta(
+            yliopisto = yliopisto.required(),
+            filePath = sahke.zipFilePath,
+            caseType = CaseType.VALMISTUMINEN,
+            yek = yek,
+            caseId = valmistumispyyntoId.toString(),
+            erikoistujanNimi = valmistumispyynto.opintooikeus?.erikoistuvaLaakari
+                ?.kayttaja?.user?.getName()
+        )
+        log.info("Sahke muodostettu ja lahetetty [valmistumispyyntoId=$valmistumispyyntoId, yek=$yek]")
+    }
+
+    fun onkoArkistointiKaytossa(yliopisto: YliopistoEnum?): Boolean =
+        arkistointiService.onKaytossa(yliopisto.required(), CaseType.VALMISTUMINEN)
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonYhteenvetoPdfService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonYhteenvetoPdfService.kt
@@ -1,0 +1,298 @@
+package fi.elsapalvelu.elsa.service.impl.valmistuminen
+
+import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
+import fi.elsapalvelu.elsa.domain.kayttaja.AsiakirjaData
+import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi
+import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusTyyppiEnum
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
+import fi.elsapalvelu.elsa.extensions.format
+import fi.elsapalvelu.elsa.extensions.toDays
+import fi.elsapalvelu.elsa.extensions.toMonths
+import fi.elsapalvelu.elsa.extensions.toYears
+import fi.elsapalvelu.elsa.repository.kayttaja.AsiakirjaRepository
+import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyyntoRepository
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.arviointi.ArviointiasteikkoService
+import fi.elsapalvelu.elsa.service.dto.tyoskentely.TyoskentelyjaksotTilastotDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyynnonTarkistusDTO
+import fi.elsapalvelu.elsa.service.koulutus.OpintosuoritusService
+import fi.elsapalvelu.elsa.service.koulutus.TeoriakoulutusService
+import fi.elsapalvelu.elsa.service.tyoskentely.TyoskentelyjaksoService
+import fi.elsapalvelu.elsa.service.valmistuminen.PdfService
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.thymeleaf.context.Context
+import java.io.ByteArrayOutputStream
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.Period
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@Service
+class ValmistumispyynnonYhteenvetoPdfService(
+    private val pdfService: PdfService,
+    private val asiakirjaRepository: AsiakirjaRepository,
+    private val valmistumispyyntoRepository: ValmistumispyyntoRepository,
+    private val tyoskentelyjaksoService: TyoskentelyjaksoService,
+    private val teoriakoulutusService: TeoriakoulutusService,
+    private val arviointiasteikkoService: ArviointiasteikkoService,
+    private val opintosuoritusService: OpintosuoritusService,
+    private val arviointitietoService: ValmistumispyynnonArviointitietoService
+) {
+
+    fun luo(
+        tarkistus: ValmistumispyynnonTarkistusDTO,
+        valmistumispyynto: Valmistumispyynto
+    ): Asiakirja = tallenna(
+        valmistumispyynto = valmistumispyynto,
+        template = "pdf/valmistumisenyhteenveto.html",
+        tiedostonimenAlku = "valmistumisen_yhteenveto",
+        context = luoContext(tarkistus, valmistumispyynto)
+    )
+
+    fun luoYek(
+        tarkistus: ValmistumispyynnonTarkistusDTO,
+        valmistumispyynto: Valmistumispyynto
+    ): Asiakirja = tallenna(
+        valmistumispyynto = valmistumispyynto,
+        template = "pdf/valmistumisenyhteenveto_yek.html",
+        tiedostonimenAlku = "valmistumisen_yhteenveto_yek",
+        context = luoYekContext(tarkistus, valmistumispyynto)
+    )
+
+    private fun luoContext(
+        tarkistus: ValmistumispyynnonTarkistusDTO,
+        valmistumispyynto: Valmistumispyynto
+    ) = Context(SUOMEN_LOCALE).apply {
+        lisaaTarkistusmuuttujat(tarkistus)
+        setVariable("sateilusuojakoulutusSuoritettu", tarkistus.sateilusuojakoulutusSuoritettu)
+        setVariable("sateilusuojakoulutusVaadittu", tarkistus.sateilusuojakoulutusVaadittu)
+        setVariable("johtamiskoulutusSuoritettu", tarkistus.johtamiskoulutusSuoritettu)
+        setVariable("johtamiskoulutusVaadittu", tarkistus.johtamiskoulutusVaadittu)
+        setVariable("virkailijanYhteenveto", tarkistus.virkailijanYhteenveto)
+
+        valmistumispyynto.opintooikeus?.let { opintooikeus ->
+            val tilastot = tyoskentelyjaksoService.getTilastot(opintooikeus)
+            lisaaTyoskentelytilastot(tilastot)
+
+            val koulutusYhteensa = tilastot.kaytannonKoulutus.sumOf { it.suoritettu }
+            tilastot.kaytannonKoulutus.forEach { koulutus ->
+                lisaaKaytannonKoulutus(
+                    koulutus.kaytannonKoulutus,
+                    koulutus.suoritettu,
+                    koulutusYhteensa
+                )
+            }
+
+            setVariable(
+                "tyoskentelyjaksot",
+                tyoskentelyjaksoService.findAllByOpintooikeusId(opintooikeus.id.required())
+                    .sortedByDescending { it.alkamispaiva }
+            )
+            setVariable(
+                "tyoskentelyjaksotSuoritettu",
+                tilastot.tyoskentelyjaksot.groupBy { it.id }
+                    .mapValues { (_, jaksot) ->
+                        paivatAjanjaksoksi(jaksot.sumOf { it.suoritettu }).format()
+                    }
+            )
+
+            val teoriakoulutukset = teoriakoulutusService.findAll(opintooikeus.id.required())
+            setVariable("teoriakoulutukset", teoriakoulutukset)
+            setVariable(
+                "teoriakoulutusSuoritettuYhteensa",
+                teoriakoulutukset.mapNotNull { it.erikoistumiseenHyvaksyttavaTuntimaara }.sum()
+            )
+            setVariable(
+                "teoriakoulutusVaadittu",
+                opintooikeus.opintoopas?.erikoisalanVaatimaTeoriakoulutustenVahimmaismaara
+            )
+            setVariable(
+                "arvioinninKategoriat",
+                arviointitietoService.haeKategoriat(opintooikeus.id.required(), true)
+            )
+            setVariable(
+                "arviointiasteikonTasot",
+                arviointiasteikkoService.findByOpintooikeusId(opintooikeus.id.required())?.tasot
+            )
+        }
+    }
+
+    private fun luoYekContext(
+        tarkistus: ValmistumispyynnonTarkistusDTO,
+        valmistumispyynto: Valmistumispyynto
+    ) = Context(SUOMEN_LOCALE).apply {
+        lisaaTarkistusmuuttujat(tarkistus)
+
+        valmistumispyynto.opintooikeus?.let { opintooikeus ->
+            val tilastot = tyoskentelyjaksoService.getTilastot(opintooikeus)
+            lisaaYekTyoskentelytilastot(tilastot)
+            val tyoskentelyjaksot =
+                tyoskentelyjaksoService.findAllByOpintooikeusId(opintooikeus.id.required())
+            setVariable(
+                "tyoskentelyjaksot",
+                tyoskentelyjaksot.sortedByDescending { it.alkamispaiva }
+            )
+            setVariable(
+                "tyoskentelyjaksotSuoritettu",
+                tilastot.tyoskentelyjaksot.groupBy { it.id }
+                    .mapValues { (_, jaksot) ->
+                        paivatAjanjaksoksi(jaksot.sumOf { it.suoritettu }).format()
+                    }
+            )
+            setVariable(
+                "laakarikoulutusSuoritettuSuomiTaiBelgia",
+                opintooikeus.erikoistuvaLaakari?.laakarikoulutusSuoritettuSuomiTaiBelgia
+            )
+
+            val opintosuoritukset =
+                opintosuoritusService.getOpintosuorituksetByOpintooikeusIdAndTyyppi(
+                opintooikeus.id.required(),
+                OpintosuoritusTyyppiEnum.YEK_TEORIAKOULUTUS
+            )
+            setVariable("teoriakoulutukset", opintosuoritukset.opintosuoritukset)
+        }
+    }
+
+    private fun Context.lisaaTarkistusmuuttujat(tarkistus: ValmistumispyynnonTarkistusDTO) {
+        setVariable("tarkistus", tarkistus)
+        setVariable("teoriakoulutusSuoritettu", tarkistus.teoriakoulutusSuoritettu)
+        setVariable("teoriakoulutusVaadittu", tarkistus.teoriakoulutusVaadittu)
+    }
+
+    private fun Context.lisaaTyoskentelytilastot(tilastot: TyoskentelyjaksotTilastotDTO) {
+        lisaaYhteisetTyoskentelytilastot(tilastot)
+        val koulutustyypit = tilastot.koulutustyypit
+        setVariable(
+            "yliopistosairaalaSuoritettu",
+            paivatAjanjaksoksi(koulutustyypit.yliopistosairaalaSuoritettu).format()
+        )
+        setVariable(
+            "yliopistosairaalaVaadittuVahintaan",
+            paivatAjanjaksoksi(koulutustyypit.yliopistosairaalaVaadittuVahintaan).format()
+        )
+        setVariable(
+            "yliopistosairaaloidenUlkopuolinenSuoritettu",
+            paivatAjanjaksoksi(koulutustyypit.yliopistosairaaloidenUlkopuolinenSuoritettu).format()
+        )
+        setVariable(
+            "yliopistosairaaloidenUlkopuolinenVaadittuVahintaan",
+            paivatAjanjaksoksi(
+                koulutustyypit.yliopistosairaaloidenUlkopuolinenVaadittuVahintaan
+            ).format()
+        )
+    }
+
+    private fun Context.lisaaYekTyoskentelytilastot(tilastot: TyoskentelyjaksotTilastotDTO) {
+        lisaaYhteisetTyoskentelytilastot(tilastot)
+        val koulutustyypit = tilastot.koulutustyypit
+        setVariable(
+            "sairaalaSuoritettu",
+            paivatAjanjaksoksi(koulutustyypit.yliopistosairaalaSuoritettu).format()
+        )
+        setVariable(
+            "sairaalaVaadittuVahintaan",
+            paivatAjanjaksoksi(koulutustyypit.yliopistosairaalaVaadittuVahintaan).format()
+        )
+        setVariable(
+            "muuSuoritettu",
+            paivatAjanjaksoksi(koulutustyypit.yliopistosairaaloidenUlkopuolinenSuoritettu).format()
+        )
+        setVariable(
+            "muuVaadittuVahintaan",
+            paivatAjanjaksoksi(
+                koulutustyypit.yliopistosairaaloidenUlkopuolinenVaadittuVahintaan
+            ).format()
+        )
+    }
+
+    private fun Context.lisaaYhteisetTyoskentelytilastot(
+        tilastot: TyoskentelyjaksotTilastotDTO
+    ) {
+        val koulutustyypit = tilastot.koulutustyypit
+        setVariable(
+            "tyoskentelyaikaYhteensa",
+            paivatAjanjaksoksi(koulutustyypit.yhteensaSuoritettu).format()
+        )
+        setVariable(
+            "arvioErikoistumiseenHyvaksyttavista",
+            paivatAjanjaksoksi(tilastot.arvioErikoistumiseenHyvaksyttavista).format()
+        )
+        setVariable(
+            "arvioPuuttuvastaKoulutuksesta",
+            paivatAjanjaksoksi(tilastot.arvioPuuttuvastaKoulutuksesta).format()
+        )
+        setVariable(
+            "terveyskeskusSuoritettu",
+            paivatAjanjaksoksi(koulutustyypit.terveyskeskusSuoritettu).format()
+        )
+        setVariable(
+            "terveyskeskusVaadittuVahintaan",
+            paivatAjanjaksoksi(koulutustyypit.terveyskeskusVaadittuVahintaan).format()
+        )
+        setVariable(
+            "yhteensaSuoritettu",
+            paivatAjanjaksoksi(koulutustyypit.yhteensaSuoritettu).format()
+        )
+        setVariable(
+            "yhteensaVaadittuVahintaan",
+            paivatAjanjaksoksi(koulutustyypit.yhteensaVaadittuVahintaan).format()
+        )
+    }
+
+    private fun Context.lisaaKaytannonKoulutus(
+        tyyppi: KaytannonKoulutusTyyppi?,
+        suoritettu: Double,
+        yhteensa: Double
+    ) {
+        val (suoritettuMuuttuja, osuusMuuttuja) = when (tyyppi) {
+            KaytannonKoulutusTyyppi.OMAN_ERIKOISALAN_KOULUTUS ->
+                "omaErikoisalaSuoritettu" to "omaErikoisalaOsuus"
+            KaytannonKoulutusTyyppi.OMAA_ERIKOISALAA_TUKEVA_KOULUTUS ->
+                "omaaErikoisalaaTukevaSuoritettu" to "omaErikoisalaaTukevaOsuus"
+            KaytannonKoulutusTyyppi.TUTKIMUSTYO ->
+                "tutkimustyoSuoritettu" to "tutkimustyoOsuus"
+            KaytannonKoulutusTyyppi.TERVEYSKESKUSTYO ->
+                "terveyskeskustyoSuoritettu" to "terveyskeskustyoOsuus"
+            null -> return
+        }
+        setVariable(suoritettuMuuttuja, paivatAjanjaksoksi(suoritettu).format())
+        setVariable(osuusMuuttuja, (suoritettu / yhteensa * PROSENTTIA).toInt())
+    }
+
+    private fun tallenna(
+        valmistumispyynto: Valmistumispyynto,
+        template: String,
+        tiedostonimenAlku: String,
+        context: Context
+    ): Asiakirja {
+        val outputStream = ByteArrayOutputStream()
+        pdfService.luoPdf(template, context, outputStream)
+        val aikaleima = LocalDate.now().format(DateTimeFormatter.ofPattern(PAIVAMAARAFORMAATTI))
+        val asiakirja = asiakirjaRepository.save(
+            Asiakirja(
+                opintooikeus = valmistumispyynto.opintooikeus,
+                nimi = "${tiedostonimenAlku}_${aikaleima}.pdf",
+                tyyppi = MediaType.APPLICATION_PDF_VALUE,
+                lisattypvm = LocalDateTime.now(),
+                asiakirjaData = AsiakirjaData(data = outputStream.toByteArray())
+            )
+        )
+        valmistumispyynto.yhteenvetoAsiakirja = asiakirja
+        valmistumispyyntoRepository.save(valmistumispyynto)
+        return asiakirja
+    }
+
+    private fun paivatAjanjaksoksi(paivat: Double) = Period.of(
+        paivat.toYears(),
+        paivat.toMonths(),
+        paivat.toDays()
+    )
+
+    private companion object {
+        const val PAIVAMAARAFORMAATTI = "yyyyMMdd"
+        const val PROSENTTIA = 100
+        val SUOMEN_LOCALE: Locale = Locale.forLanguageTag("fi")
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyyntoServiceImpl.kt
@@ -1,176 +1,88 @@
 package fi.elsapalvelu.elsa.service.impl.valmistuminen
 
-import fi.elsapalvelu.elsa.required
-
-import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonHyvaksyjaRole
-import java.time.LocalDate
-import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
-import fi.elsapalvelu.elsa.config.ApplicationProperties
 import fi.elsapalvelu.elsa.config.YEK_ERIKOISALA_ID
-import fi.elsapalvelu.elsa.domain.*
-import fi.elsapalvelu.elsa.domain.koejakso.*
-import fi.elsapalvelu.elsa.domain.tyoskentely.*
-import fi.elsapalvelu.elsa.domain.arviointi.*
-import fi.elsapalvelu.elsa.domain.suoritteet.*
-import fi.elsapalvelu.elsa.domain.koulutus.*
-import fi.elsapalvelu.elsa.domain.seuranta.*
-import fi.elsapalvelu.elsa.domain.valmistuminen.*
-import fi.elsapalvelu.elsa.domain.kayttaja.*
-import fi.elsapalvelu.elsa.domain.perustiedot.*
-import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto.Companion.fromValmistumispyyntoArvioija
-import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto.Companion.fromValmistumispyyntoArvioijaHyvaksyja
+import fi.elsapalvelu.elsa.domain.perustiedot.ErikoisalaTyyppi
+import fi.elsapalvelu.elsa.domain.perustiedot.VastuuhenkilonTehtavatyyppiEnum
+import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
 import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto.Companion.fromValmistumispyyntoErikoistuja
-import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto.Companion.fromValmistumispyyntoHyvaksyja
-import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto.Companion.fromValmistumispyyntoVirkailija
-import fi.elsapalvelu.elsa.domain.koejakso.*
-import fi.elsapalvelu.elsa.domain.tyoskentely.*
-import fi.elsapalvelu.elsa.domain.arviointi.*
-import fi.elsapalvelu.elsa.domain.suoritteet.*
-import fi.elsapalvelu.elsa.domain.koulutus.*
-import fi.elsapalvelu.elsa.domain.seuranta.*
-import fi.elsapalvelu.elsa.domain.valmistuminen.*
-import fi.elsapalvelu.elsa.domain.kayttaja.*
-import fi.elsapalvelu.elsa.domain.perustiedot.*
-import fi.elsapalvelu.elsa.domain.koulutus.OpintosuoritusTyyppiEnum.*
-import fi.elsapalvelu.elsa.domain.tyoskentely.TyoskentelyjaksoTyyppi.*
-import fi.elsapalvelu.elsa.domain.koulutus.KaytannonKoulutusTyyppi.*
-import fi.elsapalvelu.elsa.extensions.format
-import fi.elsapalvelu.elsa.extensions.toDays
-import fi.elsapalvelu.elsa.extensions.toMonths
-import fi.elsapalvelu.elsa.extensions.toYears
-import fi.elsapalvelu.elsa.repository.*
-import fi.elsapalvelu.elsa.repository.koejakso.*
-import fi.elsapalvelu.elsa.repository.tyoskentely.*
-import fi.elsapalvelu.elsa.repository.arviointi.*
-import fi.elsapalvelu.elsa.repository.suoritteet.*
-import fi.elsapalvelu.elsa.repository.koulutus.*
-import fi.elsapalvelu.elsa.repository.seuranta.*
-import fi.elsapalvelu.elsa.repository.valmistuminen.*
-import fi.elsapalvelu.elsa.repository.kayttaja.*
-import fi.elsapalvelu.elsa.repository.perustiedot.*
-import fi.elsapalvelu.elsa.security.VASTUUHENKILO
-import fi.elsapalvelu.elsa.service.*
-import fi.elsapalvelu.elsa.service.koejakso.*
-import fi.elsapalvelu.elsa.service.tyoskentely.*
-import fi.elsapalvelu.elsa.service.arviointi.*
-import fi.elsapalvelu.elsa.service.suoritteet.*
-import fi.elsapalvelu.elsa.service.koulutus.*
-import fi.elsapalvelu.elsa.service.seuranta.*
-import fi.elsapalvelu.elsa.service.valmistuminen.*
-import fi.elsapalvelu.elsa.service.kayttaja.*
-import fi.elsapalvelu.elsa.service.perustiedot.*
-import fi.elsapalvelu.elsa.service.arkistointi.ArkistointiService
-import fi.elsapalvelu.elsa.service.constants.*
+import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyynnonTarkistusRepository
+import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyyntoRepository
+import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.constants.ERIKOISALA_NOT_FOUND_ERROR
 import fi.elsapalvelu.elsa.service.criteria.NimiErikoisalaAndAvoinCriteria
-import fi.elsapalvelu.elsa.service.dto.*
-import fi.elsapalvelu.elsa.service.dto.koejakso.*
-import fi.elsapalvelu.elsa.service.dto.tyoskentely.*
-import fi.elsapalvelu.elsa.service.dto.arviointi.*
-import fi.elsapalvelu.elsa.service.dto.suoritteet.*
-import fi.elsapalvelu.elsa.service.dto.koulutus.*
-import fi.elsapalvelu.elsa.service.dto.seuranta.*
-import fi.elsapalvelu.elsa.service.dto.valmistuminen.*
-import fi.elsapalvelu.elsa.service.dto.kayttaja.*
-import fi.elsapalvelu.elsa.service.dto.perustiedot.*
-import fi.elsapalvelu.elsa.service.dto.arkistointi.CaseType
-import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordProperties
-import fi.elsapalvelu.elsa.service.dto.arkistointi.RecordType.*
 import fi.elsapalvelu.elsa.service.dto.enumeration.ValmistumispyynnonTila
-import fi.elsapalvelu.elsa.service.mail.TransactionalMailService
-import fi.elsapalvelu.elsa.service.mapper.*
-import fi.elsapalvelu.elsa.service.mapper.koejakso.*
-import fi.elsapalvelu.elsa.service.mapper.tyoskentely.*
-import fi.elsapalvelu.elsa.service.mapper.arviointi.*
-import fi.elsapalvelu.elsa.service.mapper.suoritteet.*
-import fi.elsapalvelu.elsa.service.mapper.koulutus.*
-import fi.elsapalvelu.elsa.service.mapper.seuranta.*
-import fi.elsapalvelu.elsa.service.mapper.valmistuminen.*
-import fi.elsapalvelu.elsa.service.mapper.kayttaja.*
-import fi.elsapalvelu.elsa.service.mapper.perustiedot.*
+import fi.elsapalvelu.elsa.service.dto.kayttaja.AsiakirjaDTO
+import fi.elsapalvelu.elsa.service.dto.suoritteet.VanhentuneetSuorituksetDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.UusiValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyynnonTarkistusDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyynnonTarkistusUpdateDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoArviointienTilaDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoHyvaksyntaFormDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoListItemDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoOsaamisenArviointiDTO
+import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoOsaamisenArviointiFormDTO
+import fi.elsapalvelu.elsa.service.kayttaja.ErikoistuvaLaakariService
+import fi.elsapalvelu.elsa.service.mapper.valmistuminen.ValmistumispyynnonTarkistusMapper
+import fi.elsapalvelu.elsa.service.mapper.valmistuminen.ValmistumispyynnonTarkistusUpdateMapper
+import fi.elsapalvelu.elsa.service.mapper.valmistuminen.ValmistumispyyntoMapper
+import fi.elsapalvelu.elsa.service.mapper.valmistuminen.ValmistumispyyntoOsaamisenArviointiMapper
+import fi.elsapalvelu.elsa.service.valmistuminen.ValmistumispyyntoService
 import jakarta.persistence.EntityNotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.data.repository.findByIdOrNull
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
-import org.thymeleaf.context.Context
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.time.*
-import java.time.format.DateTimeFormatter
-import java.util.*
+import java.time.Clock
+import java.time.LocalDate
 
-private const val VANHENTUNUT_KUULUSTELU_YEARS = 4L
-private const val VANHENTUNUT_SUORITUS_YEARS_EL = 10L
-private const val VANHENTUNUT_SUORITUS_YEARS_EHL = 6L
-private const val ARVIOINTI_VAHINTAAN = 4
-
-@Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
+@Suppress("TooManyFunctions") // ValmistumispyyntoService declares 22 operations.
 @Service
 @Transactional
 class ValmistumispyyntoServiceImpl(
     private val valmistumispyyntoRepository: ValmistumispyyntoRepository,
     private val valmistumispyyntoQueryService: ValmistumispyyntoQueryService,
-    private val arvioitavaKokonaisuusRepository: ArvioitavaKokonaisuusRepository,
-    private val suoritusarviointiRepository: SuoritusarviointiRepository,
-    private val kayttajaRepository: KayttajaRepository,
-    private val kayttajaMapper: KayttajaMapper,
     private val valmistumispyyntoMapper: ValmistumispyyntoMapper,
     private val valmistumispyyntoOsaamisenArviointiMapper: ValmistumispyyntoOsaamisenArviointiMapper,
-    private val opintooikeusRepository: OpintooikeusRepository,
-    private val tyoskentelyjaksoRepository: TyoskentelyjaksoRepository,
-    private val tyoskentelyjaksoMapper: TyoskentelyjaksoMapper,
-    private val opintosuoritusRepository: OpintosuoritusRepository,
-    private val transactionalMailService: TransactionalMailService,
-    private val applicationProperties: ApplicationProperties,
     private val clock: Clock,
     private val valmistumispyynnonTarkistusRepository: ValmistumispyynnonTarkistusRepository,
     private val valmistumispyynnonTarkistusMapper: ValmistumispyynnonTarkistusMapper,
     private val valmistumispyynnonTarkistusUpdateMapper: ValmistumispyynnonTarkistusUpdateMapper,
-    private val tyoskentelyjaksoService: TyoskentelyjaksoService,
-    private val terveyskeskuskoulutusjaksonHyvaksyntaRepository: TerveyskeskuskoulutusjaksonHyvaksyntaRepository,
-    private val teoriakoulutusRepository: TeoriakoulutusRepository,
-    private val opintosuoritusMapper: OpintosuoritusMapper,
-    private val koejaksonVastuuhenkilonArvioRepository: KoejaksonVastuuhenkilonArvioRepository,
-    private val pdfService: PdfService,
-    private val asiakirjaRepository: AsiakirjaRepository,
-    private val arkistointiService: ArkistointiService,
-    private val teoriakoulutusService: TeoriakoulutusService,
-    private val suoritusarviointiMapper: SuoritusarviointiMapper,
-    private val arviointiasteikkoService: ArviointiasteikkoService,
-    private val asiakirjaMapper: AsiakirjaMapper,
-    private val koulutussuunnitelmaRepository: KoulutussuunnitelmaRepository,
-    private val suoritemerkintaRepository: SuoritemerkintaRepository,
-    private val suoritteenKategoriaRepository: SuoritteenKategoriaRepository,
-    private val suoritemerkintaMapper: SuoritemerkintaMapper,
-    private val paivakirjamerkintaRepository: PaivakirjamerkintaRepository,
-    private val seurantajaksoService: SeurantajaksoService,
-    private val userRepository: UserRepository,
     private val erikoistuvaLaakariService: ErikoistuvaLaakariService,
-    private val opintosuoritusService: OpintosuoritusService
+    private val vanhentumisService: ValmistumispyynnonVanhentumisService,
+    private val tilaService: ValmistumispyynnonTilaService,
+    private val osapuoliService: ValmistumispyynnonOsapuoliService,
+    private val arviointienTilaService: ValmistumispyynnonArviointienTilaService,
+    private val asiakirjaService: ValmistumispyynnonAsiakirjaService,
+    private val viimeistelyService: ValmistumispyynnonViimeistelyService,
+    private val ilmoitusService: ValmistumispyynnonIlmoitusService,
+    private val tarkistusService: ValmistumispyynnonTarkistusService
 ) : ValmistumispyyntoService {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional(readOnly = true)
     override fun findErikoisalaTyyppiByOpintooikeusId(opintooikeusId: Long): ErikoisalaTyyppi =
-        getOpintooikeus(opintooikeusId).erikoisala?.tyyppi ?: throw EntityNotFoundException(ERIKOISALA_NOT_FOUND_ERROR)
+        osapuoliService.haeOpintooikeus(opintooikeusId).erikoisala?.tyyppi
+            ?: throw EntityNotFoundException(ERIKOISALA_NOT_FOUND_ERROR)
 
     @Transactional(readOnly = true)
     override fun findOneByOpintooikeusId(opintooikeusId: Long): ValmistumispyyntoDTO? {
         val valmistumispyynto = valmistumispyyntoRepository.findByOpintooikeusId(opintooikeusId)
         val tila = fromValmistumispyyntoErikoistuja(valmistumispyynto)
-        val opintooikeus = getOpintooikeus(opintooikeusId)
+        val opintooikeus = osapuoliService.haeOpintooikeus(opintooikeusId)
         val yliopistoId = opintooikeus.yliopisto?.id.required()
         val erikoisalaId = opintooikeus.erikoisala?.id.required()
         val vastuuhenkiloOsaamisenarvioija =
-            if (erikoisalaId != YEK_ERIKOISALA_ID) getVastuuhenkiloOsaamisenArvioija(
+            if (erikoisalaId != YEK_ERIKOISALA_ID) osapuoliService.haeOsaamisenArvioija(
                 yliopistoId,
                 erikoisalaId
             ) else null
-        val vastuuhenkiloHyvaksyja = getVastuuhenkiloHyvaksyja(yliopistoId, erikoisalaId)
+        val vastuuhenkiloHyvaksyja = osapuoliService.haeHyvaksyja(
+            yliopistoId,
+            erikoisalaId
+        )
         val valmistumispyyntoDTO =
             valmistumispyynto?.let { valmistumispyyntoMapper.toDto(it) } ?: ValmistumispyyntoDTO().apply {
                 erikoistujanLaillistamispaiva = opintooikeus.erikoistuvaLaakari?.laillistamispaiva
@@ -187,7 +99,7 @@ class ValmistumispyyntoServiceImpl(
             vastuuhenkiloOsaamisenArvioijaNimike = vastuuhenkiloOsaamisenarvioija?.nimike
             vastuuhenkiloHyvaksyjaNimi = vastuuhenkiloHyvaksyja.getNimi()
             vastuuhenkiloHyvaksyjaNimike = vastuuhenkiloHyvaksyja.nimike
-            arkistoitava = arkistointiService.onKaytossa(opintooikeus.yliopisto?.nimi.required(), CaseType.VALMISTUMINEN)
+            arkistoitava = viimeistelyService.onkoArkistointiKaytossa(opintooikeus.yliopisto?.nimi)
         }
     }
 
@@ -195,42 +107,19 @@ class ValmistumispyyntoServiceImpl(
     override fun findSuoritustenTila(
         opintooikeusId: Long,
         erikoisalaTyyppi: ErikoisalaTyyppi
-    ): VanhentuneetSuorituksetDTO {
-        val vanhentunutSuoritusYears =
-            if (erikoisalaTyyppi == ErikoisalaTyyppi.LAAKETIEDE) VANHENTUNUT_SUORITUS_YEARS_EL
-            else VANHENTUNUT_SUORITUS_YEARS_EHL
-        val vanhojaTyoskentelyjaksojaExists =
-            tyoskentelyjaksoRepository.findAllByOpintooikeusId(opintooikeusId).asSequence().filter {
-                it.kaytannonKoulutus != KaytannonKoulutusTyyppi.TERVEYSKESKUSTYO
-            }.any {
-                it.alkamispaiva?.isBefore(LocalDate.now(clock).minusYears(vanhentunutSuoritusYears)) == true
-            }
-        val opintosuoritukset = opintosuoritusRepository.findAllByOpintooikeusId(opintooikeusId).asSequence()
-        val vanhojaSuorituksiaExists =
-            opintosuoritukset.filter { it.tyyppi?.nimi != OpintosuoritusTyyppiEnum.VALTAKUNNALLINEN_KUULUSTELU }.any {
-                it.suorituspaiva?.isBefore(LocalDate.now(clock).minusYears(vanhentunutSuoritusYears)) == true
-            }
-        val kuulusteluVanhentunut =
-            opintosuoritukset.filter { it.tyyppi?.nimi == OpintosuoritusTyyppiEnum.VALTAKUNNALLINEN_KUULUSTELU }.any {
-                it.suorituspaiva?.isBefore(LocalDate.now(clock).minusYears(VANHENTUNUT_KUULUSTELU_YEARS)) == true
-            }
-
-        return VanhentuneetSuorituksetDTO(
-            vanhojaTyoskentelyjaksojaOrSuorituksiaExists = vanhojaTyoskentelyjaksojaExists || vanhojaSuorituksiaExists,
-            kuulusteluVanhentunut = kuulusteluVanhentunut
-        )
-    }
+    ): VanhentuneetSuorituksetDTO =
+        vanhentumisService.haeVanhentuneetSuoritukset(opintooikeusId, erikoisalaTyyppi)
 
     override fun create(
         opintooikeusId: Long,
         uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO
     ): ValmistumispyyntoDTO {
-        getOpintooikeus(opintooikeusId).let { opintooikeus ->
-            opintooikeus.erikoistuvaLaakari?.kayttaja?.user?.let { user ->
-                user.email = uusiValmistumispyyntoDTO.erikoistujanSahkoposti
-                user.phoneNumber = uusiValmistumispyyntoDTO.erikoistujanPuhelinnumero
-                userRepository.save(user)
-            }
+        osapuoliService.haeOpintooikeus(opintooikeusId).let { opintooikeus ->
+            osapuoliService.paivitaYhteystiedot(
+                opintooikeus.erikoistuvaLaakari?.kayttaja?.user,
+                uusiValmistumispyyntoDTO.erikoistujanSahkoposti,
+                uusiValmistumispyyntoDTO.erikoistujanPuhelinnumero
+            )
             val valmistumispyynto = Valmistumispyynto(
                 opintooikeus = opintooikeus,
                 selvitysVanhentuneistaSuorituksista = uusiValmistumispyyntoDTO.selvitysVanhentuneistaSuorituksista,
@@ -238,16 +127,17 @@ class ValmistumispyyntoServiceImpl(
             )
             valmistumispyyntoRepository.save(valmistumispyynto).let { saved ->
                 if (saved.opintooikeus?.erikoisala?.id != YEK_ERIKOISALA_ID) {
-                    val vastuuhenkiloOsaamisenArvioijaUser = getVastuuhenkiloOsaamisenArvioija(
+                    val vastuuhenkiloOsaamisenArvioijaUser =
+                        osapuoliService.haeOsaamisenArvioija(
                         opintooikeus.yliopisto?.id.required(),
                         opintooikeus.erikoisala?.id.required()
                     ).user.required()
-                    sendMailNotificationUusiValmistumispyynto(vastuuhenkiloOsaamisenArvioijaUser, saved)
-                } else {
-                    sendMailNotificationOdottaaVirkailijanTarkastustaYek(
-                        opintooikeus.yliopisto.required().nimi.required(),
-                        saved.id.required()
+                    ilmoitusService.lahetaIlmoitusUudestaValmistumispyynnosta(
+                        vastuuhenkiloOsaamisenArvioijaUser,
+                        saved
                     )
+                } else {
+                    ilmoitusService.lahetaIlmoitusVirkailijanTarkastuksesta(saved)
                 }
                 return valmistumispyyntoMapper.toDto(saved)
                     .apply { tila = ValmistumispyynnonTila.ODOTTAA_VASTUUHENKILON_TARKASTUSTA }
@@ -259,13 +149,13 @@ class ValmistumispyyntoServiceImpl(
         opintooikeusId: Long,
         uusiValmistumispyyntoDTO: UusiValmistumispyyntoDTO
     ): ValmistumispyyntoDTO {
-        getOpintooikeus(opintooikeusId).let { opintooikeus ->
-            opintooikeus.erikoistuvaLaakari?.kayttaja?.user?.let { user ->
-                user.email = uusiValmistumispyyntoDTO.erikoistujanSahkoposti
-                user.phoneNumber = uusiValmistumispyyntoDTO.erikoistujanPuhelinnumero
-                userRepository.save(user)
-            }
-            getValmistumispyyntoByOpintooikeusId(opintooikeusId).apply {
+        osapuoliService.haeOpintooikeus(opintooikeusId).let { opintooikeus ->
+            osapuoliService.paivitaYhteystiedot(
+                opintooikeus.erikoistuvaLaakari?.kayttaja?.user,
+                uusiValmistumispyyntoDTO.erikoistujanSahkoposti,
+                uusiValmistumispyyntoDTO.erikoistujanPuhelinnumero
+            )
+            osapuoliService.haeValmistumispyyntoOpintooikeudella(opintooikeusId).apply {
                 vastuuhenkiloOsaamisenArvioijaKorjausehdotus = null
                 vastuuhenkiloOsaamisenArvioijaPalautusaika = null
                 erikoistujanKuittausaika = LocalDate.now()
@@ -275,25 +165,22 @@ class ValmistumispyyntoServiceImpl(
                     virkailijanPalautusaika = null
                 } else if (vastuuhenkiloOsaamisenArvioijaKuittausaika != null) {
                     virkailijanPalautusaika = null
-                    sendMailNotificationOdottaaVirkailijanTarkastusta(
-                        opintooikeus.yliopisto.required().nimi.required(),
-                        id.required()
-                    )
+                    ilmoitusService.lahetaIlmoitusVirkailijanTarkastuksesta(this)
                 }
             }.let {
                 valmistumispyyntoRepository.save(it).let { saved ->
                     if (it.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID) {
-                        sendMailNotificationOdottaaVirkailijanTarkastustaYek(
-                            opintooikeus.yliopisto.required().nimi.required(),
-                            saved.id.required()
-                        )
+                        ilmoitusService.lahetaIlmoitusVirkailijanTarkastuksesta(saved)
                     } else if (saved.vastuuhenkiloOsaamisenArvioijaKuittausaika == null) {
                         val vastuuhenkiloOsaamisenArvioijaUser =
-                            getVastuuhenkiloOsaamisenArvioija(
+                            osapuoliService.haeOsaamisenArvioija(
                                 opintooikeus.yliopisto?.id.required(),
                                 opintooikeus.erikoisala?.id.required()
                             ).user.required()
-                        sendMailNotificationUusiValmistumispyynto(vastuuhenkiloOsaamisenArvioijaUser, saved)
+                        ilmoitusService.lahetaIlmoitusUudestaValmistumispyynnosta(
+                            vastuuhenkiloOsaamisenArvioijaUser,
+                            saved
+                        )
                     }
                     return valmistumispyyntoMapper.toDto(saved)
                         .apply { tila = ValmistumispyynnonTila.ODOTTAA_VASTUUHENKILON_TARKASTUSTA }
@@ -308,10 +195,10 @@ class ValmistumispyyntoServiceImpl(
         userId: String,
         osaamisenArviointiDTO: ValmistumispyyntoOsaamisenArviointiFormDTO
     ): ValmistumispyyntoDTO {
-        val kayttaja = getKayttaja(userId)
-        val yliopisto = getYliopisto(kayttaja)
+        val kayttaja = osapuoliService.haeKayttaja(userId)
+        val yliopisto = osapuoliService.haeYliopisto(kayttaja)
 
-        val valmistumispyynto = getValmistumispyyntoByYliopistoIdOrThrow(
+        val valmistumispyynto = osapuoliService.haeValmistumispyynto(
             id,
             kayttaja,
             yliopisto.id.required(),
@@ -323,38 +210,40 @@ class ValmistumispyyntoServiceImpl(
         if (osaamisenArviointiDTO.osaaminenRiittavaValmistumiseen == true) {
             valmistumispyynto.vastuuhenkiloOsaamisenArvioijaKuittausaika = LocalDate.now()
             valmistumispyynto.virkailijanPalautusaika = null
-            sendMailNotificationOdottaaVirkailijanTarkastusta(
-                yliopisto.nimi.required(),
-                valmistumispyynto.id.required()
-            )
+            ilmoitusService.lahetaIlmoitusVirkailijanTarkastuksesta(valmistumispyynto)
         } else {
             valmistumispyynto.vastuuhenkiloOsaamisenArvioijaPalautusaika = LocalDate.now()
             valmistumispyynto.vastuuhenkiloOsaamisenArvioijaKorjausehdotus = osaamisenArviointiDTO.korjausehdotus
             valmistumispyynto.erikoistujanKuittausaika = null
-            sendMailNotificationOsaamisenArvioijaPalauttanut(valmistumispyynto)
+            ilmoitusService.lahetaIlmoitusPalautuksesta(valmistumispyynto)
         }
 
         return valmistumispyyntoMapper.toDto(valmistumispyynto).apply {
-            tila = getValmistumispyynnonTilaForArvioija(valmistumispyynto)
+            tila = tilaService.haeTilaOsaamisenArvioijalle(valmistumispyynto)
         }
     }
 
     override fun updateValmistumispyyntoByHyvaksyjaUserId(id: Long, userId: String, hyvaksyntaFormDTO: ValmistumispyyntoHyvaksyntaFormDTO): ValmistumispyynnonTarkistusDTO {
         log.info("Hyvaksynta-operaatio aloitettu [valmistumispyyntoId=$id]")
 
-        val kayttaja = getKayttaja(userId)
-        val yliopisto = getYliopisto(kayttaja)
+        val kayttaja = osapuoliService.haeKayttaja(userId)
+        val yliopisto = osapuoliService.haeYliopisto(kayttaja)
         log.info("Kayttaja ja yliopisto haettu [valmistumispyyntoId=$id, yliopistoId=${yliopisto.id}]")
 
-        val valmistumispyynto = getValmistumispyyntoByYliopistoIdOrThrow(id, kayttaja, yliopisto.id.required(), VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA)
+        val valmistumispyynto = osapuoliService.haeValmistumispyynto(
+            id,
+            kayttaja,
+            yliopisto.id.required(),
+            VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA
+        )
         log.info("Valmistumispyynto haettu [valmistumispyyntoId=$id]")
 
-        kayttaja?.user?.let { user ->
-            user.email = hyvaksyntaFormDTO.sahkoposti
-            user.phoneNumber = hyvaksyntaFormDTO.puhelinnumero
-            userRepository.save(user)
-            log.info("Kayttajan yhteystiedot paivitetty [valmistumispyyntoId=$id]")
-        }
+        osapuoliService.paivitaYhteystiedot(
+            kayttaja.user,
+            hyvaksyntaFormDTO.sahkoposti,
+            hyvaksyntaFormDTO.puhelinnumero
+        )
+        log.info("Kayttajan yhteystiedot paivitetty [valmistumispyyntoId=$id]")
 
         valmistumispyynto.vastuuhenkiloHyvaksyja = kayttaja
 
@@ -364,7 +253,10 @@ class ValmistumispyyntoServiceImpl(
             valmistumispyynto.vastuuhenkiloHyvaksyjaKorjausehdotus = hyvaksyntaFormDTO.korjausehdotus
             valmistumispyynto.erikoistujanKuittausaika = null
             valmistumispyynto.virkailijanKuittausaika = null
-            sendMailNotificationHyvaksyjaPalauttanut(valmistumispyynto)
+            ilmoitusService.lahetaIlmoitusPalautuksesta(
+                valmistumispyynto,
+                ilmoitaYliopistolle = true
+            )
             log.info("Palautussahkoposti lahetetty [valmistumispyyntoId=$id]")
         } else {
             log.info("Valmistumispyynto hyvaksytaan: tallennetaan kuittausaika [valmistumispyyntoId=$id]")
@@ -373,23 +265,12 @@ class ValmistumispyyntoServiceImpl(
             log.info("Kuittausaika tallennettu [valmistumispyyntoId=$id]")
 
             result.valmistumispyynnonTarkistus?.let {
-                val arkistoitavatAsiakirjat = luoValmistumispyynnonAsiakirjatJaLahetaViesti(
+                viimeistelyService.viimeistele(
                     id,
                     it,
-                    valmistumispyynto
+                    valmistumispyynto,
+                    yliopisto.nimi
                 )
-
-                log.info("Tarkistetaan arkistointi [valmistumispyyntoId=$id, yliopisto=${yliopisto.nimi}]")
-                if (arkistointiService.onKaytossa(yliopisto.nimi.required(), CaseType.VALMISTUMINEN)) {
-                    arkistoiValmistumispyynto(
-                        id,
-                        valmistumispyynto,
-                        yliopisto.nimi,
-                        arkistoitavatAsiakirjat
-                    )
-                } else {
-                    log.info("Arkistointi ei kaytossa [valmistumispyyntoId=$id, yliopisto=${yliopisto.nimi}]")
-                }
             }
         }
 
@@ -398,79 +279,14 @@ class ValmistumispyyntoServiceImpl(
         log.info("Hyvaksynta-operaatio valmis [valmistumispyyntoId=$id]")
         return valmistumispyynnonTarkistusMapper.toDto(valmistumispyynnonTarkistus.required()).apply {
             this.kommentitVirkailijoille = null
-            this.valmistumispyynto?.tila = getValmistumispyynnonTilaForHyvaksyja(valmistumispyynto)
+            this.valmistumispyynto?.tila = tilaService.haeTilaHyvaksyjalle(valmistumispyynto)
         }
     }
 
-    private fun luoValmistumispyynnonAsiakirjatJaLahetaViesti(
-        id: Long,
-        tarkistus: ValmistumispyynnonTarkistus,
-        valmistumispyynto: Valmistumispyynto
-    ): List<RecordProperties> {
-        val mappedTarkistus = mapValmistumispyynnonTarkistus(
-            valmistumispyynnonTarkistusMapper.toDto(tarkistus)
-        )
-        if (tarkistus.valmistumispyynto?.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID) {
-            log.info("Luodaan YEK PDF:t [valmistumispyyntoId=$id]")
-            val yhteenveto = luoYEKYhteenvetoPdf(mappedTarkistus, valmistumispyynto)
-            val liitteet = luoLiitteetPdf(valmistumispyynto)
-            log.info("YEK PDF:t luotu [valmistumispyyntoId=$id]")
-            sendMailNotificationHyvaksyttyYek(valmistumispyynto)
-            log.info("YEK hyvaksynta-sahkoposti lahetetty [valmistumispyyntoId=$id]")
-            return listOf(
-                RecordProperties(yhteenveto, YHTEENVETO),
-                RecordProperties(liitteet, LIITE)
-            )
-        }
-
-        log.info("Luodaan PDF:t [valmistumispyyntoId=$id]")
-        val liitteet = luoLiitteetPdf(valmistumispyynto)
-        luoErikoistujanTiedotPdf(valmistumispyynto)
-        val yhteenveto = luoYhteenvetoPdf(mappedTarkistus, valmistumispyynto)
-        log.info("PDF:t luotu [valmistumispyyntoId=$id]")
-        sendMailNotificationHyvaksytty(valmistumispyynto)
-        log.info("Hyvaksynta-sahkoposti lahetetty [valmistumispyyntoId=$id]")
-        return listOf(
-            RecordProperties(yhteenveto, YHTEENVETO),
-            RecordProperties(liitteet, LIITE)
-        )
-    }
-
-    private fun arkistoiValmistumispyynto(
-        id: Long,
-        valmistumispyynto: Valmistumispyynto,
-        nimi: YliopistoEnum?,
-        asiakirjat: List<RecordProperties>
-    ) {
-        log.info("Arkistointi kaytossa, muodostetaan sahke [valmistumispyyntoId=$id]")
-        val result = arkistointiService.muodostaSahke(
-            valmistumispyynto.opintooikeus,
-            asiakirjat,
-            caseId = valmistumispyynto.id.required().toString(),
-            tarkastaja = valmistumispyynto.virkailija?.user?.getName(),
-            tarkastusPaiva = valmistumispyynto.virkailijanKuittausaika,
-            hyvaksyja = valmistumispyynto.vastuuhenkiloHyvaksyja?.user?.getName(),
-            hyvaksymisPaiva = valmistumispyynto.vastuuhenkiloHyvaksyjaKuittausaika,
-            yliopisto = nimi,
-            caseType = CaseType.VALMISTUMINEN
-        )
-        val erikoisala = valmistumispyynto.opintooikeus?.erikoisala.required()
-        val yek = erikoisala.id == YEK_ERIKOISALA_ID
-        val erikoistujanNimi = valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user?.getName()
-        arkistointiService.laheta(
-            yliopisto = nimi.required(),
-            filePath = result.zipFilePath,
-            caseType = CaseType.VALMISTUMINEN,
-            yek = yek,
-            caseId = id.toString(),
-            erikoistujanNimi = erikoistujanNimi
-        )
-        log.info("Sahke muodostettu ja lahetetty [valmistumispyyntoId=$id, yek=$yek]")
-    }
 
     override fun updateTarkistusByVirkailijaUserId(id: Long, userId: String, valmistumispyynnonTarkistusDTO: ValmistumispyynnonTarkistusUpdateDTO,
         laillistamistodistus: MultipartFile?): ValmistumispyynnonTarkistusDTO? {
-        val kayttaja = getKayttaja(userId)
+        val kayttaja = osapuoliService.haeKayttaja(userId)
         val yliopisto = kayttaja.yliopistot.first()
         var tarkistus = valmistumispyynnonTarkistusRepository.findByValmistumispyyntoIdAndValmistumispyyntoOpintooikeusYliopistoId(id, yliopisto.id.required())
 
@@ -514,18 +330,18 @@ class ValmistumispyyntoServiceImpl(
                     it.valmistumispyynto?.virkailijanKorjausehdotus = valmistumispyynnonTarkistusDTO.korjausehdotus
                     it.valmistumispyynto?.virkailijanPalautusaika = LocalDate.now(clock)
                     it.valmistumispyynto?.erikoistujanKuittausaika = null
-                    sendMailNotificationVirkailijaPalauttanut(it.valmistumispyynto.required())
+                    ilmoitusService.lahetaIlmoitusPalautuksesta(
+                        it.valmistumispyynto.required()
+                    )
                 } else {
                     it.valmistumispyynto?.virkailijanSaate = valmistumispyynnonTarkistusDTO.lisatiedotVastuuhenkilolle
                     it.valmistumispyynto?.virkailijanKuittausaika = LocalDate.now(clock)
                     it.valmistumispyynto?.vastuuhenkiloHyvaksyjaKorjausehdotus = null
                     it.valmistumispyynto?.vastuuhenkiloHyvaksyjaPalautusaika = null
                     it.valmistumispyynto?.virkailijanKorjausehdotus = null
-                    if (it.valmistumispyynto?.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID) {
-                        sendMailNotificationOdottaaHyvaksyntaaYek(it.valmistumispyynto.required())
-                    } else {
-                        sendMailNotificationOdottaaHyvaksyntaa(it.valmistumispyynto.required())
-                    }
+                    ilmoitusService.lahetaIlmoitusHyvaksyjalle(
+                        it.valmistumispyynto.required()
+                    )
                 }
 
                 it.valmistumispyynto?.let { pyynto -> valmistumispyyntoRepository.save(pyynto) }
@@ -543,21 +359,21 @@ class ValmistumispyyntoServiceImpl(
         valmistumispyyntoCriteria: NimiErikoisalaAndAvoinCriteria,
         pageable: Pageable
     ): Page<ValmistumispyyntoListItemDTO> {
-        val kayttaja = getKayttaja(userId)
-        val yliopisto = getYliopisto(kayttaja)
+        val kayttaja = osapuoliService.haeKayttaja(userId)
+        val yliopisto = osapuoliService.haeYliopisto(kayttaja)
         val yek = valmistumispyyntoCriteria.erikoisalaId?.equals == YEK_ERIKOISALA_ID
-        val hyvaksyjaRole = getValmistumispyynnonHyvaksyjaRoleForVastuuhenkilo(kayttaja, yek)
-        arkistointiService.onKaytossa(yliopisto.nimi.required(), CaseType.VALMISTUMINEN)
+        val hyvaksyjaRole = tilaService.haeVastuuhenkilonRoolit(kayttaja, yek)
+        viimeistelyService.onkoArkistointiKaytossa(yliopisto.nimi)
         return valmistumispyyntoQueryService.findValmistumispyynnotByCriteria(
             valmistumispyyntoCriteria,
             hyvaksyjaRole,
             pageable,
             yliopisto.id.required(),
-            if (yek) listOf(YEK_ERIKOISALA_ID) else getErikoisalaIds(kayttaja),
+            if (yek) listOf(YEK_ERIKOISALA_ID) else osapuoliService.haeErikoisalaIds(kayttaja),
             kayttaja.user?.langKey
         ).map {
             val isAvoin = valmistumispyyntoCriteria.avoin == true
-            mapValmistumispyyntoListItem(it, hyvaksyjaRole, isAvoin)
+            tilaService.mapVastuuhenkilonListItem(it, hyvaksyjaRole, isAvoin)
         }
     }
 
@@ -568,7 +384,7 @@ class ValmistumispyyntoServiceImpl(
         excludedErikoisalaIds: List<Long>,
         pageable: Pageable
     ): Page<ValmistumispyyntoListItemDTO> {
-        val kayttaja = getKayttaja(userId)
+        val kayttaja = osapuoliService.haeKayttaja(userId)
         return valmistumispyyntoQueryService.findValmistumispyynnotByCriteriaForVirkailija(
             valmistumispyyntoCriteria,
             pageable,
@@ -578,7 +394,7 @@ class ValmistumispyyntoServiceImpl(
             kayttaja.user?.langKey
         ).map {
             val isAvoin = valmistumispyyntoCriteria.avoin == true
-            mapValmistumispyyntoListItemVirkailija(it, isAvoin)
+            tilaService.mapVirkailijanListItem(it, isAvoin)
         }
     }
 
@@ -587,9 +403,9 @@ class ValmistumispyyntoServiceImpl(
         id: Long,
         userId: String
     ): ValmistumispyyntoOsaamisenArviointiDTO? {
-        val kayttaja = getKayttaja(userId)
-        val yliopisto = getYliopisto(kayttaja)
-        val valmistumispyynto = getValmistumispyyntoByYliopistoIdOrThrow(
+        val kayttaja = osapuoliService.haeKayttaja(userId)
+        val yliopisto = osapuoliService.haeYliopisto(kayttaja)
+        val valmistumispyynto = osapuoliService.haeValmistumispyynto(
             id,
             kayttaja,
             yliopisto.id.required(),
@@ -597,7 +413,7 @@ class ValmistumispyyntoServiceImpl(
         )
 
         return valmistumispyyntoOsaamisenArviointiMapper.toDto(valmistumispyynto).apply {
-            tila = getValmistumispyynnonTilaForArvioija(valmistumispyynto)
+            tila = tilaService.haeTilaOsaamisenArvioijalle(valmistumispyynto)
         }
     }
 
@@ -605,27 +421,27 @@ class ValmistumispyyntoServiceImpl(
         id: Long,
         userId: String
     ): ValmistumispyynnonTarkistusDTO? {
-        val kayttaja = getKayttaja(userId)
+        val kayttaja = osapuoliService.haeKayttaja(userId)
         val yliopisto = kayttaja.yliopistot.first()
         valmistumispyynnonTarkistusRepository.findByValmistumispyyntoIdAndValmistumispyyntoOpintooikeusYliopistoId(
             id,
             yliopisto.id.required()
         )?.let {
-            val result = mapValmistumispyynnonTarkistus(valmistumispyynnonTarkistusMapper.toDto(it))
+            val result = tarkistusService.taydenna(valmistumispyynnonTarkistusMapper.toDto(it))
             it.valmistumispyynto?.let { pyynto ->
-                result.valmistumispyynto?.tila = getValmistumispyynnonTilaForVirkailija(pyynto)
+                result.valmistumispyynto?.tila = tilaService.haeTilaVirkailijalle(pyynto)
             }
             return result
         }
 
         val valmistumispyynto =
             valmistumispyyntoRepository.findByIdAndOpintooikeusYliopistoId(id, yliopisto.id.required())
-                ?: throw getValmistumispyyntoNotFoundException()
+                ?: throw osapuoliService.valmistumispyyntoaEiLoydy()
 
-        return mapValmistumispyynnonTarkistus(ValmistumispyynnonTarkistusDTO(
+        return tarkistusService.taydenna(ValmistumispyynnonTarkistusDTO(
             valmistumispyynto = valmistumispyyntoMapper.toDto(
                 valmistumispyynto
-            ).apply { tila = getValmistumispyynnonTilaForVirkailija(valmistumispyynto) }
+            ).apply { tila = tilaService.haeTilaVirkailijalle(valmistumispyynto) }
         ))
     }
 
@@ -633,28 +449,29 @@ class ValmistumispyyntoServiceImpl(
         id: Long,
         userId: String
     ): ValmistumispyynnonTarkistusDTO? {
-        val kayttaja = getKayttaja(userId)
-        val yliopisto = getYliopisto(kayttaja)
+        val kayttaja = osapuoliService.haeKayttaja(userId)
+        val yliopisto = osapuoliService.haeYliopisto(kayttaja)
         val tarkistus = valmistumispyynnonTarkistusRepository.findByValmistumispyyntoIdForHyvaksyja(id, yliopisto.id.required())
-            ?: throw getValmistumispyyntoNotFoundException()
+            ?: throw osapuoliService.valmistumispyyntoaEiLoydy()
         val yek = tarkistus.valmistumispyynto?.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID
-        if (getValmistumispyynnonHyvaksyjaRoleForVastuuhenkilo(kayttaja, yek).isEmpty()) {
-            throw getValmistumispyyntoNotFoundException()
+        if (tilaService.haeVastuuhenkilonRoolit(kayttaja, yek).isEmpty()) {
+            throw osapuoliService.valmistumispyyntoaEiLoydy()
         }
 
-        if (!yek && !getErikoisalaIds(kayttaja).contains(
+        if (!yek && !osapuoliService.haeErikoisalaIds(kayttaja).contains(
                 tarkistus.valmistumispyynto?.opintooikeus
                     ?.erikoisala?.id
             )
         ) {
-            throw getValmistumispyyntoNotFoundException()
+            throw osapuoliService.valmistumispyyntoaEiLoydy()
         }
 
-        val result = mapValmistumispyynnonTarkistus(valmistumispyynnonTarkistusMapper.toDto(tarkistus))
+        val result = tarkistusService.taydenna(valmistumispyynnonTarkistusMapper.toDto(tarkistus))
         result.kommentitVirkailijoille = null
         tarkistus.valmistumispyynto?.let { pyynto ->
-            result.valmistumispyynto?.tila = getValmistumispyynnonTilaForHyvaksyja(pyynto)
-            result.valmistumispyynto?.arkistoitava = arkistointiService.onKaytossa(yliopisto.nimi.required(), CaseType.VALMISTUMINEN)
+            result.valmistumispyynto?.tila = tilaService.haeTilaHyvaksyjalle(pyynto)
+            result.valmistumispyynto?.arkistoitava =
+                viimeistelyService.onkoArkistointiKaytossa(yliopisto.nimi)
         }
         return result
     }
@@ -669,1073 +486,59 @@ class ValmistumispyyntoServiceImpl(
         id: Long,
         userId: String
     ): ValmistumispyyntoArviointienTilaDTO? {
-        val kayttaja = getKayttaja(userId)
-        val yliopisto = getYliopisto(kayttaja)
-        val valmistumispyynto = getValmistumispyyntoByYliopistoIdOrThrow(
+        val kayttaja = osapuoliService.haeKayttaja(userId)
+        val yliopisto = osapuoliService.haeYliopisto(kayttaja)
+        val valmistumispyynto = osapuoliService.haeValmistumispyynto(
             id,
             kayttaja,
             yliopisto.id.required(),
             VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_OSAAMISEN_ARVIOINTI
         )
-
-        val opintooikeus = valmistumispyynto.opintooikeus
-        val erikoistujanArvioivatKokonaisuudet = arvioitavaKokonaisuusRepository.findAllByErikoisalaIdAndValid(
-            opintooikeus?.erikoisala?.id, opintooikeus?.osaamisenArvioinninOppaanPvm ?: LocalDate.now()
-        )
-        val erikoistujanTyoskentelyjaksot = tyoskentelyjaksoRepository.findAllByOpintooikeusId(opintooikeus?.id.required())
-        val opintooikeusId = opintooikeus?.id.required()
-        val erikoistujanArvioinnit = erikoistujanTyoskentelyjaksot.map {
-            suoritusarviointiRepository.findAllByTyoskentelyjaksoOpintooikeusId(opintooikeusId)
-        }.flatten()
-        val erikoistujanArviointienArvioitavaKokonaisuusIds =
-            erikoistujanArvioinnit.flatMap { it.arvioitavatKokonaisuudet.map { k -> k.arvioitavaKokonaisuus?.id.required() } }
-                .distinct()
-        val arviointienTilaDTO = ValmistumispyyntoArviointienTilaDTO(
-            hasArvioitaviaKokonaisuuksiaWithArviointiLowerThanFour = erikoistujanArvioinnit.flatMap { it.arvioitavatKokonaisuudet }
-                .filter { it.arviointiasteikonTaso != null }
-                .any {
-                    it.arviointiasteikonTaso.required() < ARVIOINTI_VAHINTAAN
-                },
-            hasArvioitaviaKokonaisuuksiaWithoutArviointi = erikoistujanArvioivatKokonaisuudet.any {
-                it.id.required() !in erikoistujanArviointienArvioitavaKokonaisuusIds
-            }
-        )
-
-        return arviointienTilaDTO
+        return arviointienTilaService.haeArviointienTila(valmistumispyynto)
     }
 
-    @Suppress("ComplexCondition")
     override fun getValmistumispyynnonAsiakirja(
         userId: String,
         valmistumispyyntoId: Long,
         asiakirjaId: Long
-    ): AsiakirjaDTO? {
-        valmistumispyyntoRepository.findByIdOrNull(valmistumispyyntoId)?.let {
-            if ((it.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user?.id == userId ||
-                    it.vastuuhenkiloOsaamisenArvioija?.user?.id == userId ||
-                    it.vastuuhenkiloHyvaksyja?.user?.id == userId ||
-                    it.virkailija?.user?.id == userId) &&
-                (it.yhteenvetoAsiakirja?.id == asiakirjaId || it.liitteetAsiakirja?.id == asiakirjaId)
-            ) {
-                asiakirjaRepository.findByIdOrNull(asiakirjaId)?.let { asiakirja ->
-                    val result = asiakirjaMapper.toDto(asiakirja)
-                    result.asiakirjaData?.fileInputStream =
-                        ByteArrayInputStream(asiakirja.asiakirjaData?.data)
-                    return result
-                }
-            }
-        }
-        return null
-    }
+    ): AsiakirjaDTO? = asiakirjaService.haeValmistumispyynnonAsiakirja(
+        userId,
+        valmistumispyyntoId,
+        asiakirjaId
+    )
 
     override fun getValmistumispyynnonAsiakirjaVirkailija(
         valmistumispyyntoId: Long,
         yliopistoId: Long?,
         asiakirjaId: Long
-    ): AsiakirjaDTO? {
-        valmistumispyyntoRepository.findByIdOrNull(valmistumispyyntoId)?.let {
-            if (it.opintooikeus?.yliopisto?.id == yliopistoId &&
-                (it.yhteenvetoAsiakirja?.id == asiakirjaId || it.liitteetAsiakirja?.id == asiakirjaId)
-            ) {
-                asiakirjaRepository.findByIdOrNull(asiakirjaId)?.let { asiakirja ->
-                    val result = asiakirjaMapper.toDto(asiakirja)
-                    result.asiakirjaData?.fileInputStream =
-                        ByteArrayInputStream(asiakirja.asiakirjaData?.data)
-                    return result
-                }
-            }
-        }
-        return null
-    }
+    ): AsiakirjaDTO? = asiakirjaService.haeValmistumispyynnonAsiakirjaVirkailijalle(
+        valmistumispyyntoId,
+        yliopistoId,
+        asiakirjaId
+    )
 
     override fun getValmistumispyynnonTyoskentelyjaksoAsiakirja(
         userId: String,
         valmistumispyyntoId: Long,
         asiakirjaId: Long
-    ): AsiakirjaDTO? {
-        val kayttaja = getKayttaja(userId)
-        valmistumispyyntoRepository.findByIdOrNull(valmistumispyyntoId)?.let { valmistumispyynto ->
-            if (kayttaja.yliopistotAndErikoisalat.any {
-                    it.yliopisto?.id == valmistumispyynto.opintooikeus?.yliopisto?.id
-                        && (valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID && it.vastuuhenkilonTehtavat.map { tehtava -> tehtava.nimi }
-                        .contains(VastuuhenkilonTehtavatyyppiEnum.YEK_VALMISTUMINEN)
-                        || it.erikoisala?.id == valmistumispyynto.opintooikeus?.erikoisala?.id && it.vastuuhenkilonTehtavat.map { tehtava -> tehtava.nimi }
-                        .contains(VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA))
-                }
-            ) {
-                asiakirjaRepository.findByIdOrNull(asiakirjaId)?.let { asiakirja ->
-                    if (asiakirja.tyoskentelyjakso?.opintooikeus?.id != valmistumispyynto.opintooikeus?.id) {
-                        return null
-                    }
-                    val result = asiakirjaMapper.toDto(asiakirja)
-                    result.asiakirjaData?.fileInputStream =
-                        ByteArrayInputStream(asiakirja.asiakirjaData?.data)
-                    return result
-                }
-            }
-        }
-        return null
-    }
+    ): AsiakirjaDTO? = asiakirjaService.haeTyoskentelyjaksonAsiakirja(
+        userId,
+        valmistumispyyntoId,
+        asiakirjaId
+    )
 
     override fun onkoLahetetty(opintooikeusId: Long): Boolean {
         val valmistumispyynto = valmistumispyyntoRepository.findByOpintooikeusId(opintooikeusId)
         return valmistumispyynto?.erikoistujanKuittausaika != null
     }
 
-    override fun onkoAvoinOsaamisenTarkistaminen(userId: String, id: Long): Boolean {
-        val kayttaja = getKayttaja(userId)
-        val yliopisto = getYliopisto(kayttaja)
-        val valmistumispyynto = getValmistumispyyntoByYliopistoIdOrThrow(
-            id,
-            kayttaja,
-            yliopisto.id.required(),
-            VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_OSAAMISEN_ARVIOINTI
-        )
+    override fun onkoAvoinOsaamisenTarkistaminen(userId: String, id: Long): Boolean =
+        osapuoliService.onkoOsaamisenArviointiAvoin(userId, id)
 
-        return valmistumispyynto.erikoistujanKuittausaika != null
-            && valmistumispyynto.vastuuhenkiloOsaamisenArvioijaKuittausaika == null
-    }
+    override fun onkoAvoinVirkailija(userId: String, id: Long): Boolean =
+        osapuoliService.onkoVirkailijanTarkistusAvoin(userId, id)
 
-    override fun onkoAvoinVirkailija(userId: String, id: Long): Boolean {
-        val kayttaja = getKayttaja(userId)
-        val yliopisto = kayttaja.yliopistot.first()
-        val tarkistus =
-            valmistumispyynnonTarkistusRepository.findByValmistumispyyntoIdAndValmistumispyyntoOpintooikeusYliopistoId(
-                id,
-                yliopisto.id.required()
-            )
-        val valmistumispyynto =
-            tarkistus?.valmistumispyynto ?: valmistumispyyntoRepository.findByIdAndOpintooikeusYliopistoId(
-                id,
-                yliopisto.id.required()
-            )
-        return valmistumispyynto?.erikoistujanKuittausaika != null
-            && (valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID || valmistumispyynto.vastuuhenkiloOsaamisenArvioijaKuittausaika != null)
-            && valmistumispyynto.virkailijanKuittausaika == null
-    }
+    override fun onkoAvoinHyvaksyja(userId: String, id: Long): Boolean =
+        osapuoliService.onkoLopullinenHyvaksyntaAvoin(userId, id)
 
-    override fun onkoAvoinHyvaksyja(userId: String, id: Long): Boolean {
-        val kayttaja = getKayttaja(userId)
-        val yliopisto = getYliopisto(kayttaja)
-        val valmistumispyynto = getValmistumispyyntoByYliopistoIdOrThrow(
-            id,
-            kayttaja,
-            yliopisto.id.required(),
-            VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA
-        )
-
-        return valmistumispyynto.virkailijanKuittausaika != null
-            && valmistumispyynto.vastuuhenkiloHyvaksyjaKuittausaika == null
-    }
-
-    private fun getKayttaja(userId: String) =
-        kayttajaRepository.findOneByUserId(userId).orElseThrow { EntityNotFoundException(KAYTTAJA_NOT_FOUND_ERROR) }
-
-    private fun getOpintooikeus(id: Long) =
-        opintooikeusRepository.findByIdOrNull(id) ?: throw EntityNotFoundException(OPINTOOIKEUS_NOT_FOUND_ERROR)
-
-    private fun getYliopisto(kayttaja: Kayttaja) =
-        kayttaja.yliopistotAndErikoisalat.firstOrNull()?.yliopisto ?: throw EntityNotFoundException(
-            KAYTTAJA_YLIOPISTO_ERIKOISALA_NOT_FOUND_ERROR
-        )
-
-    private fun getErikoisalaIds(kayttaja: Kayttaja) = kayttaja.yliopistotAndErikoisalat.map { it.erikoisala?.id.required() }
-
-    private fun getValmistumispyyntoByYliopistoIdOrThrow(
-        id: Long,
-        kayttaja: Kayttaja,
-        yliopistoId: Long,
-        tehtava: VastuuhenkilonTehtavatyyppiEnum
-    ): Valmistumispyynto {
-        val valmistumispyynto = valmistumispyyntoRepository.findByIdAndOpintooikeusYliopistoId(id, yliopistoId)
-            ?: throw getValmistumispyyntoNotFoundException()
-        val yek = valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID
-
-        if (!yek && kayttaja.yliopistotAndErikoisalat.none {
-                it.erikoisala?.id == valmistumispyynto.opintooikeus?.erikoisala?.id
-                    && it.vastuuhenkilonTehtavat.map { vastuuhenkilonTehtava -> vastuuhenkilonTehtava.nimi }
-                    .contains(tehtava)
-            }) {
-            throw getValmistumispyyntoNotFoundException()
-        } else if (yek && kayttaja.yliopistotAndErikoisalat.none {
-                it.vastuuhenkilonTehtavat.map { vastuuhenkilonTehtava -> vastuuhenkilonTehtava.nimi }
-                    .contains(VastuuhenkilonTehtavatyyppiEnum.YEK_VALMISTUMINEN)
-            }) {
-            throw getValmistumispyyntoNotFoundException()
-        }
-
-        return valmistumispyynto
-    }
-
-    private fun getValmistumispyyntoByOpintooikeusId(opintooikeusId: Long) =
-        valmistumispyyntoRepository.findByOpintooikeusId(opintooikeusId) ?: throw EntityNotFoundException(
-            VALMISTUMISPYYNTO_NOT_FOUND_ERROR
-        )
-
-    private fun getValmistumispyyntoNotFoundException() = EntityNotFoundException(
-        "Valmistumispyyntöä ei löydy tai sinulla ei ole oikeuksia tarkastella kyseistä valmistumispyyntöä."
-    )
-
-    private fun getValmistumispyynnonTilaForArvioija(valmistumispyynto: Valmistumispyynto): ValmistumispyynnonTila {
-        val isAvoin =
-            valmistumispyynto.erikoistujanKuittausaika != null &&
-                valmistumispyynto.vastuuhenkiloOsaamisenArvioijaKuittausaika == null &&
-                valmistumispyynto.vastuuhenkiloOsaamisenArvioijaPalautusaika == null
-        return fromValmistumispyyntoArvioija(valmistumispyynto, isAvoin)
-    }
-
-    private fun getValmistumispyynnonTilaForVirkailija(valmistumispyynto: Valmistumispyynto): ValmistumispyynnonTila {
-        val isAvoin =
-            valmistumispyynto.erikoistujanKuittausaika != null &&
-                (valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID || valmistumispyynto.vastuuhenkiloOsaamisenArvioijaKuittausaika != null) &&
-                valmistumispyynto.virkailijanKuittausaika == null &&
-                valmistumispyynto.virkailijanPalautusaika == null
-        return fromValmistumispyyntoVirkailija(valmistumispyynto, isAvoin)
-    }
-
-    private fun getValmistumispyynnonTilaForHyvaksyja(valmistumispyynto: Valmistumispyynto): ValmistumispyynnonTila {
-        val isAvoin =
-            valmistumispyynto.virkailijanKuittausaika != null &&
-                valmistumispyynto.vastuuhenkiloHyvaksyjaKuittausaika == null &&
-                valmistumispyynto.vastuuhenkiloHyvaksyjaPalautusaika == null
-        return fromValmistumispyyntoHyvaksyja(valmistumispyynto, isAvoin)
-    }
-
-    private fun mapValmistumispyyntoListItem(
-        pyynto: Valmistumispyynto,
-        hyvaksyjaRole: List<Pair<Long, ValmistumispyynnonHyvaksyjaRole>>,
-        isAvoin: Boolean
-    ): ValmistumispyyntoListItemDTO {
-        val rooli =
-            if (pyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID) ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_HYVAKSYJA
-            else hyvaksyjaRole.first { it.first == pyynto.opintooikeus?.erikoisala?.id }.second
-        val tila = getValmistumispyynnonTilaForHyvaksyja(pyynto, rooli, isAvoin)
-        return ValmistumispyyntoListItemDTO(
-            id = pyynto.id,
-            erikoistujanNimi = pyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.getNimi(),
-            tila = tila,
-            tapahtumanAjankohta = getValmistumispyyntoTapahtumaAjankohtaDate(pyynto, tila) ?: pyynto.muokkauspaiva,
-            isAvoinForCurrentKayttaja = isAvoin,
-            rooli = rooli
-        )
-    }
-
-    private fun mapValmistumispyyntoListItemVirkailija(
-        pyynto: Valmistumispyynto,
-        isAvoin: Boolean
-    ): ValmistumispyyntoListItemDTO {
-        val tila = getValmistumispyynnonTilaForHyvaksyja(pyynto, ValmistumispyynnonHyvaksyjaRole.VIRKAILIJA, isAvoin)
-        return ValmistumispyyntoListItemDTO(
-            id = pyynto.id,
-            erikoistujanNimi = pyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.getNimi(),
-            tila = tila,
-            tapahtumanAjankohta = getValmistumispyyntoTapahtumaAjankohtaDate(pyynto, tila) ?: pyynto.muokkauspaiva,
-            isAvoinForCurrentKayttaja = isAvoin,
-            rooli = ValmistumispyynnonHyvaksyjaRole.VIRKAILIJA
-        )
-    }
-
-    private fun getValmistumispyyntoTapahtumaAjankohtaDate(
-        valmistumispyynto: Valmistumispyynto,
-        tila: ValmistumispyynnonTila
-    ) = when (tila) {
-        ValmistumispyynnonTila.VASTUUHENKILON_TARKASTUS_PALAUTETTU ->
-            valmistumispyynto.vastuuhenkiloOsaamisenArvioijaPalautusaika
-
-        ValmistumispyynnonTila.VIRKAILIJAN_TARKASTUS_PALAUTETTU ->
-            valmistumispyynto.virkailijanPalautusaika
-
-        ValmistumispyynnonTila.VASTUUHENKILON_HYVAKSYNTA_PALAUTETTU ->
-            valmistumispyynto.vastuuhenkiloHyvaksyjaPalautusaika
-
-        else -> null
-    }
-
-    private fun getValmistumispyynnonTilaForHyvaksyja(
-        valmistumispyynto: Valmistumispyynto,
-        hyvaksyjaRole: ValmistumispyynnonHyvaksyjaRole,
-        isAvoin: Boolean
-    ) = when (hyvaksyjaRole) {
-        ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_OSAAMISEN_ARVIOIJA ->
-            fromValmistumispyyntoArvioija(valmistumispyynto, isAvoin)
-
-        ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_HYVAKSYJA ->
-            fromValmistumispyyntoHyvaksyja(valmistumispyynto, isAvoin)
-
-        ValmistumispyynnonHyvaksyjaRole.VIRKAILIJA -> fromValmistumispyyntoVirkailija(valmistumispyynto, isAvoin)
-        ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_OSAAMISEN_ARVIOIJA_HYVAKSYJA ->
-            fromValmistumispyyntoArvioijaHyvaksyja(valmistumispyynto, isAvoin)
-    }
-
-    private fun getValmistumispyynnonHyvaksyjaRoleForVastuuhenkilo(
-        kayttaja: Kayttaja,
-        yek: Boolean = false
-    ): List<Pair<Long, ValmistumispyynnonHyvaksyjaRole>> {
-        val roles: MutableList<Pair<Long, ValmistumispyynnonHyvaksyjaRole>> = mutableListOf()
-        kayttaja.yliopistotAndErikoisalat.forEach {
-            val vastuuhenkilonTehtavat = it.vastuuhenkilonTehtavat.map { tehtava -> tehtava.nimi }
-            if (yek) {
-                if (vastuuhenkilonTehtavat.contains(VastuuhenkilonTehtavatyyppiEnum.YEK_VALMISTUMINEN))
-                    roles.add(
-                        Pair(
-                            YEK_ERIKOISALA_ID,
-                            ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_OSAAMISEN_ARVIOIJA_HYVAKSYJA
-                        )
-                    )
-            } else if (
-                vastuuhenkilonTehtavat.contains(VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_OSAAMISEN_ARVIOINTI) &&
-                vastuuhenkilonTehtavat.contains(VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA)
-            ) {
-                roles.add(
-                    Pair(
-                        it.erikoisala?.id.required(),
-                        ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_OSAAMISEN_ARVIOIJA_HYVAKSYJA
-                    )
-                )
-            } else if (vastuuhenkilonTehtavat.contains(VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_OSAAMISEN_ARVIOINTI)) {
-                roles.add(
-                    Pair(
-                        it.erikoisala?.id.required(),
-                        ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_OSAAMISEN_ARVIOIJA
-                    )
-                )
-            } else if (vastuuhenkilonTehtavat.contains(VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA)) {
-                roles.add(Pair(it.erikoisala?.id.required(), ValmistumispyynnonHyvaksyjaRole.VASTUUHENKILO_HYVAKSYJA))
-            }
-        }
-        return roles
-    }
-
-    private fun getVastuuhenkiloOsaamisenArvioija(yliopistoId: Long, erikoisalaId: Long) =
-        kayttajaRepository.findOneByAuthoritiesYliopistoErikoisalaAndVastuuhenkilonTehtavatyyppi(
-            listOf(VASTUUHENKILO),
-            yliopistoId,
-            erikoisalaId,
-            VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_OSAAMISEN_ARVIOINTI
-        ) ?: throw EntityNotFoundException("Vastuuhenkilöä, joka hyväksyisi osaamisen arvioinnin, ei löydy.")
-
-    private fun getVastuuhenkiloHyvaksyja(yliopistoId: Long, erikoisalaId: Long): Kayttaja {
-        if (erikoisalaId == YEK_ERIKOISALA_ID) {
-            return kayttajaRepository.findOneByAuthoritiesYliopistoAndVastuuhenkilonTehtavatyyppi(
-                listOf(VASTUUHENKILO),
-                yliopistoId,
-                VastuuhenkilonTehtavatyyppiEnum.YEK_VALMISTUMINEN
-            ) ?: throw EntityNotFoundException("Vastuuhenkilöä, joka hyväksyisi valmistumispyynnon, ei löydy.")
-        }
-        return kayttajaRepository.findOneByAuthoritiesYliopistoErikoisalaAndVastuuhenkilonTehtavatyyppi(
-            listOf(VASTUUHENKILO),
-            yliopistoId,
-            erikoisalaId,
-            VastuuhenkilonTehtavatyyppiEnum.VALMISTUMISPYYNNON_HYVAKSYNTA
-        ) ?: throw EntityNotFoundException("Vastuuhenkilöä, joka hyväksyisi valmistumispyynnon, ei löydy.")
-    }
-
-    private fun sendMailNotificationUusiValmistumispyynto(
-        vastuuhenkiloOsaamisenArvioijaUser: User,
-        valmistumispyynto: Valmistumispyynto
-    ) {
-        transactionalMailService.sendEmailFromTemplate(
-            vastuuhenkiloOsaamisenArvioijaUser,
-            templateName = "uusivalmistumispyynto.html",
-            titleKey = "email.uusivalmistumispyynto.title",
-            properties = mapOf(
-                Pair(
-                    MailProperty.NAME,
-                    valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user?.getName().toString()
-                ), Pair(MailProperty.ID, valmistumispyynto.id.required().toString())
-            )
-        )
-    }
-
-    private fun sendMailNotificationOdottaaVirkailijanTarkastusta(
-        erikoistujanYliopisto: YliopistoEnum,
-        valmistumispyyntoId: Long
-    ) {
-        transactionalMailService.sendEmailFromTemplate(
-            to = erikoistujanYliopisto.getOpintohallintoEmailAddress(applicationProperties),
-            templateName = "valmistumispyyntoTarkastettavissa.html",
-            titleKey = "email.valmistumispyyntoTarkastettavissa.title",
-            properties = mapOf(Pair(MailProperty.ID, valmistumispyyntoId.toString()))
-        )
-    }
-
-    private fun sendMailNotificationOdottaaVirkailijanTarkastustaYek(
-        erikoistujanYliopisto: YliopistoEnum,
-        valmistumispyyntoId: Long
-    ) {
-        transactionalMailService.sendEmailFromTemplate(
-            to = erikoistujanYliopisto.getOpintohallintoEmailAddress(applicationProperties),
-            templateName = "valmistumispyyntoTarkastettavissaYek.html",
-            titleKey = "email.yekValmistumispyyntoTarkastettavissa.title",
-            properties = mapOf(Pair(MailProperty.ID, valmistumispyyntoId.toString()))
-        )
-    }
-
-    private fun sendMailNotificationOdottaaHyvaksyntaa(
-        valmistumispyynto: Valmistumispyynto
-    ) {
-        val opintooikeus = valmistumispyynto.opintooikeus
-        transactionalMailService.sendEmailFromTemplate(
-            getVastuuhenkiloHyvaksyja(opintooikeus?.yliopisto?.id.required(), requireNotNull(opintooikeus).erikoisala?.id.required()).user.required(),
-            templateName = "valmistumispyyntoTarkastettavissaVastuuhenkilo.html",
-            titleKey = "email.valmistumispyyntoTarkastettavissaVastuuhenkilo.title",
-            properties = mapOf(Pair(MailProperty.ID, valmistumispyynto.id.toString()))
-        )
-    }
-
-    private fun sendMailNotificationOdottaaHyvaksyntaaYek(
-        valmistumispyynto: Valmistumispyynto
-    ) {
-        val opintooikeus = valmistumispyynto.opintooikeus
-        transactionalMailService.sendEmailFromTemplate(
-            getVastuuhenkiloHyvaksyja(opintooikeus?.yliopisto?.id.required(), requireNotNull(opintooikeus).erikoisala?.id.required()).user.required(),
-            templateName = "valmistumispyyntoTarkastettavissaYek.html",
-            titleKey = "email.yekValmistumispyyntoTarkastettavissa.title",
-            properties = mapOf(Pair(MailProperty.ID, valmistumispyynto.id.toString()))
-        )
-    }
-
-    private fun sendMailNotificationOsaamisenArvioijaPalauttanut(
-        valmistumispyynto: Valmistumispyynto
-    ) {
-        transactionalMailService.sendEmailFromTemplate(
-            valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user.required(),
-            templateName = "valmistumispyyntoPalautettuErikoistuja.html",
-            titleKey = "email.valmistumispyyntoPalautettuErikoistuja.title",
-            properties = mapOf()
-        )
-    }
-
-    private fun sendMailNotificationVirkailijaPalauttanut(
-        valmistumispyynto: Valmistumispyynto
-    ) {
-        transactionalMailService.sendEmailFromTemplate(
-            valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user.required(),
-            templateName = "valmistumispyyntoPalautettuErikoistuja.html",
-            titleKey = "email.valmistumispyyntoPalautettuErikoistuja.title",
-            properties = mapOf()
-        )
-    }
-
-    private fun sendMailNotificationHyvaksyjaPalauttanut(
-        valmistumispyynto: Valmistumispyynto
-    ) {
-        transactionalMailService.sendEmailFromTemplate(
-            valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user.required(),
-            templateName = "valmistumispyyntoPalautettuErikoistuja.html",
-            titleKey = "email.valmistumispyyntoPalautettuErikoistuja.title",
-            properties = mapOf()
-        )
-
-        val nimi = valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.getNimi()
-
-        if (valmistumispyynto.opintooikeus?.erikoisala?.id == YEK_ERIKOISALA_ID) {
-            transactionalMailService.sendEmailFromTemplate(
-                valmistumispyynto.opintooikeus?.yliopisto?.nimi?.getOpintohallintoEmailAddress(applicationProperties),
-                templateName = "valmistumispyyntoPalautettuMuutYek.html",
-                titleKey = "email.valmistumispyyntoPalautettuMuut.title",
-                titleProperties = arrayOf("$nimi"),
-                properties = mapOf(Pair(MailProperty.NAME, nimi.toString()))
-            )
-        } else {
-            transactionalMailService.sendEmailFromTemplate(
-                valmistumispyynto.opintooikeus?.yliopisto?.nimi?.getOpintohallintoEmailAddress(applicationProperties),
-                templateName = "valmistumispyyntoPalautettuMuut.html",
-                titleKey = "email.valmistumispyyntoPalautettuMuut.title",
-                titleProperties = arrayOf("$nimi"),
-                properties = mapOf(Pair(MailProperty.NAME, nimi.toString()))
-            )
-        }
-    }
-
-    private fun sendMailNotificationHyvaksytty(
-        valmistumispyynto: Valmistumispyynto
-    ) {
-        transactionalMailService.sendEmailFromTemplate(
-            valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user.required(),
-            templateName = "valmistumispyyntoHyvaksytty.html",
-            titleKey = "email.valmistumispyyntoHyvaksytty.title",
-            properties = mapOf()
-        )
-
-        transactionalMailService.sendEmailFromTemplate(
-            valmistumispyynto.opintooikeus?.yliopisto?.nimi?.getOpintohallintoEmailAddress(applicationProperties),
-            templateName = "valmistumispyyntoHyvaksyttyVirkailija.html",
-            titleKey = "email.valmistumispyyntoHyvaksytty.title",
-            properties = mapOf(
-                Pair(MailProperty.ID, valmistumispyynto.id.toString())
-            )
-        )
-    }
-
-    private fun sendMailNotificationHyvaksyttyYek(
-        valmistumispyynto: Valmistumispyynto
-    ) {
-        transactionalMailService.sendEmailFromTemplate(
-            valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.kayttaja?.user.required(),
-            templateName = "valmistumispyyntoHyvaksyttyYek.html",
-            titleKey = "email.yekValmistumispyyntoHyvaksytty.title",
-            properties = mapOf()
-        )
-
-        transactionalMailService.sendEmailFromTemplate(
-            valmistumispyynto.opintooikeus?.yliopisto?.nimi?.getOpintohallintoEmailAddress(applicationProperties),
-            templateName = "valmistumispyyntoHyvaksyttyYekVirkailija.html",
-            titleKey = "email.yekValmistumispyyntoHyvaksytty.title",
-            properties = mapOf(
-                Pair(MailProperty.ID, valmistumispyynto.id.toString())
-            )
-        )
-    }
-
-    @Suppress("CyclomaticComplexMethod")
-    private fun mapValmistumispyynnonTarkistus(dto: ValmistumispyynnonTarkistusDTO): ValmistumispyynnonTarkistusDTO {
-        dto.valmistumispyynto?.opintooikeusId?.let {
-            dto.tyoskentelyjaksotTilastot = tyoskentelyjaksoService.getTilastot(it).koulutustyypit
-            terveyskeskuskoulutusjaksonHyvaksyntaRepository.findByOpintooikeusId(it)?.let { hyvaksynta ->
-                if (hyvaksynta.vastuuhenkiloHyvaksynyt) { dto.terveyskeskustyoHyvaksyttyPvm = hyvaksynta.vastuuhenkilonKuittausaika }
-                dto.terveyskeskustyoHyvaksyntaId = hyvaksynta.id
-            }
-
-            val opintooikeus = getOpintooikeus(it)
-            val yekOikeus = opintooikeus.erikoisala?.id == YEK_ERIKOISALA_ID
-            val yekTyypit = listOf(YEK_TEORIAKOULUTUS, YEK_TERVEYSKESKUSKOULUTUSJAKSO, YEK_PATEVYYS)
-            val opintosuoritukset = opintosuoritusRepository.findAllByOpintooikeusId(it).filter { suoritus ->
-                if (yekOikeus) yekTyypit.contains(suoritus.tyyppi?.nimi) else !yekTyypit.contains(suoritus.tyyppi?.nimi)
-            }
-            val yekSuoritukset = if (!yekOikeus) opintosuoritusRepository.findAllByErikoistuvaLaakariIdAndErikoisalaId(opintooikeus.erikoistuvaLaakari?.id.required(),
-                YEK_ERIKOISALA_ID) else listOf()
-            (opintosuoritukset + yekSuoritukset)
-                .firstOrNull { suoritus -> suoritus.tyyppi?.nimi == TERVEYSKESKUSKOULUTUSJAKSO || suoritus.tyyppi?.nimi == YEK_TERVEYSKESKUSKOULUTUSJAKSO }
-                ?.let { suoritus -> dto.terveyskeskustyoOpintosuoritusId = suoritus.id }
-            yekSuoritukset.firstOrNull { suoritus -> suoritus.tyyppi?.nimi == YEK_PATEVYYS }?.let { suoritus ->
-                    dto.yekSuoritettu = true
-                    dto.yekSuorituspaiva = suoritus.suorituspaiva
-                }
-            val teoriakoulutukset = teoriakoulutusRepository.findAllByOpintooikeusId(it)
-            // YEK teoriakoulutukset lasketaan opintosuoritteista, riittää että yksi suoritus löytyy
-            dto.teoriakoulutusSuoritettu = if (opintooikeus.erikoisala?.id == YEK_ERIKOISALA_ID) {
-                    if (opintosuoritukset.count { suoritus -> suoritus.tyyppi?.nimi == YEK_TEORIAKOULUTUS } > 0)
-                        opintooikeus.opintoopas?.erikoisalanVaatimaTeoriakoulutustenVahimmaismaara else 0.0
-                } else teoriakoulutukset.filter { koulutus -> koulutus.erikoistumiseenHyvaksyttavaTuntimaara != null }
-                    .sumOf { koulutus -> koulutus.erikoistumiseenHyvaksyttavaTuntimaara.required() }
-            dto.teoriakoulutusVaadittu = opintooikeus.opintoopas?.erikoisalanVaatimaTeoriakoulutustenVahimmaismaara
-            val sateilysuojakoulutukset = opintosuoritukset.filter { suoritus -> suoritus.tyyppi?.nimi == SATEILYSUOJAKOULUTUS }
-            dto.sateilusuojakoulutusSuoritettu = sateilysuojakoulutukset.filter { suoritus -> suoritus.opintopisteet != null }
-                .sumOf { koulutus -> koulutus.opintopisteet.required() }
-            dto.sateilusuojakoulutusVaadittu = opintooikeus.opintoopas?.erikoisalanVaatimaSateilysuojakoulutustenVahimmaismaara
-            val johtamisopinnot = opintosuoritukset.filter { suoritus -> suoritus.tyyppi?.nimi == JOHTAMISOPINTO }
-            dto.johtamiskoulutusSuoritettu = johtamisopinnot.filter { suoritus -> suoritus.opintopisteet != null }.sumOf { suoritus -> suoritus.opintopisteet.required() }
-            dto.johtamiskoulutusVaadittu = opintooikeus.opintoopas?.erikoisalanVaatimaJohtamisopintojenVahimmaismaara
-            dto.kuulustelut = opintosuoritukset.filter { suoritus -> suoritus.tyyppi?.nimi == VALTAKUNNALLINEN_KUULUSTELU }.map(opintosuoritusMapper::toDto)
-            opintosuoritukset.firstOrNull { s -> s.tyyppi?.nimi == KOEJAKSO && s.hyvaksytty }?.let { o -> dto.koejaksoHyvaksyttyPvm = o.suorituspaiva }
-            koejaksonVastuuhenkilonArvioRepository.findByOpintooikeusId(it).orElse(null)?.let { arvio ->
-                if (arvio.vastuuhenkiloHyvaksynyt) { dto.koejaksoHyvaksyttyPvm = arvio.vastuuhenkilonKuittausaika }
-            }
-            val erikoisalaTyyppi = findErikoisalaTyyppiByOpintooikeusId(it)
-            val vanhatSuorituksetDTO = findSuoritustenTila(it, erikoisalaTyyppi)
-            dto.suoritustenTila = ValmistumispyyntoSuoritustenTilaDTO(erikoisalaTyyppi = erikoisalaTyyppi,
-                vanhojaTyoskentelyjaksojaOrSuorituksiaExists = vanhatSuorituksetDTO.vanhojaTyoskentelyjaksojaOrSuorituksiaExists,
-                kuulusteluVanhentunut = vanhatSuorituksetDTO.kuulusteluVanhentunut)
-            dto.tutkimustyotaTehty = tyoskentelyjaksoService.existsByKaytannonKoulutus(it, KaytannonKoulutusTyyppi.TUTKIMUSTYO)
-
-            if (opintooikeus.erikoisala?.id == YEK_ERIKOISALA_ID) {
-                val tyoskentelyjaksot = tyoskentelyjaksoService.findAllByOpintooikeusIdWithKeskeytykset(it)
-                dto.tyoskentelyjaksot = TyoskentelyjaksotKoulutustyypitDTO(
-                    terveyskeskus = tyoskentelyjaksot.filter { t -> t.tyoskentelypaikka?.tyyppi == TERVEYSKESKUS }, yliopistosairaala = tyoskentelyjaksot.filter { t ->
-                        t.tyoskentelypaikka?.tyyppi in listOf(YLIOPISTOLLINEN_SAIRAALA, KESKUSSAIRAALA)
-                    },
-                    yliopistosairaaloidenUlkopuolinen = tyoskentelyjaksot.filter { t -> t.tyoskentelypaikka?.tyyppi in listOf(YKSITYINEN, MUU) }
-                )
-            }
-        }
-
-        return dto
-    }
-
-    private fun luoYhteenvetoPdf(
-        valmistumispyynnonTarkistusDTO: ValmistumispyynnonTarkistusDTO,
-        valmistumispyynto: Valmistumispyynto
-    ): Asiakirja {
-        val context = getYhteenvetoPdfContext(valmistumispyynnonTarkistusDTO, valmistumispyynto)
-        return saveYhteenvetoPdf(
-            valmistumispyynto = valmistumispyynto,
-            template = "pdf/valmistumisenyhteenveto.html",
-            fileNamePrefix = "valmistumisen_yhteenveto",
-            context = context
-        )
-    }
-
-    private fun getYhteenvetoPdfContext(valmistumispyynnonTarkistusDTO: ValmistumispyynnonTarkistusDTO, valmistumispyynto: Valmistumispyynto): Context {
-        return Context(Locale.forLanguageTag("fi")).apply {
-            setVariable("tarkistus", valmistumispyynnonTarkistusDTO)
-            setVariable("teoriakoulutusSuoritettu", valmistumispyynnonTarkistusDTO.teoriakoulutusSuoritettu)
-            setVariable("teoriakoulutusVaadittu", valmistumispyynnonTarkistusDTO.teoriakoulutusVaadittu)
-            setVariable("sateilusuojakoulutusSuoritettu", valmistumispyynnonTarkistusDTO.sateilusuojakoulutusSuoritettu)
-            setVariable("sateilusuojakoulutusVaadittu", valmistumispyynnonTarkistusDTO.sateilusuojakoulutusVaadittu)
-            setVariable("johtamiskoulutusSuoritettu", valmistumispyynnonTarkistusDTO.johtamiskoulutusSuoritettu)
-            setVariable("johtamiskoulutusVaadittu", valmistumispyynnonTarkistusDTO.johtamiskoulutusVaadittu)
-            setVariable("virkailijanYhteenveto", valmistumispyynnonTarkistusDTO.virkailijanYhteenveto)
-
-            valmistumispyynto.opintooikeus?.let {
-                val tyoskentelyjaksotTilastot = tyoskentelyjaksoService.getTilastot(it)
-                setVariable("tyoskentelyaikaYhteensa", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yhteensaSuoritettu).format())
-                setVariable("arvioErikoistumiseenHyvaksyttavista", daysToPeriod(tyoskentelyjaksotTilastot.arvioErikoistumiseenHyvaksyttavista).format())
-                setVariable("arvioPuuttuvastaKoulutuksesta", daysToPeriod(tyoskentelyjaksotTilastot.arvioPuuttuvastaKoulutuksesta).format())
-                setVariable("terveyskeskusSuoritettu", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.terveyskeskusSuoritettu).format())
-                setVariable("terveyskeskusVaadittuVahintaan", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.terveyskeskusVaadittuVahintaan).format())
-                setVariable("yliopistosairaalaSuoritettu", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yliopistosairaalaSuoritettu).format())
-                setVariable("yliopistosairaalaVaadittuVahintaan", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yliopistosairaalaVaadittuVahintaan).format())
-                setVariable("yliopistosairaaloidenUlkopuolinenSuoritettu",
-                    daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yliopistosairaaloidenUlkopuolinenSuoritettu).format())
-                setVariable("yliopistosairaaloidenUlkopuolinenVaadittuVahintaan",
-                    daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yliopistosairaaloidenUlkopuolinenVaadittuVahintaan).format())
-                setVariable("yhteensaSuoritettu", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yhteensaSuoritettu).format())
-                setVariable("yhteensaVaadittuVahintaan", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yhteensaVaadittuVahintaan).format())
-
-                val koulutusYhteensa = tyoskentelyjaksotTilastot.kaytannonKoulutus.sumOf { koulutus -> koulutus.suoritettu }
-                tyoskentelyjaksotTilastot.kaytannonKoulutus.forEach { koulutus ->
-                    when (koulutus.kaytannonKoulutus) {
-                        OMAN_ERIKOISALAN_KOULUTUS -> {
-                            setVariable("omaErikoisalaSuoritettu", daysToPeriod(koulutus.suoritettu).format())
-                            setVariable("omaErikoisalaOsuus", (koulutus.suoritettu / koulutusYhteensa * 100).toInt())
-                        }
-
-                        OMAA_ERIKOISALAA_TUKEVA_KOULUTUS -> {
-                            setVariable("omaaErikoisalaaTukevaSuoritettu", daysToPeriod(koulutus.suoritettu).format())
-                            setVariable("omaErikoisalaaTukevaOsuus", (koulutus.suoritettu / koulutusYhteensa * 100).toInt())
-                        }
-
-                        TUTKIMUSTYO -> {
-                            setVariable("tutkimustyoSuoritettu", daysToPeriod(koulutus.suoritettu).format())
-                            setVariable("tutkimustyoOsuus", (koulutus.suoritettu / koulutusYhteensa * 100).toInt())
-                        }
-
-                        TERVEYSKESKUSTYO -> {
-                            setVariable("terveyskeskustyoSuoritettu", daysToPeriod(koulutus.suoritettu).format())
-                            setVariable("terveyskeskustyoOsuus", (koulutus.suoritettu / koulutusYhteensa * 100).toInt())
-                        }
-                    }
-                }
-
-                setVariable("tyoskentelyjaksot", tyoskentelyjaksoService.findAllByOpintooikeusId(it.id.required()).sortedByDescending { jakso -> jakso.alkamispaiva })
-                setVariable("tyoskentelyjaksotSuoritettu", tyoskentelyjaksotTilastot.tyoskentelyjaksot.groupBy { jakso -> jakso.id }
-                        .mapValues { jakso -> daysToPeriod(jakso.value.sumOf { value -> value.suoritettu }).format() })
-
-                val teoriakoulutukset = teoriakoulutusService.findAll(it.id.required())
-                setVariable("teoriakoulutukset", teoriakoulutukset)
-                setVariable("teoriakoulutusSuoritettuYhteensa", teoriakoulutukset.filter { koulutus -> koulutus.erikoistumiseenHyvaksyttavaTuntimaara != null }
-                        .sumOf { koulutus -> koulutus.erikoistumiseenHyvaksyttavaTuntimaara.required() })
-                setVariable("teoriakoulutusVaadittu", it.opintoopas?.erikoisalanVaatimaTeoriakoulutustenVahimmaismaara)
-                setVariable("arvioinninKategoriat", getArviointiKategoriat(it.id.required(), true))
-                setVariable("arviointiasteikonTasot", arviointiasteikkoService.findByOpintooikeusId(it.id.required())?.tasot)
-            }
-        }
-    }
-
-    private fun luoYEKYhteenvetoPdf(
-        valmistumispyynnonTarkistusDTO: ValmistumispyynnonTarkistusDTO,
-        valmistumispyynto: Valmistumispyynto
-    ): Asiakirja {
-        val locale = Locale.forLanguageTag("fi")
-        val context = Context(locale).apply {
-            setVariable("tarkistus", valmistumispyynnonTarkistusDTO)
-            setVariable("teoriakoulutusSuoritettu", valmistumispyynnonTarkistusDTO.teoriakoulutusSuoritettu)
-            setVariable("teoriakoulutusVaadittu", valmistumispyynnonTarkistusDTO.teoriakoulutusVaadittu)
-
-            valmistumispyynto.opintooikeus?.let {
-                val tyoskentelyjaksotTilastot = tyoskentelyjaksoService.getTilastot(it)
-                setVariable("tyoskentelyaikaYhteensa", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yhteensaSuoritettu).format())
-                setVariable("arvioErikoistumiseenHyvaksyttavista", daysToPeriod(tyoskentelyjaksotTilastot.arvioErikoistumiseenHyvaksyttavista).format())
-                setVariable("arvioPuuttuvastaKoulutuksesta", daysToPeriod(tyoskentelyjaksotTilastot.arvioPuuttuvastaKoulutuksesta).format())
-                setVariable("terveyskeskusSuoritettu", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.terveyskeskusSuoritettu).format())
-                setVariable("terveyskeskusVaadittuVahintaan", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.terveyskeskusVaadittuVahintaan).format())
-                setVariable("sairaalaSuoritettu", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yliopistosairaalaSuoritettu).format())
-                setVariable("sairaalaVaadittuVahintaan", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yliopistosairaalaVaadittuVahintaan).format())
-                setVariable("muuSuoritettu", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yliopistosairaaloidenUlkopuolinenSuoritettu).format())
-                setVariable("muuVaadittuVahintaan", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yliopistosairaaloidenUlkopuolinenVaadittuVahintaan).format())
-                setVariable("yhteensaSuoritettu", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yhteensaSuoritettu).format())
-                setVariable("yhteensaVaadittuVahintaan", daysToPeriod(tyoskentelyjaksotTilastot.koulutustyypit.yhteensaVaadittuVahintaan).format())
-
-                val tyoskentelyjaksot = tyoskentelyjaksoService.findAllByOpintooikeusId(it.id.required())
-                setVariable("tyoskentelyjaksot", tyoskentelyjaksot.sortedByDescending { jakso -> jakso.alkamispaiva })
-                setVariable("tyoskentelyjaksotSuoritettu", tyoskentelyjaksotTilastot.tyoskentelyjaksot.groupBy { jakso -> jakso.id }
-                        .mapValues { jakso -> daysToPeriod(jakso.value.sumOf { value -> value.suoritettu }).format() })
-                setVariable("laakarikoulutusSuoritettuSuomiTaiBelgia", valmistumispyynto.opintooikeus?.erikoistuvaLaakari?.laakarikoulutusSuoritettuSuomiTaiBelgia)
-
-                val opintosuoritukset = opintosuoritusService.getOpintosuorituksetByOpintooikeusIdAndTyyppi(it.id.required(), OpintosuoritusTyyppiEnum.YEK_TEORIAKOULUTUS)
-                setVariable("teoriakoulutukset", opintosuoritukset.opintosuoritukset)
-            }
-        }
-        return saveYhteenvetoPdf(
-            valmistumispyynto = valmistumispyynto,
-            template = "pdf/valmistumisenyhteenveto_yek.html",
-            fileNamePrefix = "valmistumisen_yhteenveto_yek",
-            context = context
-        )
-    }
-
-    private fun saveYhteenvetoPdf(
-        valmistumispyynto: Valmistumispyynto,
-        template: String,
-        fileNamePrefix: String,
-        context: Context
-    ): Asiakirja {
-        val outputStream = ByteArrayOutputStream()
-        pdfService.luoPdf(template, context, outputStream)
-        val timestamp = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
-
-        val asiakirja = asiakirjaRepository.save(
-            Asiakirja(opintooikeus = valmistumispyynto.opintooikeus, nimi = "${fileNamePrefix}_${timestamp}.pdf", tyyppi = MediaType.APPLICATION_PDF_VALUE,
-                lisattypvm = LocalDateTime.now(), asiakirjaData = AsiakirjaData(data = outputStream.toByteArray()))
-        )
-
-        valmistumispyynto.yhteenvetoAsiakirja = asiakirja
-        valmistumispyyntoRepository.save(valmistumispyynto)
-        return asiakirja
-    }
-
-    private fun luoLiitteetPdf(valmistumispyynto: Valmistumispyynto): Asiakirja {
-        val opintooikeus = valmistumispyynto.opintooikeus.required()
-        val tyoskentelyjaksot = tyoskentelyjaksoRepository.findAllByOpintooikeusId(opintooikeus.id.required())
-
-        val outputStream = ByteArrayOutputStream()
-        try {
-            pdfService.yhdistaAsiakirjat(tyoskentelyjaksot.flatMap { t -> t.asiakirjat }, outputStream)
-        } catch (e: Exception) {
-            log.error("Virhe yhdistäessä asiakirjoja valmistumispyynnölle: ${valmistumispyynto.id}", e)
-        }
-        val timestamp = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
-
-        val asiakirja = asiakirjaRepository.save(
-            Asiakirja(
-                opintooikeus = opintooikeus,
-                nimi = "valmistumisen_yhteenvedon_liitteet_${timestamp}.pdf",
-                tyyppi = MediaType.APPLICATION_PDF_VALUE,
-                lisattypvm = LocalDateTime.now(),
-                asiakirjaData = AsiakirjaData(data = outputStream.toByteArray())
-            )
-        )
-
-        valmistumispyynto.liitteetAsiakirja = asiakirja
-        valmistumispyyntoRepository.save(valmistumispyynto)
-        return asiakirja
-    }
-
-    private fun luoErikoistujanTiedotPdf(valmistumispyynto: Valmistumispyynto) {
-        if (valmistumispyynto.opintooikeus == null) {
-            return
-        }
-        val opintooikeusId = valmistumispyynto.opintooikeus.required().id.required()
-
-        val outputStream = ByteArrayOutputStream()
-        lisaaKoulutussuunnitelma(opintooikeusId, outputStream)
-        lisaaArvioinnit(opintooikeusId, valmistumispyynto, outputStream)
-        lisaaSuoritemerkinnat(opintooikeusId, valmistumispyynto, outputStream)
-        lisaaPaivakirjamerkinnat(opintooikeusId, outputStream)
-        lisaaSeurantajaksot(opintooikeusId, valmistumispyynto, outputStream)
-
-        val timestamp = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
-
-        val asiakirja = asiakirjaRepository.save(
-            Asiakirja(
-                opintooikeus = valmistumispyynto.opintooikeus,
-                nimi = "koulutussuunnitelma_ja_osaaminen_${timestamp}.pdf",
-                tyyppi = MediaType.APPLICATION_PDF_VALUE,
-                lisattypvm = LocalDateTime.now(),
-                asiakirjaData = AsiakirjaData(data = outputStream.toByteArray())
-            )
-        )
-        valmistumispyynto.erikoistujanTiedotAsiakirja = asiakirja
-        valmistumispyyntoRepository.save(valmistumispyynto)
-    }
-
-    private fun lisaaKoulutussuunnitelma(opintooikeusId: Long, outputStream: ByteArrayOutputStream) {
-        val koulutussuunitelma = koulutussuunnitelmaRepository.findOneByOpintooikeusId(opintooikeusId)
-        val locale = Locale.forLanguageTag("fi")
-        val context = Context(locale).apply {
-            setVariable("koulutussuunnitelma", koulutussuunitelma)
-        }
-        pdfService.luoPdf("pdf/erikoistujantiedot/koulutussuunnitelma.html", context, outputStream)
-
-        if (koulutussuunitelma?.motivaatiokirjeAsiakirja != null) {
-            val data = koulutussuunitelma.motivaatiokirjeAsiakirja?.asiakirjaData?.data
-            if (data == null || data.isEmpty()) {
-                log.warn(
-                    "Motivaatiokirjeasiakirja ${koulutussuunitelma.motivaatiokirjeAsiakirja?.id} " +
-                        "data on tyhjä tai null – ohitetaan"
-                )
-            } else {
-                val inputStream = ByteArrayInputStream(outputStream.toByteArray())
-                outputStream.reset()
-                pdfService.yhdistaPdf(inputStream, ByteArrayInputStream(data), outputStream)
-            }
-        }
-    }
-
-    private fun lisaaArvioinnit(
-        opintooikeusId: Long,
-        valmistumispyynto: Valmistumispyynto,
-        outputStream: ByteArrayOutputStream
-    ) {
-        val kategoriat = getArviointiKategoriat(opintooikeusId, false)
-        val arviointiasteikko = valmistumispyynto.opintooikeus?.opintoopas?.arviointiasteikko
-        val arviointiasteikonTasot = arviointiasteikko?.tasot?.associateBy { it.taso }
-        val locale = Locale.forLanguageTag("fi")
-        val context = Context(locale).apply {
-            setVariable("arvioinninKategoriat", kategoriat)
-            setVariable("arviointiasteikko", arviointiasteikko)
-            setVariable("arviointiasteikonTasot", arviointiasteikonTasot)
-        }
-        val arvioinnitStream = ByteArrayOutputStream()
-        pdfService.luoPdf("pdf/erikoistujantiedot/arvioinnit.html", context, arvioinnitStream)
-
-        var result = ByteArrayInputStream(outputStream.toByteArray())
-        var newPdf = ByteArrayInputStream(arvioinnitStream.toByteArray())
-        outputStream.reset()
-        pdfService.yhdistaPdf(result, newPdf, outputStream)
-
-        suoritusarviointiRepository.findAllByTyoskentelyjaksoOpintooikeusId(opintooikeusId)
-            .sortedWith(
-                compareBy<Suoritusarviointi>(
-                    { a -> a.arvioitavatKokonaisuudet.minOf { k -> k.arvioitavaKokonaisuus?.kategoria?.nimi.required() } },
-                    { a -> a.arvioitavatKokonaisuudet.minOf { k -> k.arvioitavaKokonaisuus?.nimi.required() } }).thenByDescending { a -> a.tapahtumanAjankohta })
-            .forEach { a ->
-                val arviointiStream = ByteArrayOutputStream()
-                pdfService.luoPdf(
-                    "pdf/erikoistujantiedot/arviointi.html",
-                    Context(locale).apply {
-                        setVariable("arviointi", suoritusarviointiMapper.toDto(a))
-                        setVariable("arviointiasteikonTasot", arviointiasteikonTasot)
-                        setVariable("vaativuusTasot", getVaativuustasot())
-                    },
-                    arviointiStream
-                )
-
-                result = ByteArrayInputStream(outputStream.toByteArray())
-                newPdf = ByteArrayInputStream(arviointiStream.toByteArray())
-                outputStream.reset()
-                pdfService.yhdistaPdf(result, newPdf, outputStream)
-
-                // FIX (ELSA-1127): only non-empty PDF attachments are merged.
-                // Non-PDF types (e.g. JPEG) are skipped – they were never supported here.
-                // Empty/null data blobs are skipped with a warning – they cause PdfReader to
-                // throw "PDF header not found" and roll back the entire approval transaction.
-                yhdistaPdfAsiakirjat(a.arviointiAsiakirjat, outputStream, "Arviointiasiakirja")
-                yhdistaPdfAsiakirjat(a.itsearviointiAsiakirjat, outputStream, "Itsearviointiasiakirja")
-            }
-    }
-
-    /**
-     * Merges each PDF attachment from [asiakirjat] into [outputStream].
-     * Non-PDF MIME types and empty/null data blobs are skipped with a warning –
-     * passing either to PdfReader throws "PDF header not found" (ELSA-1127).
-     */
-    private fun yhdistaPdfAsiakirjat(
-        asiakirjat: Collection<Asiakirja>,
-        outputStream: ByteArrayOutputStream,
-        label: String
-    ) {
-        asiakirjat.forEach {
-            if (it.tyyppi != MediaType.APPLICATION_PDF_VALUE) {
-                log.warn("$label ${it.id} (${it.nimi}) tyyppiä '${it.tyyppi}' ei tueta PDF-yhdistelyyn – ohitetaan")
-                return@forEach
-            }
-            val data = it.asiakirjaData?.data
-            if (data == null || data.isEmpty()) {
-                log.warn("$label ${it.id} (${it.nimi}) data on tyhjä tai null – ohitetaan")
-                return@forEach
-            }
-            val inputStream = ByteArrayInputStream(outputStream.toByteArray())
-            outputStream.reset()
-            pdfService.yhdistaPdf(inputStream, ByteArrayInputStream(data), outputStream)
-        }
-    }
-
-    private fun lisaaSuoritemerkinnat(opintooikeusId: Long, valmistumispyynto: Valmistumispyynto, outputStream: ByteArrayOutputStream) {
-        val arviointiasteikko = valmistumispyynto.opintooikeus?.opintoopas?.arviointiasteikko
-        val arviointiasteikonTasot = arviointiasteikko?.tasot?.associateBy { it.taso }
-        val suoritemerkinnat = suoritemerkintaRepository.findAllByTyoskentelyjaksoOpintooikeusId(opintooikeusId).groupBy { it.suorite?.id }
-        val suoritteenKategoriat =
-            suoritteenKategoriaRepository.findAllByErikoisalaId(valmistumispyynto.opintooikeus?.erikoisala?.id.required())
-                .sortedBy { it.nimi }.map {
-                    SuoritteenKategoriaWithSuoritemerkinnatDTO(
-                        id = it.id,
-                        nimi = it.nimi,
-                        nimiSv = it.nimiSv,
-                        arviointiasteikko = valmistumispyynto.opintooikeus?.opintoopas?.arviointiasteikko?.nimi,
-                        suoritteet = it.suoritteet.sortedBy { s -> s.nimi }.map { s ->
-                            SuoriteWithSuoritemerkinnatDTO(
-                                id = s.id,
-                                nimi = s.nimi,
-                                nimiSv = s.nimiSv,
-                                voimassaolonAlkamispaiva = s.voimassaolonAlkamispaiva,
-                                voimassaolonPaattymispaiva = s.voimassaolonPaattymispaiva,
-                                vaadittulkm = s.vaadittulkm,
-                                suoritemerkinnat = suoritemerkinnat[s.id]?.sortedByDescending { m -> m.suorituspaiva }
-                                    ?.map(suoritemerkintaMapper::toDto).orEmpty()
-                            )
-                        },
-                        jarjestysnumero = it.jarjestysnumero
-                    )
-                }
-        val locale = Locale.forLanguageTag("fi")
-        val context = Context(locale).apply {
-            setVariable("suoritteenKategoriat", suoritteenKategoriat)
-            setVariable("arviointiasteikko", arviointiasteikko)
-            setVariable("arviointiasteikonTasot", arviointiasteikonTasot)
-        }
-        val suoritemerkinnatStream = ByteArrayOutputStream()
-        pdfService.luoPdf("pdf/erikoistujantiedot/suoritemerkinnat.html", context, suoritemerkinnatStream)
-
-        var result = ByteArrayInputStream(outputStream.toByteArray())
-        var newPdf = ByteArrayInputStream(suoritemerkinnatStream.toByteArray())
-        outputStream.reset()
-        pdfService.yhdistaPdf(result, newPdf, outputStream)
-
-        suoritteenKategoriat.forEach { k ->
-            k.suoritteet?.forEach { ak ->
-                ak.suoritemerkinnat?.forEach { m ->
-                    val suoritemerkintaStream = ByteArrayOutputStream()
-                    pdfService.luoPdf("pdf/erikoistujantiedot/suoritemerkinta.html",
-                        Context(locale).apply {
-                            setVariable("suoritemerkinta", m)
-                            setVariable("arviointiasteikonTasot", arviointiasteikonTasot)
-                            setVariable("vaativuusTasot", getVaativuustasot())
-                        },
-                        suoritemerkintaStream
-                    )
-
-                    result = ByteArrayInputStream(outputStream.toByteArray())
-                    newPdf = ByteArrayInputStream(suoritemerkintaStream.toByteArray())
-                    outputStream.reset()
-                    pdfService.yhdistaPdf(result, newPdf, outputStream)
-                }
-            }
-        }
-    }
-
-    private fun lisaaPaivakirjamerkinnat(opintooikeusId: Long, outputStream: ByteArrayOutputStream) {
-        val paivakirjamerkinnat = paivakirjamerkintaRepository.findAllByOpintooikeusId(opintooikeusId)
-        val locale = Locale.forLanguageTag("fi")
-        val context = Context(locale).apply {
-            setVariable("paivakirjamerkinnat", paivakirjamerkinnat)
-        }
-        val paivakirjamerkinnatStream = ByteArrayOutputStream()
-        pdfService.luoPdf("pdf/erikoistujantiedot/paivittaisetmerkinnat.html", context, paivakirjamerkinnatStream)
-
-        val result = ByteArrayInputStream(outputStream.toByteArray())
-        val newPdf = ByteArrayInputStream(paivakirjamerkinnatStream.toByteArray())
-        outputStream.reset()
-        pdfService.yhdistaPdf(result, newPdf, outputStream)
-    }
-
-    private fun lisaaSeurantajaksot(
-        opintooikeusId: Long,
-        valmistumispyynto: Valmistumispyynto,
-        outputStream: ByteArrayOutputStream
-    ) {
-        val seurantajaksot = seurantajaksoService.findByOpintooikeusId(opintooikeusId)
-        val arviointiasteikko = valmistumispyynto.opintooikeus?.opintoopas?.arviointiasteikko
-        val arviointiasteikonTasot = arviointiasteikko?.tasot?.associateBy { it.taso }
-        val locale = Locale.forLanguageTag("fi")
-
-        seurantajaksot.forEach {
-            val jaksonTiedot = seurantajaksoService.findSeurantajaksonTiedot(
-                it.opintooikeusId.required(),
-                it.alkamispaiva.required(),
-                it.paattymispaiva.required(),
-                it.koulutusjaksot?.map { k -> k.id.required() }.orEmpty()
-            )
-            val seurantajaksoStream = ByteArrayOutputStream()
-            pdfService.luoPdf(
-                "pdf/erikoistujantiedot/seurantajakso.html",
-                Context(locale).apply {
-                    setVariable("seurantajakso", it)
-                    setVariable("seurantajaksonTiedot", jaksonTiedot)
-                    setVariable("arviointiasteikko", arviointiasteikko)
-                    setVariable("arviointiasteikonTasot", arviointiasteikonTasot)
-                },
-                seurantajaksoStream
-            )
-
-            val result = ByteArrayInputStream(outputStream.toByteArray())
-            val newPdf = ByteArrayInputStream(seurantajaksoStream.toByteArray())
-            outputStream.reset()
-            pdfService.yhdistaPdf(result, newPdf, outputStream)
-        }
-    }
-
-    private fun getVaativuustasot(): Map<Int, String> {
-        return mapOf(
-            (1 to "ERITTAIN_HELPPO"),
-            (2 to "MELKO_HELPPO"),
-            (3 to "TAVANOMAINEN"),
-            (4 to "MELKO_VAATIVA"),
-            (5 to "ERITTAIN_VAATIVA")
-        )
-    }
-
-    private fun getArviointiKategoriat(opintooikeusId: Long, korkeinArviointi: Boolean): List<ArvioitavanKokonaisuudenKategoriaWithArvioinnitDTO> {
-        var suoritusarvioinnit = suoritusarviointiRepository.findAllByTyoskentelyjaksoOpintooikeusId(opintooikeusId).flatMap { it.arvioitavatKokonaisuudet }
-        if (korkeinArviointi) {
-            suoritusarvioinnit = suoritusarvioinnit.filter { arviointi -> arviointi.arviointiasteikonTaso != null }
-        }
-
-        val kokonaisuudetMap = suoritusarvioinnit.groupBy { arviointi -> arviointi.arvioitavaKokonaisuus }
-        val kategoriatMap = kokonaisuudetMap.keys.sortedBy { k -> k?.kategoria?.nimi }.groupBy { k -> k?.kategoria }
-        return kategoriatMap.entries.map { m ->
-            ArvioitavanKokonaisuudenKategoriaWithArvioinnitDTO(
-                id = m.key?.id,
-                nimi = m.key?.nimi,
-                nimiSv = m.key?.nimiSv,
-                jarjestysnumero = m.key?.jarjestysnumero,
-                arviointejaYhteensa = if (korkeinArviointi) m.value.size else m.value.sumOf { k -> kokonaisuudetMap[k]?.size ?: 0 },
-                arvioitavatKokonaisuudet = m.value.sortedBy { k -> k?.nimi }.map { k ->
-                    ArvioitavaKokonaisuusWithArvioinnitDTO(
-                        id = k?.id,
-                        nimi = k?.nimi,
-                        nimiSv = k?.nimiSv,
-                        kuvaus = k?.kuvaus,
-                        kuvausSv = k?.kuvausSv,
-                        voimassaoloAlkaa = k?.voimassaoloAlkaa,
-                        voimassaoloLoppuu = k?.voimassaoloLoppuu,
-                        suoritusarvioinnit = if (korkeinArviointi) listOf(kokonaisuudetMap[k]?.sortedByDescending { a -> a.suoritusarviointi?.tapahtumanAjankohta }
-                            ?.maxByOrNull { a -> a.arviointiasteikonTaso.required() }).map { a ->
-                            SuoritusarviointiByKokonaisuusDTO(
-                                id = a?.suoritusarviointi?.id,
-                                tapahtumanAjankohta = a?.suoritusarviointi?.tapahtumanAjankohta,
-                                arvioitavaTapahtuma = a?.suoritusarviointi?.arvioitavaTapahtuma,
-                                arviointiasteikonTaso = a?.arviointiasteikonTaso,
-                                arvioinninAntaja = kayttajaMapper.toDto(a?.suoritusarviointi?.arvioinninAntaja.required()),
-                                tyoskentelyjakso = tyoskentelyjaksoMapper.toDto(requireNotNull(a).suoritusarviointi?.tyoskentelyjakso.required())
-                            )
-                        } else kokonaisuudetMap[k]?.sortedByDescending { a -> a.suoritusarviointi?.tapahtumanAjankohta }
-                            ?.map { a ->
-                                val result = SuoritusarviointiByKokonaisuusDTO(
-                                    id = a.suoritusarviointi?.id,
-                                    tapahtumanAjankohta = a.suoritusarviointi?.tapahtumanAjankohta,
-                                    arvioitavaTapahtuma = a.suoritusarviointi?.arvioitavaTapahtuma,
-                                    arviointiasteikonTaso = a.arviointiasteikonTaso,
-                                    itsearviointiArviointiasteikonTaso = a.itsearviointiArviointiasteikonTaso,
-                                    arvioinninAntaja = kayttajaMapper.toDto(a.suoritusarviointi?.arvioinninAntaja.required()),
-                                    arvioinninSaaja = kayttajaMapper.toDto(a.suoritusarviointi?.tyoskentelyjakso?.opintooikeus?.erikoistuvaLaakari?.kayttaja.required()),
-                                    tyoskentelyjakso = tyoskentelyjaksoMapper.toDto(a.suoritusarviointi?.tyoskentelyjakso.required()),
-                                    arviointiAsiakirjat = a.suoritusarviointi?.arviointiAsiakirjat?.map { asiakirja ->
-                                        asiakirjaMapper.toDto(
-                                            asiakirja
-                                        )
-                                    },
-                                    itsearviointiAsiakirjat = a.suoritusarviointi?.itsearviointiAsiakirjat?.map { asiakirja -> asiakirjaMapper.toDto(asiakirja) })
-                                result
-                            }
-                    )
-                }
-            )
-        }
-    }
-
-    private fun daysToPeriod(days: Double): Period {
-        return Period.of(days.toYears(), days.toMonths(), days.toDays())
-    }
 }


### PR DESCRIPTION
This pull request introduces several new service classes related to the processing and management of graduation requests ("valmistumispyyntö") in the Elsa system. The changes add functionality for generating, retrieving, and evaluating documents and assessments associated with graduation requests, as well as for organizing and archiving these documents. The main themes are the creation and management of PDFs, document access control, assessment evaluation, and data aggregation for graduation processes.

The most important changes are:

**PDF Generation and Aggregation:**

* Added `ValmistumispyynnonArviointiPdfService` to generate and aggregate assessment summary and individual assessment PDFs, including supporting the merging of related documents and handling of PDF content types.
* Introduced `ValmistumispyynnonAsiakirjojenLuontiService` to orchestrate the creation of summary and attachment PDFs for graduation requests, handling different flows for YEK and non-YEK specialties and returning metadata for archiving.

**Document Access and Security:**

* Added `ValmistumispyynnonAsiakirjaService` to control and validate access to graduation request documents and attachments, ensuring only authorized users or officials can retrieve specific documents, and providing logic for access based on user roles and affiliations.

**Assessment Data Aggregation and Evaluation:**

* Introduced `ValmistumispyynnonArviointitietoService` to aggregate, map, and organize assessment data by categories and entities, supporting both highest-grade-only and all-assessments views, and providing DTOs for downstream use.
* Added `ValmistumispyynnonArviointienTilaService` to evaluate the status of assessments for a graduation request, determining if any assessments are missing or below a minimum threshold, and returning a summary DTO.