### PR TITLE
ELSA-1194: Olemassa olevan vastuuhenkilön lisääminen erikoistuvan arvioijaksi tai kouluttajaksi ei enää laajenna hänen käyttöoikeuksiaan tahattomasti.

### DIFF
--- a/e2e/cypress.config.ts
+++ b/e2e/cypress.config.ts
@@ -3,7 +3,7 @@ import { registerDbTasks } from './cypress/plugins/db-tasks'
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:8080',
+    baseUrl: 'http://localhost:9060',
     specPattern: 'cypress/e2e/**/*.cy.ts',
     supportFile: 'cypress/support/e2e.ts',
     setupNodeEvents(on) {

--- a/e2e/cypress.config.ts
+++ b/e2e/cypress.config.ts
@@ -3,7 +3,7 @@ import { registerDbTasks } from './cypress/plugins/db-tasks'
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:9060',
+    baseUrl: 'http://localhost:8080',
     specPattern: 'cypress/e2e/**/*.cy.ts',
     supportFile: 'cypress/support/e2e.ts',
     setupNodeEvents(on) {

--- a/e2e/cypress/e2e/security/vastuuhenkilon-oikeuksien-laajeneminen.cy.ts
+++ b/e2e/cypress/e2e/security/vastuuhenkilon-oikeuksien-laajeneminen.cy.ts
@@ -1,0 +1,102 @@
+import {
+  E2E_ERIKOISTUVA_EMAIL,
+  VASTUUHENKILO_EMAIL,
+} from '../../support/commands/credentials'
+
+export {}
+
+const VASTUUHENKILO_ETUNIMI = 'Mia'
+const VASTUUHENKILO_SUKUNIMI = 'Ålands'
+const VASTUUHENKILON_ERIKOISALA_ID = 1
+
+describe('Vastuuhenkilön oikeuksien tahaton laajeneminen', () => {
+  let alkuperaisetRajaimet: unknown
+  let erikoistuvanOpintooikeusId: number
+  let vastuuhenkiloToken: string
+
+  before(() => {
+    Cypress.session.clearAllSavedSessions()
+    cy.task('db:cleanupErikoistuva', { email: E2E_ERIKOISTUVA_EMAIL })
+    cy.task('db:cleanupVastuuhenkilo', { email: VASTUUHENKILO_EMAIL })
+
+    cy.seedVastuuhenkiloUser(
+      {
+        email: VASTUUHENKILO_EMAIL,
+        etunimi: VASTUUHENKILO_ETUNIMI,
+        sukunimi: VASTUUHENKILO_SUKUNIMI,
+        // Erikoistuvan oletuserikoisala on 46. Vastuuhenkilö kuuluu tarkoituksella
+        // eri erikoisalalle, jotta hänen oikeuksiensa ei pidä laajentua kutsusta.
+        erikoisalaId: VASTUUHENKILON_ERIKOISALA_ID,
+      },
+      'vastuuhenkiloToken'
+    ).then((result) => {
+      expect(result?.token, 'vastuuhenkilön kirjautumistunniste').to.be.a('string').and.not.be.empty
+      vastuuhenkiloToken = result!.token!
+      cy.loginAsVastuuhenkilo(vastuuhenkiloToken)
+    })
+
+    cy.apiRequest({
+      method: 'GET',
+      url: '/api/vastuuhenkilo/etusivu/erikoistujien-seuranta-rajaimet',
+    }).then(({ status, body }) => {
+      expect(status).to.eq(200)
+      alkuperaisetRajaimet = body
+    })
+
+    cy.loginAsErikoistuva()
+    cy.task('db:getActiveOpintooikeusId', { email: E2E_ERIKOISTUVA_EMAIL }).then((id) => {
+      erikoistuvanOpintooikeusId = Number(id)
+      expect(erikoistuvanOpintooikeusId).to.be.greaterThan(0)
+    })
+
+    // Sama operaatio, jonka arviointipyyntö-, keskustelu- ja katseluoikeuslomakkeet
+    // tekevät, kun olemassa oleva vastuuhenkilö lisätään arvioijaksi.
+    cy.apiRequest({
+      method: 'POST',
+      url: '/api/erikoistuva-laakari/lahikouluttajat',
+      body: {
+        etunimi: VASTUUHENKILO_ETUNIMI,
+        sukunimi: VASTUUHENKILO_SUKUNIMI,
+        sahkoposti: VASTUUHENKILO_EMAIL,
+      },
+    }).then(({ status }) => {
+      expect(status).to.eq(200)
+    })
+  })
+
+  after(() => {
+    cy.task('db:cleanupVastuuhenkilo', { email: VASTUUHENKILO_EMAIL })
+    cy.task('db:cleanupErikoistuva', { email: E2E_ERIKOISTUVA_EMAIL })
+  })
+
+  it('ei laajenna vastuuhenkilön erikoisaloja tai anna pääsyä erikoistujan tietoihin', () => {
+    cy.loginAsVastuuhenkilo(vastuuhenkiloToken)
+
+    let rajaimetKutsunJalkeen: unknown
+    let impersonoinninStatus: number
+
+    cy.apiRequest({
+      method: 'GET',
+      url: '/api/vastuuhenkilo/etusivu/erikoistujien-seuranta-rajaimet',
+    }).then(({ status, body }) => {
+      expect(status).to.eq(200)
+      rajaimetKutsunJalkeen = body
+    })
+
+    cy.apiRequest({
+      method: 'GET',
+      url: `/api/login/impersonate?opintooikeusId=${erikoistuvanOpintooikeusId}`,
+      failOnStatusCode: false,
+      followRedirect: false,
+    }).then(({ status }) => {
+      impersonoinninStatus = status
+    })
+
+    cy.then(() => {
+      expect(rajaimetKutsunJalkeen).to.deep.equal(alkuperaisetRajaimet)
+      // Käyttäjä on kirjautunut sisään, mutta hänellä ei ole oikeutta
+      // impersonoida eri erikoisalan erikoistujaa.
+      expect(impersonoinninStatus).to.eq(403)
+    })
+  })
+})

--- a/e2e/cypress/plugins/db-tasks/kayttaja-utils.ts
+++ b/e2e/cypress/plugins/db-tasks/kayttaja-utils.ts
@@ -8,19 +8,24 @@ export async function ensureYliopistoLink(client: Client, kayttajaId: number): P
   )
 }
 
-export async function ensureYliopistoErikoisalaLink(client: Client, kayttajaId: number): Promise<number> {
+export async function ensureYliopistoErikoisalaLink(
+  client: Client,
+  kayttajaId: number,
+  yliopistoId = 1,
+  erikoisalaId = 46
+): Promise<number> {
   const existing = await client.query(
     `SELECT id FROM kayttaja_yliopisto_erikoisala
-     WHERE kayttaja_id = $1 AND yliopisto_id = 1 AND erikoisala_id = 46`,
-    [kayttajaId]
+     WHERE kayttaja_id = $1 AND yliopisto_id = $2 AND erikoisala_id = $3`,
+    [kayttajaId, yliopistoId, erikoisalaId]
   )
   if (existing.rows.length > 0) return existing.rows[0].id
 
   return (
     await client.query(
       `INSERT INTO kayttaja_yliopisto_erikoisala (kayttaja_id, yliopisto_id, erikoisala_id)
-       VALUES ($1, 1, 46) RETURNING id`,
-      [kayttajaId]
+       VALUES ($1, $2, $3) RETURNING id`,
+      [kayttajaId, yliopistoId, erikoisalaId]
     )
   ).rows[0].id
 }

--- a/e2e/cypress/plugins/db-tasks/opintooikeus.ts
+++ b/e2e/cypress/plugins/db-tasks/opintooikeus.ts
@@ -1,6 +1,6 @@
 import { Client } from 'pg'
 import { dbClient, withDb } from './db-client'
-import {addRoletoUser, getErikoistujaLaakariId} from './db-helpers'
+import {addRoletoUser, getErikoistujaLaakariId, getOpintooikeusId} from './db-helpers'
 
 export type OpintoOikeus = {
   id: number,
@@ -24,6 +24,10 @@ export type OpintoOikeus = {
 
 
 export const opintoOikeusTasks = {
+  async 'db:getActiveOpintooikeusId'({ email }: { email: string }): Promise<number | null> {
+    return withDb(dbClient, async (client: Client) => getOpintooikeusId(client, email))
+  },
+
   async 'db:seedOpintooikeus'({
     email,
     opintoOikeus,

--- a/e2e/cypress/plugins/db-tasks/vastuuhenkilo.ts
+++ b/e2e/cypress/plugins/db-tasks/vastuuhenkilo.ts
@@ -47,10 +47,14 @@ export const vastuuhenkiloTasks = {
     email,
     etunimi,
     sukunimi,
+    yliopistoId = 1,
+    erikoisalaId = 46,
   }: {
     email: string
     etunimi: string
     sukunimi: string
+    yliopistoId?: number
+    erikoisalaId?: number
   }): Promise<{ kayttajaId: number; token?: string } | null> {
     return withDb(dbClient, async (client: Client) => {
       await client.query(
@@ -60,7 +64,12 @@ export const vastuuhenkiloTasks = {
 
       const existing = await fetchUserIdsByEmailOrLogin(client, email)
       if (existing) {
-        const yeId = await ensureYliopistoErikoisalaLink(client, existing.kayttajaId)
+        const yeId = await ensureYliopistoErikoisalaLink(
+          client,
+          existing.kayttajaId,
+          yliopistoId,
+          erikoisalaId
+        )
         await seedTehtavatyyppit(client, yeId)
         await ensureUserAuthority(client, existing.userId, ROLE)
         return { kayttajaId: existing.kayttajaId }
@@ -68,7 +77,12 @@ export const vastuuhenkiloTasks = {
 
       // Custom linkFn for vastuuhenkilo: ensure link and seed tehtavatyyppit
       const linkFn = async (client: Client, kayttajaId: number) => {
-        const yeId = await ensureYliopistoErikoisalaLink(client, kayttajaId)
+        const yeId = await ensureYliopistoErikoisalaLink(
+          client,
+          kayttajaId,
+          yliopistoId,
+          erikoisalaId
+        )
         await seedTehtavatyyppit(client, yeId)
         return yeId
       }

--- a/e2e/cypress/support/commands/setup.ts
+++ b/e2e/cypress/support/commands/setup.ts
@@ -11,12 +11,22 @@ type SeedUser = {
   sukunimi: string
 }
 
+type SeedVastuuhenkilo = SeedUser & {
+  yliopistoId?: number
+  erikoisalaId?: number
+}
+
+type SeededUser = {
+  kayttajaId: number
+  token?: string
+} | null
+
 type KoejaksoSetupOptions = {
   erikoistuvaEmail?: string
   cleanupSupportUsers?: boolean
   seedVirkailija?: boolean
   kouluttaja?: SeedUser
-  vastuuhenkilo?: SeedUser
+  vastuuhenkilo?: SeedVastuuhenkilo
   virkailija?: SeedUser
   storeTokens?: boolean
 }
@@ -75,7 +85,10 @@ declare global {
       /**
        * Seeds a single vastuuhenkilo support user and optionally stores its token in Cypress.env.
        */
-      seedVastuuhenkiloUser(user: SeedUser, tokenEnvKey?: string): void
+      seedVastuuhenkiloUser(
+        user: SeedVastuuhenkilo,
+        tokenEnvKey?: string
+      ): Chainable<SeededUser>
 
       /**
        * Resets koejakso state, seeds support users, logs in as erikoistuva, and seeds kouluttajavaltuutus.
@@ -124,7 +137,7 @@ Cypress.Commands.add('seedKouluttajaUser', (user: SeedUser, tokenEnvKey?: string
   })
 })
 
-const seedVastuuhenkilo = (user: SeedUser, storeTokens: boolean) => {
+const seedVastuuhenkilo = (user: SeedVastuuhenkilo, storeTokens: boolean) => {
   return cy.task('db:seedVastuuhenkilo', user).then((result: any) => {
     Cypress.env('vastuuhenkiloId', Number(result?.kayttajaId))
     if (storeTokens) {
@@ -133,11 +146,12 @@ const seedVastuuhenkilo = (user: SeedUser, storeTokens: boolean) => {
   })
 }
 
-Cypress.Commands.add('seedVastuuhenkiloUser', (user: SeedUser, tokenEnvKey?: string) => {
-  cy.task('db:seedVastuuhenkilo', user).then((result: any) => {
+Cypress.Commands.add('seedVastuuhenkiloUser', (user: SeedVastuuhenkilo, tokenEnvKey?: string) => {
+  return cy.task<SeededUser>('db:seedVastuuhenkilo', user).then((result) => {
     if (tokenEnvKey) {
       Cypress.env(tokenEnvKey, result?.token)
     }
+    return result
   })
 })
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KayttajaServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/KayttajaServiceImpl.kt
@@ -235,6 +235,14 @@ class KayttajaServiceImpl(
                 val erikoistuvanYliopisto = requireNotNull(opintooikeus.yliopisto)
                 val erikoistuvanErikoisala = requireNotNull(opintooikeus.erikoisala)
 
+                // Vastuuhenkilö voi toimia yksittäisen erikoistujan kouluttajana tai arvioijana
+                // ilman, että hänelle annetaan vastuuhenkilön oikeuksia erikoistujan erikoisalalle.
+                // KayttajaYliopistoErikoisala-rivi laajentaisi vastuuhenkilön oikeudet kaikkiin saman
+                // yliopiston ja erikoisalan erikoistujiin.
+                if (it.user?.authorities?.any { authority -> authority.name == VASTUUHENKILO } == true) {
+                    return@let kayttajaMapper.toDto(it)
+                }
+
                 if (it.yliopistotAndErikoisalat.any { yliopistotAndErikoisalat ->
                         yliopistotAndErikoisalat.yliopisto?.id == erikoistuvanYliopisto.id &&
                             yliopistotAndErikoisalat.erikoisala?.id == erikoistuvanErikoisala.id

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariMuutToiminnotResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariMuutToiminnotResourceIT.kt
@@ -15,6 +15,7 @@ import fi.elsapalvelu.elsa.domain.perustiedot.YliopistoEnum
 import fi.elsapalvelu.elsa.repository.kayttaja.KayttajaRepository
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI
 import fi.elsapalvelu.elsa.security.KOULUTTAJA
+import fi.elsapalvelu.elsa.security.VASTUUHENKILO
 import fi.elsapalvelu.elsa.service.dto.kayttaja.UusiLahikouluttajaDTO
 import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
 import fi.elsapalvelu.elsa.web.rest.convertObjectToJsonBytes
@@ -200,9 +201,48 @@ class ErikoistuvaLaakariMuutToiminnotResourceIT {
         assertThat(yliopistotAndErikoisalatList[1].erikoisala).isEqualTo(opintooikeus.erikoisala)
     }
 
-    fun initKouluttajaWithYliopistoAndErikoisala(yliopisto: Yliopisto? = null, erikoisala: Erikoisala? = null) {
-         val kouluttajaUser =
-            KayttajaResourceWithMockUserIT.createEntity(TyoskentelypaikkaHelper.DEFAULT_NIMI, DEFAULT_EMAIL, Authority(name = KOULUTTAJA))
+    @Test
+    @Transactional
+    fun `test that existing vastuuhenkilo does not get erikoistuva yliopisto and erikoisala`() {
+        initKouluttajaWithYliopistoAndErikoisala(authority = Authority(name = VASTUUHENKILO))
+
+        val vastuuhenkiloBefore = kayttajaRepository.findOneByUserEmail(DEFAULT_EMAIL).get()
+        assertThat(vastuuhenkiloBefore.yliopistotAndErikoisalat).hasSize(1)
+        val yliopistotAndErikoisalatBefore = vastuuhenkiloBefore.yliopistotAndErikoisalat.map {
+            Triple(it.id, it.yliopisto?.id, it.erikoisala?.id)
+        }
+
+        val uusiLahikouluttajaDTO =
+            UusiLahikouluttajaDTO(DEFAULT_ETUNIMI, DEFAULT_SUKUNIMI, DEFAULT_EMAIL)
+
+        restLahikouluttajatMockMvc.perform(
+            post("/api/erikoistuva-laakari/lahikouluttajat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(convertObjectToJsonBytes(uusiLahikouluttajaDTO))
+                .with(csrf())
+        ).andExpect(status().isOk)
+
+        em.flush()
+        em.clear()
+
+        val vastuuhenkiloAfter = kayttajaRepository.findOneByUserEmail(DEFAULT_EMAIL).get()
+        assertThat(vastuuhenkiloAfter.yliopistotAndErikoisalat).hasSize(1)
+        assertThat(vastuuhenkiloAfter.yliopistotAndErikoisalat.map {
+            Triple(it.id, it.yliopisto?.id, it.erikoisala?.id)
+        }).containsExactlyElementsOf(yliopistotAndErikoisalatBefore)
+    }
+
+    fun initKouluttajaWithYliopistoAndErikoisala(
+        yliopisto: Yliopisto? = null,
+        erikoisala: Erikoisala? = null,
+        authority: Authority = Authority(name = KOULUTTAJA)
+    ) {
+        val kouluttajaUser =
+            KayttajaResourceWithMockUserIT.createEntity(
+                TyoskentelypaikkaHelper.DEFAULT_NIMI,
+                DEFAULT_EMAIL,
+                authority
+            )
         em.persist(kouluttajaUser)
         em.flush()
         val kouluttajaKayttaja = KayttajaHelper.createEntity(em, kouluttajaUser)


### PR DESCRIPTION
This pull request introduces an end-to-end (E2E) test and supporting backend changes to ensure that when an existing "vastuuhenkilo" (responsible person) is added as an evaluator or trainer for a "erikoistuva" (specializing doctor), their access rights are not unintentionally expanded. The changes also generalize and improve the test and seed utilities to handle more flexible user seeding and authority assignment.

The most important changes are:

**E2E Test Coverage and Support:**

* Added a new E2E test (`vastuuhenkilon-oikeuksien-laajeneminen.cy.ts`) to verify that a vastuuhenkilo's rights are not broadened when added as an evaluator for a different specialty, and that no unauthorized access is granted to the erikoistuva's data.
* Extended Cypress commands and types to allow seeding vastuuhenkilo users with custom `yliopistoId` and `erikoisalaId`, and to return seeded user information and tokens for use in tests. [[1]](diffhunk://#diff-d39ae7bdbd25322db92f1c434fcb0c17e204b8ad1152c83f32ab6e4661db049dR14-R29) [[2]](diffhunk://#diff-d39ae7bdbd25322db92f1c434fcb0c17e204b8ad1152c83f32ab6e4661db049dL78-R91) [[3]](diffhunk://#diff-d39ae7bdbd25322db92f1c434fcb0c17e204b8ad1152c83f32ab6e4661db049dL127-R140) [[4]](diffhunk://#diff-d39ae7bdbd25322db92f1c434fcb0c17e204b8ad1152c83f32ab6e4661db049dL136-R154)

**Backend Logic and Database Utilities:**

* Updated the backend logic (`KayttajaServiceImpl.kt`) so that when an existing vastuuhenkilo is added as an evaluator, their access rights are not expanded to cover all specializing doctors of the new specialty and university—preserving least privilege.
* Generalized the database helper function `ensureYliopistoErikoisalaLink` to accept arbitrary `yliopistoId` and `erikoisalaId` parameters, supporting more flexible test setups.
* Enhanced the vastuuhenkilo seeding task to support custom university and specialty IDs, ensuring correct authority and relationship assignment during test setup. [[1]](diffhunk://#diff-9515ab15c7646d375c30845442a1cb0d0f64374f809c121100959d45600b85b0R50-R57) [[2]](diffhunk://#diff-9515ab15c7646d375c30845442a1cb0d0f64374f809c121100959d45600b85b0L63-R85)

**Testing and Validation:**

* Added a backend integration test to confirm that an existing vastuuhenkilo does not receive new specialty-university links when added as an evaluator, ensuring the backend enforces the correct access control. [[1]](diffhunk://#diff-a62880ce53f2b9e0bfaf3159ec221fc8100ee5c7334108f2edf14263ec42db4bR18) [[2]](diffhunk://#diff-a62880ce53f2b9e0bfaf3159ec221fc8100ee5c7334108f2edf14263ec42db4bL203-R245)

**Other Improvements:**

* Added a new task to fetch an erikoistuva's active `opintooikeusId` for use in E2E tests. [[1]](diffhunk://#diff-490bf1c4b16f4635a273bc334301bb3e777bea8b305f96b1c76d73ace6e65a80L3-R3) [[2]](diffhunk://#diff-490bf1c4b16f4635a273bc334301bb3e777bea8b305f96b1c76d73ace6e65a80R27-R30)