### PR TITLE
ELSA-1199 implement PDF content validation and enhance error handling…

### DIFF
--- a/e2e/cypress/e2e/tyoskentelyjakso/tyoskentelyjakso.cy.ts
+++ b/e2e/cypress/e2e/tyoskentelyjakso/tyoskentelyjakso.cy.ts
@@ -13,38 +13,26 @@
  */
 
 describe('Työskentelyjakso', () => {
-  before(() => {
+  beforeEach(() => {
     cy.resetErikoistuvaE2eState()
     cy.loginAsErikoistuva()
   })
 
-  it('suorittaa koko Työskentelyjakson lisäämisen käyttötapauksen (case 4)', () => {
-    // --- Vaihe 1: Siirrytään työskentelyjaksojen listaukseen ---
+  const openAndFillNewTyoskentelyjakso = (tyoskentelypaikka: string) => {
     cy.visit('/tyoskentelyjaksot')
     cy.contains('h1', 'Työskentelyjaksot').should('be.visible')
-
-    // --- Vaihe 2: Täytetään ja lähetetään työskentelyjakso -lomake ---
     cy.visit('/tyoskentelyjaksot/uusi')
-    // Odotetaan, että lomake latautuu (varmistetaan että työskentelypaikan nimi -kenttä on näkyvissä)
     cy.get('.lisaa-tyoskentelyjakso').should('be.visible')
     cy.get('[data-testid="loading"]', { timeout: 10000 }).should('not.exist')
-    // Tyyppi – valitaan ensimmäinen saatavilla oleva radiovaihtoehto
-    cy.get('input[type="radio"][name="tyoskentelyjakso-tyyppi"]')
-      .first()
-      .click({ force: true })
-    // Työskentelypaikan nimi
+    cy.get('input[type="radio"][name="tyoskentelyjakso-tyyppi"]').first().click({ force: true })
     cy.contains('label', 'Työskentelypaikka')
       .parent()
       .find('input[type="text"]')
       .first()
       .clear()
-      .type('E2E Testisairaala')
-    // Kunta – valitaan ensimmäinen monivalintavaihtoehto
-    cy.contains('label', 'Kunta')
-      .parent()
-      .as('kuntaGroup')
+      .type(tyoskentelypaikka)
+    cy.contains('label', 'Kunta').parent().as('kuntaGroup')
     cy.selectFirstMultiselectOption(cy.get('@kuntaGroup'))
-    // Alkamispäivä
     cy.contains('label', 'Alkamispäivä')
       .parent()
       .find('input.date-input')
@@ -52,7 +40,6 @@ describe('Työskentelyjakso', () => {
       .clear()
       .type('01.01.2025')
       .blur()
-    // Päättymispäivä
     cy.contains('label', 'Päättymispäivä')
       .parent()
       .find('input.date-input')
@@ -61,17 +48,45 @@ describe('Työskentelyjakso', () => {
       .type('30.06.2027')
       .blur()
 
-    // Työaika (osaaikaprosentti) – pakollinen kenttä (50–100%)
     cy.get('input[type="number"]').first().clear().type('100')
-
-    // Käytännön koulutus – pakollinen radiovaihtoehto
     cy.get('input[type="radio"][name="kaytannon-koulutus-tyyppi"]').first().click({ force: true })
+  }
+
+  it('estää virheellisen sisällön lähettämisen PDF-tiedostona', () => {
+    openAndFillNewTyoskentelyjakso('E2E Virheellinen PDF')
+
+    cy.get('input[type="file"]')
+      .first()
+      .selectFile(
+        {
+          contents: Cypress.Buffer.from('DOCX content, not a PDF. '.repeat(512)),
+          fileName: 'virheellinen.pdf',
+          mimeType: 'application/pdf'
+        },
+        { force: true }
+      )
+
+    cy.intercept('POST', '**/erikoistuva-laakari/tyoskentelyjaksot').as(
+      'invalidTyoskentelyjaksoPost'
+    )
+    cy.contains('button', 'Lisää').click()
+
+    cy.wait('@invalidTyoskentelyjaksoPost', { timeout: 30000 })
+      .its('response.statusCode')
+      .should('eq', 400)
+    cy.url().should('include', '/tyoskentelyjaksot/uusi')
+    cy.contains(
+      '.toast-body',
+      'Työskentelyjakson tallentaminen epäonnistui: tiedosto ei ole kelvollinen tai samanniminen tiedosto on jo olemassa'
+    ).should('be.visible')
+  })
+
+  it('suorittaa koko Työskentelyjakson lisäämisen käyttötapauksen (case 4)', () => {
+    // --- Vaihe 1–2: Täytetään ja lähetetään työskentelyjakso PDF-liitteineen ---
+    openAndFillNewTyoskentelyjakso('E2E Testisairaala')
 
     // Työtodistus – tiedoston liittäminen
-    cy.get('input[type="file"]').first().selectFile(
-      'cypress/fixtures/test.pdf',
-      { force: true }
-    )
+    cy.get('input[type="file"]').first().selectFile('cypress/fixtures/test.pdf', { force: true })
     cy.wait(1)
     // Lähetä lomake
     cy.contains('button', 'Lisää').click()
@@ -90,9 +105,7 @@ describe('Työskentelyjakso', () => {
     cy.contains('Lisää poissaolo').click()
     cy.url().should('include', '/poissaolot/uusi')
     // Poissaolon syy
-    cy.contains('label', 'Poissaolon syy')
-      .parent()
-      .as('syy')
+    cy.contains('label', 'Poissaolon syy').parent().as('syy')
     cy.selectFirstMultiselectOption(cy.get('@syy'))
     // Poissaolon alkamispäivä
     cy.contains('label', 'Alkamispäivä')

--- a/e2e/cypress/e2e/valmistumispyynto/valmistumispyynto.cy.ts
+++ b/e2e/cypress/e2e/valmistumispyynto/valmistumispyynto.cy.ts
@@ -196,6 +196,44 @@ describe('Valmistumispyyntö', () => {
         expect(status).to.eq(200)
         expect(body.valmistumispyynto.tila).to.eq('ODOTTAA_VASTUUHENKILON_HYVAKSYNTAA')
       })
+
+      // Legacy invalid PDF attachments block approval and the UI identifies the file
+      // and assessment so that it can be removed or replaced intentionally.
+      cy.intercept(
+        {
+          method: 'PUT',
+          url: `**/api/vastuuhenkilo/valmistumispyynnon-hyvaksynta/${valmistumispyyntoId}`,
+          times: 1,
+        },
+        {
+          statusCode: 400,
+          headers: { 'content-type': 'application/problem+json' },
+          body: {
+            message: 'error.dataillegal.valmistumispyynnon-liite-ei-ole-kelvollinen-pdf',
+            attachmentId: 27536,
+            attachmentName: 'Leikkaustaitojen arviointityökalu.pdf',
+            attachmentSource: 'arviointi',
+            attachmentDate: '2023-02-23',
+          },
+        }
+      ).as('invalidPdfApproval')
+
+      cy.visit(`/valmistumispyynnon-hyvaksynta/${valmistumispyyntoId}`)
+      cy.contains('button', 'Hyväksy').click()
+      cy.get('#confirm-send').should('be.visible').contains('button', 'Hyväksy').click()
+      cy.wait('@invalidPdfApproval').its('response.statusCode').should('eq', 400)
+      cy.contains(
+        'Valmistumispyynnön hyväksynnän lähetys epäonnistui: ' +
+          'Valmistumispyyntöön liittyvä liite "Leikkaustaitojen arviointityökalu.pdf" ' +
+          '(Arviointi 23.2.2023) ei ole kelvollinen PDF-tiedosto. ' +
+          'Pyydä liitteen lisääjää poistamaan se tai korvaamaan se kelvollisella ' +
+          'PDF-tiedostolla ja yritä hyväksyntää uudelleen.'
+      ).should('be.visible')
+      cy.location('pathname').should(
+        'eq',
+        `/valmistumispyynnon-hyvaksynta/${valmistumispyyntoId}`
+      )
+
       cy.apiRequest({
         method: 'PUT',
         url: `/api/vastuuhenkilo/valmistumispyynnon-hyvaksynta/${valmistumispyyntoId}`,

--- a/e2e/cypress/e2e/valmistumispyynto/valmistumispyynto.cy.ts
+++ b/e2e/cypress/e2e/valmistumispyynto/valmistumispyynto.cy.ts
@@ -219,6 +219,12 @@ describe('Valmistumispyyntö', () => {
       ).as('invalidPdfApproval')
 
       cy.visit(`/valmistumispyynnon-hyvaksynta/${valmistumispyyntoId}`)
+      cy.contains('label', 'Matkapuhelinnumero')
+        .parent()
+        .find('input')
+        .clear()
+        .type('+358501234567')
+        .should('have.value', '+358501234567')
       cy.contains('button', 'Hyväksy').click()
       cy.get('#confirm-send').should('be.visible').contains('button', 'Hyväksy').click()
       cy.wait('@invalidPdfApproval').its('response.statusCode').should('eq', 400)

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/pg": "^8.11.0",
-    "cypress": "^15.20.1",
+    "cypress": "^15.21.0",
     "pg": "^8.13.0",
     "typescript": "^6.0.0"
   }

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -194,6 +194,14 @@ chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chrome-remote-interface@0.33.3:
+  version "0.33.3"
+  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.33.3.tgz#d8b4339f487b460a9461af7355bda98054e8e1a4"
+  integrity sha512-zNnn0prUL86Teru6UCAZ1yU1XeXljHl3gj7OrfPcarEfU62OUU4IujDPdTDW3dAWwRqN3ZMG/Chhkh2gPL/wiw==
+  dependencies:
+    commander "2.11.x"
+    ws "^7.2.0"
+
 ci-info@^4.1.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.4.0.tgz#7d54eff9f54b45b62401c26032696eb59c8bd18c"
@@ -252,6 +260,11 @@ combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.11.x:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+  integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
+
 commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
@@ -276,10 +289,10 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@^15.20.1:
-  version "15.20.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.20.1.tgz#60b61b4682523400b55b46ecbe703dd66f26dfab"
-  integrity sha512-7GV3O7vQQG+EVVv9BGs6lCHY49x25jVi/z1+zdjuuq/o3eZeDwmGPJpRYnOWeGvQxTCtkydXWHBPhV8xuGXPLg==
+cypress@^15.21.0:
+  version "15.21.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.21.0.tgz#61017bb85ae2886fefcd2b9b4c21b47cb62a1b6b"
+  integrity sha512-6uPy5GUjao97t/QDIwlPyJz4JUqPpFIPq5lNazN95LSA3ynJoYC1sHZ3W+aj4f+K1OFGbMfno0+OX2Gx0OmlPA==
   dependencies:
     "@cypress/request" "^4.0.0"
     "@cypress/xvfb" "^1.2.4"
@@ -292,6 +305,7 @@ cypress@^15.20.1:
     buffer "^5.7.1"
     cachedir "^2.4.0"
     chalk "^4.1.0"
+    chrome-remote-interface "0.33.3"
     ci-info "^4.1.0"
     cli-table3 "0.6.1"
     commander "^6.2.1"
@@ -1236,6 +1250,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^7.2.0:
+  version "7.5.13"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.13.tgz#12aa507eaca76c295c278b1aebf4698ab2c1845f"
+  integrity sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==
 
 xtend@^4.0.0:
   version "4.0.2"

--- a/frontend/src/locales/fi.json
+++ b/frontend/src/locales/fi.json
@@ -288,6 +288,7 @@
       "tyoskentelyjaksojen-yhteenlaskettu-aika-ylittyy": "päällekkäisten työskentelyjaksojen yhteenlaskettu työaika ylittää 100%",
       "uuden-lahikouluttajan-voi-lisata-vain-erikoistuva-laakari": "uuden lahikouluttajan voi lisätä vain erikoistuja",
       "vastuuhenkilon-tehtavat-maaritettava-enintaan-yhdelle-vastuuhenkilolle": "jokaisen vastuuhenkilön tehtävän täytyy kuulua enintään yhdelle vastuuhenkilölle saman erikoisalan sisällä",
+      "valmistumispyynnon-liite-ei-ole-kelvollinen-pdf": "Valmistumispyyntöön liittyvä liite \"{attachmentName}\" ({attachmentContext}) ei ole kelvollinen PDF-tiedosto. Pyydä liitteen lisääjää poistamaan se tai korvaamaan se kelvollisella PDF-tiedostolla ja yritä hyväksyntää uudelleen.",
       "valmistumispyynto-ei-ole-muokattavissa": "valmistumispyyntö ei ole muokattavissa",
       "valmistumispyynto-on-jo-lahetetty": "valmistumispyyntö on jo lähetetty"
     },

--- a/frontend/src/mixins/valmistumispyynto.ts
+++ b/frontend/src/mixins/valmistumispyynto.ts
@@ -1,7 +1,10 @@
 import { Component, Vue } from 'vue-property-decorator'
 
-import { Valmistumispyynto } from '@/types'
+import { ElsaError, Valmistumispyynto } from '@/types'
 import { ValmistumispyynnonTila } from '@/utils/constants'
+
+const INVALID_PDF_ATTACHMENT_ERROR =
+  'error.dataillegal.valmistumispyynnon-liite-ei-ole-kelvollinen-pdf'
 
 @Component({})
 export default class ValmistumispyyntoMixin extends Vue {
@@ -98,5 +101,24 @@ export default class ValmistumispyyntoMixin extends Vue {
 
   get useaVastuuhenkilo() {
     return this.vastuuhenkiloOsaamisenArvioija !== this.vastuuhenkiloHyvaksyja
+  }
+
+  formatValmistumispyyntoError(error?: ElsaError): string | undefined {
+    if (!error?.message) {
+      return undefined
+    }
+
+    if (error.message !== INVALID_PDF_ATTACHMENT_ERROR) {
+      return `${this.$t(error.message)}`
+    }
+
+    const attachmentSource = error.attachmentSource ? `${this.$t(error.attachmentSource)}` : ''
+    const attachmentDate = error.attachmentDate ? this.$date(error.attachmentDate) : ''
+    const attachmentContext = [attachmentSource, attachmentDate].filter(Boolean).join(' ')
+
+    return `${this.$t(error.message, {
+      attachmentName: error.attachmentName ?? '',
+      attachmentContext
+    })}`
   }
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1129,6 +1129,10 @@ export interface PaivakirjamerkintaLomake {
 export interface ElsaError {
   errorKey: string
   message: string
+  attachmentId?: number
+  attachmentName?: string
+  attachmentSource?: string
+  attachmentDate?: string
 }
 
 export type HakaYliopisto = {

--- a/frontend/src/utils/toast.ts
+++ b/frontend/src/utils/toast.ts
@@ -32,6 +32,7 @@ export function toastFail(vue: Vue, message: any) {
   vue.$root.$bvToast.toast(vNodesMsg, {
     variant: 'danger',
     solid: true,
+    autoHideDelay: 10000,
     // noAutoHide: true,
     bodyClass: 'shadow rounded p-3 pr-4'
   })

--- a/frontend/src/views/valmistumispyynnot-yek/vastuuhenkilo/valmistumispyynnon-hyvaksynta-yek.vue
+++ b/frontend/src/views/valmistumispyynnot-yek/vastuuhenkilo/valmistumispyynnon-hyvaksynta-yek.vue
@@ -569,11 +569,11 @@
         }
       } catch (err) {
         const axiosError = err as AxiosError<ElsaError>
-        const message = axiosError?.response?.data?.message
+        const message = this.formatValmistumispyyntoError(axiosError?.response?.data)
         toastFail(
           this,
           message
-            ? `${this.$t('valmistumispyynto-hyvaksynta-lahetys-epaonnistui')}: ${this.$t(message)}`
+            ? `${this.$t('valmistumispyynto-hyvaksynta-lahetys-epaonnistui')}: ${message}`
             : this.$t('valmistumispyynto-hyvaksynta-lahetys-epaonnistui')
         )
       }

--- a/frontend/src/views/valmistumispyynnot/vastuuhenkilo/valmistumispyynnon-hyvaksynta.vue
+++ b/frontend/src/views/valmistumispyynnot/vastuuhenkilo/valmistumispyynnon-hyvaksynta.vue
@@ -713,11 +713,11 @@
         }
       } catch (err) {
         const axiosError = err as AxiosError<ElsaError>
-        const message = axiosError?.response?.data?.message
+        const message = this.formatValmistumispyyntoError(axiosError?.response?.data)
         toastFail(
           this,
           message
-            ? `${this.$t('valmistumispyynto-hyvaksynta-lahetys-epaonnistui')}: ${this.$t(message)}`
+            ? `${this.$t('valmistumispyynto-hyvaksynta-lahetys-epaonnistui')}: ${message}`
             : this.$t('valmistumispyynto-hyvaksynta-lahetys-epaonnistui')
         )
       }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/PdfContentValidator.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/PdfContentValidator.kt
@@ -1,0 +1,38 @@
+package fi.elsapalvelu.elsa.service
+
+import com.itextpdf.kernel.pdf.PdfDocument
+import com.itextpdf.kernel.pdf.PdfReader
+import com.itextpdf.kernel.pdf.PdfWriter
+import org.springframework.stereotype.Component
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+/**
+ * Verifies that bytes are a readable, non-encrypted PDF whose pages iText can copy.
+ */
+@Component
+class PdfContentValidator {
+
+    fun isValid(data: ByteArray?): Boolean {
+        if (data == null || data.isEmpty()) {
+            return false
+        }
+
+        return try {
+            PdfDocument(PdfReader(ByteArrayInputStream(data))).use { source ->
+                if (source.reader.isEncrypted || source.numberOfPages < 1) {
+                    return false
+                }
+
+                ByteArrayOutputStream().use { output ->
+                    PdfDocument(PdfWriter(output)).use { target ->
+                        source.copyPagesTo(1, source.numberOfPages, target)
+                    }
+                }
+            }
+            true
+        } catch (_: RuntimeException) {
+            false
+        }
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/FileValidationServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/kayttaja/FileValidationServiceImpl.kt
@@ -2,6 +2,7 @@ package fi.elsapalvelu.elsa.service.impl.kayttaja
 
 import fi.elsapalvelu.elsa.required
 
+import fi.elsapalvelu.elsa.service.PdfContentValidator
 import fi.elsapalvelu.elsa.service.kayttaja.AsiakirjaService
 import fi.elsapalvelu.elsa.service.kayttaja.FileValidationService
 import org.slf4j.LoggerFactory
@@ -13,7 +14,8 @@ private const val MAXIMUM_FILE_NAME_LENGTH = 255
 
 @Service
 class FileValidationServiceImpl(
-    private val asiakirjaService: AsiakirjaService
+    private val asiakirjaService: AsiakirjaService,
+    private val pdfContentValidator: PdfContentValidator
 ) : FileValidationService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -46,8 +48,11 @@ class FileValidationServiceImpl(
                 log.warn("Tiedosto nimeltä '${file.originalFilename}' on jo olemassa opintooikeudella $opintooikeusId.")
                 return false
             }
-            if ( file.isEmpty ) {
+            if (file.isEmpty) {
                 log.warn("Tiedosto  '${file.originalFilename}'  on tyhjä opintooikeudella $opintooikeusId.")
+                return false
+            }
+            if (!hasValidPdfContent(file, opintooikeusId)) {
                 return false
             }
         }
@@ -60,7 +65,28 @@ class FileValidationServiceImpl(
         return !files.any {
             it.isEmpty ||
                 (it.contentType ?: "") !in allowedContentTypesOrDefault ||
-                it.name.length > MAXIMUM_FILE_NAME_LENGTH
+                it.name.length > MAXIMUM_FILE_NAME_LENGTH ||
+                !hasValidPdfContent(it)
         }
+    }
+
+    private fun hasValidPdfContent(file: MultipartFile, opintooikeusId: Long? = null): Boolean {
+        if (file.contentType != MediaType.APPLICATION_PDF_VALUE) {
+            return true
+        }
+
+        val valid = try {
+            pdfContentValidator.isValid(file.bytes)
+        } catch (_: java.io.IOException) {
+            false
+        }
+
+        if (!valid) {
+            val opintooikeus = opintooikeusId?.let { "Opintooikeus: $it - " }.orEmpty()
+            log.warn(
+                "${opintooikeus}Tiedosto '${file.originalFilename}' ei sisällä kelvollista PDF-dataa."
+            )
+        }
+        return valid
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/PdfServiceImpl.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/PdfServiceImpl.kt
@@ -14,11 +14,14 @@ import com.itextpdf.layout.properties.ObjectFit
 import com.itextpdf.layout.properties.UnitValue
 import com.itextpdf.pdfa.PdfADocument
 import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
+import fi.elsapalvelu.elsa.service.PdfContentValidator
 import fi.elsapalvelu.elsa.service.valmistuminen.PdfService
 import fi.elsapalvelu.elsa.service.metrics.PdfGenerationMetricsService
 import fi.elsapalvelu.elsa.service.metrics.PdfGenerationMetricsService.Companion.OP_LUO_PDF
 import fi.elsapalvelu.elsa.service.metrics.PdfGenerationMetricsService.Companion.OP_YHDISTA_ASIAKIRJAT
 import fi.elsapalvelu.elsa.service.metrics.PdfGenerationMetricsService.Companion.OP_YHDISTA_PDF
+import fi.elsapalvelu.elsa.web.rest.errors.InvalidPdfAttachmentException
+import fi.elsapalvelu.elsa.web.rest.errors.InvalidPdfAttachmentSource
 import org.apache.pdfbox.Loader
 import org.slf4j.LoggerFactory
 import org.springframework.core.io.Resource
@@ -31,7 +34,8 @@ import java.io.*
 @Service
 class PdfServiceImpl(
     private val templateEngine: SpringTemplateEngine,
-    private val pdfMetrics: PdfGenerationMetricsService
+    private val pdfMetrics: PdfGenerationMetricsService,
+    private val pdfContentValidator: PdfContentValidator
 ) : PdfService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -84,6 +88,9 @@ class PdfServiceImpl(
             val result = PdfDocument(PdfWriter(outputStream))
             val resultDocument = Document(result)
             asiakirjat.filter { it.tyyppi == MediaType.APPLICATION_PDF_VALUE }.forEach {
+                if (!pdfContentValidator.isValid(it.asiakirjaData?.data)) {
+                    throw invalidPdfAttachmentException(it)
+                }
                 try {
                     val sanitizedData = sanitizePdf(it.asiakirjaData?.data)
                     PdfDocument(PdfReader(ByteArrayInputStream(sanitizedData))).use { srcDoc ->
@@ -92,8 +99,8 @@ class PdfServiceImpl(
                             result.addPage(page)
                         }
                     }
-                } catch (e: IOException) {
-                    log.warn("Asiakirjan ${it.id} lisäys epäonnistui", e)
+                } catch (e: Exception) {
+                    throw invalidPdfAttachmentException(it, e)
                 }
             }
             asiakirjat.filter { it.tyyppi == MediaType.IMAGE_JPEG_VALUE || it.tyyppi == MediaType.IMAGE_PNG_VALUE }
@@ -144,4 +151,15 @@ class PdfServiceImpl(
         input.replace("\uF0B7", "\u2022")   // Wingdings bullet → •
             .replace("\uF0A7", "\u25E6")   // alternate bullet → ◦
             .replace(puaRegex, "")         // remove remaining PUA chars
+
+    private fun invalidPdfAttachmentException(
+        asiakirja: Asiakirja,
+        cause: Throwable? = null
+    ) = InvalidPdfAttachmentException(
+        attachmentId = asiakirja.id,
+        attachmentName = asiakirja.nimi,
+        source = InvalidPdfAttachmentSource.TYOSKENTELYJAKSO,
+        attachmentDate = asiakirja.tyoskentelyjakso?.alkamispaiva,
+        cause = cause
+    )
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonArviointiPdfService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonArviointiPdfService.kt
@@ -5,14 +5,18 @@ import fi.elsapalvelu.elsa.domain.kayttaja.Asiakirja
 import fi.elsapalvelu.elsa.domain.valmistuminen.Valmistumispyynto
 import fi.elsapalvelu.elsa.repository.arviointi.SuoritusarviointiRepository
 import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.PdfContentValidator
 import fi.elsapalvelu.elsa.service.mapper.arviointi.SuoritusarviointiMapper
 import fi.elsapalvelu.elsa.service.valmistuminen.PdfService
+import fi.elsapalvelu.elsa.web.rest.errors.InvalidPdfAttachmentException
+import fi.elsapalvelu.elsa.web.rest.errors.InvalidPdfAttachmentSource
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.thymeleaf.context.Context
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.time.LocalDate
 import java.util.Locale
 
 @Service
@@ -20,7 +24,8 @@ class ValmistumispyynnonArviointiPdfService(
     private val pdfService: PdfService,
     private val suoritusarviointiRepository: SuoritusarviointiRepository,
     private val suoritusarviointiMapper: SuoritusarviointiMapper,
-    private val arviointitietoService: ValmistumispyynnonArviointitietoService
+    private val arviointitietoService: ValmistumispyynnonArviointitietoService,
+    private val pdfContentValidator: PdfContentValidator
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -65,12 +70,16 @@ class ValmistumispyynnonArviointiPdfService(
                 yhdistaPdfAsiakirjat(
                     arviointi.arviointiAsiakirjat,
                     outputStream,
-                    "Arviointiasiakirja"
+                    "Arviointiasiakirja",
+                    InvalidPdfAttachmentSource.ARVIOINTI,
+                    arviointi.tapahtumanAjankohta
                 )
                 yhdistaPdfAsiakirjat(
                     arviointi.itsearviointiAsiakirjat,
                     outputStream,
-                    "Itsearviointiasiakirja"
+                    "Itsearviointiasiakirja",
+                    InvalidPdfAttachmentSource.ITSEARVIOINTI,
+                    arviointi.tapahtumanAjankohta
                 )
             }
     }
@@ -101,7 +110,9 @@ class ValmistumispyynnonArviointiPdfService(
     private fun yhdistaPdfAsiakirjat(
         asiakirjat: Collection<Asiakirja>,
         outputStream: ByteArrayOutputStream,
-        label: String
+        label: String,
+        source: InvalidPdfAttachmentSource,
+        attachmentDate: LocalDate?
     ) {
         asiakirjat.forEach { asiakirja ->
             if (asiakirja.tyyppi != MediaType.APPLICATION_PDF_VALUE) {
@@ -112,15 +123,27 @@ class ValmistumispyynnonArviointiPdfService(
                 return@forEach
             }
             val data = asiakirja.asiakirjaData?.data
-            if (data == null || data.isEmpty()) {
-                log.warn(
-                    "$label ${asiakirja.id} (${asiakirja.nimi}) data on tyhjä tai null – ohitetaan"
+            if (!pdfContentValidator.isValid(data)) {
+                throw InvalidPdfAttachmentException(
+                    attachmentId = asiakirja.id,
+                    attachmentName = asiakirja.nimi,
+                    source = source,
+                    attachmentDate = attachmentDate
                 )
-                return@forEach
             }
             val existingPdf = ByteArrayInputStream(outputStream.toByteArray())
             outputStream.reset()
-            pdfService.yhdistaPdf(existingPdf, ByteArrayInputStream(data), outputStream)
+            try {
+                pdfService.yhdistaPdf(existingPdf, ByteArrayInputStream(data), outputStream)
+            } catch (e: Exception) {
+                throw InvalidPdfAttachmentException(
+                    attachmentId = asiakirja.id,
+                    attachmentName = asiakirja.nimi,
+                    source = source,
+                    attachmentDate = attachmentDate,
+                    cause = e
+                )
+            }
         }
     }
 }

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonErikoistujanTiedotPdfService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonErikoistujanTiedotPdfService.kt
@@ -8,9 +8,11 @@ import fi.elsapalvelu.elsa.repository.koulutus.KoulutussuunnitelmaRepository
 import fi.elsapalvelu.elsa.repository.seuranta.PaivakirjamerkintaRepository
 import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyyntoRepository
 import fi.elsapalvelu.elsa.required
+import fi.elsapalvelu.elsa.service.PdfContentValidator
 import fi.elsapalvelu.elsa.service.seuranta.SeurantajaksoService
 import fi.elsapalvelu.elsa.service.valmistuminen.PdfService
-import org.slf4j.LoggerFactory
+import fi.elsapalvelu.elsa.web.rest.errors.InvalidPdfAttachmentException
+import fi.elsapalvelu.elsa.web.rest.errors.InvalidPdfAttachmentSource
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.thymeleaf.context.Context
@@ -30,10 +32,9 @@ class ValmistumispyynnonErikoistujanTiedotPdfService(
     private val paivakirjamerkintaRepository: PaivakirjamerkintaRepository,
     private val seurantajaksoService: SeurantajaksoService,
     private val arviointiPdfService: ValmistumispyynnonArviointiPdfService,
-    private val suoritemerkintaPdfService: ValmistumispyynnonSuoritemerkintaPdfService
+    private val suoritemerkintaPdfService: ValmistumispyynnonSuoritemerkintaPdfService,
+    private val pdfContentValidator: PdfContentValidator
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
-
     fun luo(valmistumispyynto: Valmistumispyynto) {
         val opintooikeus = valmistumispyynto.opintooikeus ?: return
         val opintooikeusId = opintooikeus.id.required()
@@ -76,15 +77,29 @@ class ValmistumispyynnonErikoistujanTiedotPdfService(
 
         val motivaatiokirje = koulutussuunnitelma?.motivaatiokirjeAsiakirja ?: return
         val data = motivaatiokirje.asiakirjaData?.data
-        if (data == null || data.isEmpty()) {
-            log.warn(
-                "Motivaatiokirjeasiakirja ${motivaatiokirje.id} data on tyhjä tai null – ohitetaan"
+        if (
+            motivaatiokirje.tyyppi != MediaType.APPLICATION_PDF_VALUE ||
+            data == null ||
+            !pdfContentValidator.isValid(data)
+        ) {
+            throw InvalidPdfAttachmentException(
+                attachmentId = motivaatiokirje.id,
+                attachmentName = motivaatiokirje.nimi,
+                source = InvalidPdfAttachmentSource.MOTIVAATIOKIRJE
             )
-            return
         }
         val existingPdf = ByteArrayInputStream(outputStream.toByteArray())
         outputStream.reset()
-        pdfService.yhdistaPdf(existingPdf, ByteArrayInputStream(data), outputStream)
+        try {
+            pdfService.yhdistaPdf(existingPdf, ByteArrayInputStream(data), outputStream)
+        } catch (e: Exception) {
+            throw InvalidPdfAttachmentException(
+                attachmentId = motivaatiokirje.id,
+                attachmentName = motivaatiokirje.nimi,
+                source = InvalidPdfAttachmentSource.MOTIVAATIOKIRJE,
+                cause = e
+            )
+        }
     }
 
     private fun lisaaPaivakirjamerkinnat(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonLiitteetPdfService.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/service/impl/valmistuminen/ValmistumispyynnonLiitteetPdfService.kt
@@ -8,7 +8,6 @@ import fi.elsapalvelu.elsa.repository.tyoskentely.TyoskentelyjaksoRepository
 import fi.elsapalvelu.elsa.repository.valmistuminen.ValmistumispyyntoRepository
 import fi.elsapalvelu.elsa.required
 import fi.elsapalvelu.elsa.service.valmistuminen.PdfService
-import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import java.io.ByteArrayOutputStream
@@ -23,25 +22,16 @@ class ValmistumispyynnonLiitteetPdfService(
     private val valmistumispyyntoRepository: ValmistumispyyntoRepository,
     private val tyoskentelyjaksoRepository: TyoskentelyjaksoRepository
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
-
     fun luo(valmistumispyynto: Valmistumispyynto): Asiakirja {
         val opintooikeus = valmistumispyynto.opintooikeus.required()
         val tyoskentelyjaksot = tyoskentelyjaksoRepository.findAllByOpintooikeusId(
             opintooikeus.id.required()
         )
         val outputStream = ByteArrayOutputStream()
-        try {
-            pdfService.yhdistaAsiakirjat(
-                tyoskentelyjaksot.flatMap { it.asiakirjat },
-                outputStream
-            )
-        } catch (exception: Exception) {
-            log.error(
-                "Virhe yhdistäessä asiakirjoja valmistumispyynnölle: ${valmistumispyynto.id}",
-                exception
-            )
-        }
+        pdfService.yhdistaAsiakirjat(
+            tyoskentelyjaksot.flatMap { it.asiakirjat },
+            outputStream
+        )
 
         val timestamp = LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT))
         val asiakirja = asiakirjaRepository.save(

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/errors/BadRequestExceptionAdvice.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/errors/BadRequestExceptionAdvice.kt
@@ -24,6 +24,13 @@ class BadRequestExceptionAdvice {
         body.setProperty("message", "error.${e.errorKey}")
         body.setProperty("params", e.entityName)
 
+        if (e is InvalidPdfAttachmentException) {
+            e.attachmentId?.let { body.setProperty("attachmentId", it) }
+            body.setProperty("attachmentName", e.attachmentName)
+            body.setProperty("attachmentSource", e.attachmentSource)
+            e.attachmentDate?.let { body.setProperty("attachmentDate", it) }
+        }
+
         return body
     }
 

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/errors/InvalidPdfAttachmentException.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/errors/InvalidPdfAttachmentException.kt
@@ -1,0 +1,36 @@
+package fi.elsapalvelu.elsa.web.rest.errors
+
+import fi.elsapalvelu.elsa.web.rest.VALMISTUMISPYYNTO_ENTITY_NAME
+import java.time.LocalDate
+
+enum class InvalidPdfAttachmentSource(val messageKey: String) {
+    ARVIOINTI("arviointi"),
+    ITSEARVIOINTI("itsearviointi"),
+    MOTIVAATIOKIRJE("motivaatiokirje"),
+    TYOSKENTELYJAKSO("tyoskentelyjakso")
+}
+
+class InvalidPdfAttachmentException(
+    val attachmentId: Long?,
+    attachmentName: String?,
+    source: InvalidPdfAttachmentSource,
+    val attachmentDate: LocalDate? = null,
+    cause: Throwable? = null
+) : BadRequestAlertException(
+    defaultMessage = "Asiakirja $attachmentId ('$attachmentName') ei ole kelvollinen PDF " +
+        "(${source.name}, $attachmentDate).",
+    entityName = VALMISTUMISPYYNTO_ENTITY_NAME,
+    errorKey = ERROR_KEY
+) {
+    val attachmentName: String = attachmentName.orEmpty()
+    val attachmentSource: String = source.messageKey
+
+    init {
+        cause?.let(::initCause)
+    }
+
+    companion object {
+        const val ERROR_KEY =
+            "dataillegal.valmistumispyynnon-liite-ei-ole-kelvollinen-pdf"
+    }
+}

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoResource.kt
@@ -133,7 +133,7 @@ class VastuuhenkiloValmistumispyyntoResource(
                     id,
                     user.id.required(),
                     hyvaksyntaFormDTO
-            )
+                )
             AuditLoggingWrapper.info("PUT request completed for /api/vastuuhenkilo/valmistumispyynnon-hyvaksynta/$id")
             return ResponseEntity.ok(valmistumispyynto)
         } catch (ex: InvalidPdfAttachmentException) {

--- a/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoResource.kt
+++ b/src/main/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoResource.kt
@@ -20,6 +20,7 @@ import fi.elsapalvelu.elsa.service.dto.kayttaja.*
 import fi.elsapalvelu.elsa.service.dto.perustiedot.*
 import fi.elsapalvelu.elsa.web.rest.VALMISTUMISPYYNTO_ENTITY_NAME
 import fi.elsapalvelu.elsa.web.rest.errors.BadRequestAlertException
+import fi.elsapalvelu.elsa.web.rest.errors.InvalidPdfAttachmentException
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -132,9 +133,11 @@ class VastuuhenkiloValmistumispyyntoResource(
                     id,
                     user.id.required(),
                     hyvaksyntaFormDTO
-                )
+            )
             AuditLoggingWrapper.info("PUT request completed for /api/vastuuhenkilo/valmistumispyynnon-hyvaksynta/$id")
             return ResponseEntity.ok(valmistumispyynto)
+        } catch (ex: InvalidPdfAttachmentException) {
+            throw ex
         } catch (ex: Exception) {
             log.error("PUT request failed for /api/vastuuhenkilo/valmistumispyynnon-hyvaksynta/$id", ex)
             throw ex

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/FileValidationServiceTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/FileValidationServiceTest.kt
@@ -14,12 +14,15 @@ import org.springframework.mock.web.MockMultipartFile
 class FileValidationServiceTest {
 
     private lateinit var asiakirjaService: AsiakirjaService
+    private lateinit var pdfContentValidator: PdfContentValidator
     private lateinit var fileValidationService: FileValidationService
 
     @BeforeEach
     fun setup() {
         asiakirjaService = mock(AsiakirjaService::class.java)
-        fileValidationService = FileValidationServiceImpl(asiakirjaService)
+        pdfContentValidator = mock(PdfContentValidator::class.java)
+        `when`(pdfContentValidator.isValid(any(ByteArray::class.java))).thenReturn(true)
+        fileValidationService = FileValidationServiceImpl(asiakirjaService, pdfContentValidator)
     }
 
     @Test
@@ -258,6 +261,37 @@ class FileValidationServiceTest {
             MediaType.IMAGE_PNG_VALUE,
             ByteArray(0)
         )
+
+        val result = fileValidationService.validate(listOf(file))
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `validate should reject PDF when its content is not valid`() {
+        val file = MockMultipartFile(
+            "file",
+            "document.pdf",
+            MediaType.APPLICATION_PDF_VALUE,
+            "not a PDF".toByteArray()
+        )
+        `when`(asiakirjaService.findAllByOpintooikeusId(1L)).thenReturn(emptyList())
+        `when`(pdfContentValidator.isValid(file.bytes)).thenReturn(false)
+
+        val result = fileValidationService.validate(listOf(file), 1L)
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `validate without opintooikeusId should reject PDF when its content is not valid`() {
+        val file = MockMultipartFile(
+            "file",
+            "document.pdf",
+            MediaType.APPLICATION_PDF_VALUE,
+            "not a PDF".toByteArray()
+        )
+        `when`(pdfContentValidator.isValid(file.bytes)).thenReturn(false)
 
         val result = fileValidationService.validate(listOf(file))
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/service/PdfContentValidatorTest.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/service/PdfContentValidatorTest.kt
@@ -1,0 +1,87 @@
+package fi.elsapalvelu.elsa.service
+
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.encryption.AccessPermission
+import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class PdfContentValidatorTest {
+
+    private val validator = PdfContentValidator()
+
+    @Test
+    fun `accepts a readable PDF whose pages can be copied`() {
+        assertThat(validator.isValid(validPdf())).isTrue
+    }
+
+    @Test
+    fun `rejects DOCX content labelled as PDF`() {
+        assertThat(validator.isValid(docxContent())).isFalse
+    }
+
+    @Test
+    fun `rejects arbitrary non-empty content`() {
+        assertThat(validator.isValid("not a PDF".toByteArray())).isFalse
+    }
+
+    @Test
+    fun `rejects a truncated PDF`() {
+        assertThat(validator.isValid(validPdf().copyOf(20))).isFalse
+    }
+
+    @Test
+    fun `rejects empty and null content`() {
+        assertThat(validator.isValid(ByteArray(0))).isFalse
+        assertThat(validator.isValid(null)).isFalse
+    }
+
+    @Test
+    fun `rejects a PDF without pages`() {
+        val pdfWithoutPages = ByteArrayOutputStream().use { output ->
+            PDDocument().use { it.save(output) }
+            output.toByteArray()
+        }
+
+        assertThat(validator.isValid(pdfWithoutPages)).isFalse
+    }
+
+    @Test
+    fun `rejects a password-protected PDF`() {
+        val encryptedPdf = ByteArrayOutputStream().use { output ->
+            PDDocument().use { document ->
+                document.addPage(PDPage())
+                document.protect(
+                    StandardProtectionPolicy(
+                        "owner-password",
+                        "user-password",
+                        AccessPermission()
+                    )
+                )
+                document.save(output)
+            }
+            output.toByteArray()
+        }
+
+        assertThat(validator.isValid(encryptedPdf)).isFalse
+    }
+
+    private fun validPdf(): ByteArray =
+        requireNotNull(javaClass.getResourceAsStream("/fixtures/valid.pdf")).use { it.readBytes() }
+
+    private fun docxContent(): ByteArray = ByteArrayOutputStream().use { output ->
+        ZipOutputStream(output).use { zip ->
+            zip.putNextEntry(ZipEntry("[Content_Types].xml"))
+            zip.write("<Types/>".toByteArray())
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry("word/document.xml"))
+            zip.write("<document/>".toByteArray())
+            zip.closeEntry()
+        }
+        output.toByteArray()
+    }
+}

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTeoriakoulutusResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/erikoistuvalaakari/ErikoistuvaLaakariTeoriakoulutusResourceIT.kt
@@ -9,7 +9,6 @@ import fi.elsapalvelu.elsa.repository.koulutus.TeoriakoulutusRepository
 import fi.elsapalvelu.elsa.security.ERIKOISTUVA_LAAKARI
 import fi.elsapalvelu.elsa.service.mapper.koulutus.TeoriakoulutusMapper
 import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
-import fi.elsapalvelu.elsa.web.rest.createByteArray
 import fi.elsapalvelu.elsa.web.rest.findAll
 import fi.elsapalvelu.elsa.web.rest.helpers.AsiakirjaHelper
 import fi.elsapalvelu.elsa.web.rest.helpers.AsiakirjaHelper.ASIAKIRJA_PDF_NIMI
@@ -645,8 +644,8 @@ class ErikoistuvaLaakariTeoriakoulutusResourceIT {
         private const val DEFAULT_ERIKOISTUMISEEN_HYVAKSYTTAVA_TUNTIMAARA: Double = 5.0
         private const val UPDATED_ERIKOISTUMISEEN_HYVAKSYTTAVA_TUNTIMAARA: Double = 10.0
 
-        val DEFAULT_FILE: ByteArray = createByteArray(1, "0")
-        val UPDATED_FILE: ByteArray = createByteArray(1, "1")
+        val DEFAULT_FILE: ByteArray = AsiakirjaHelper.ASIAKIRJA_PDF_DATA
+        val UPDATED_FILE: ByteArray = AsiakirjaHelper.ASIAKIRJA_PDF_DATA
 
         private const val ENTITY_API_URL: String = "/api/erikoistuva-laakari/teoriakoulutukset"
         private const val ENTITY_API_URL_ID: String = ENTITY_API_URL + "/{id}"

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/AsiakirjaHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/AsiakirjaHelper.kt
@@ -22,7 +22,9 @@ object AsiakirjaHelper {
     const val ASIAKIRJA_PDF_TYYPPI = "application/pdf"
     const val ASIAKIRJA_PNG_TYYPPI = "image/png"
 
-    val ASIAKIRJA_PDF_DATA = byteArrayOf(0x2E, 0x38)
+    val ASIAKIRJA_PDF_DATA: ByteArray =
+        requireNotNull(AsiakirjaHelper::class.java.getResourceAsStream("/fixtures/valid.pdf"))
+            .use { it.readBytes() }
     val ASIAKIRJA_PNG_DATA = byteArrayOf(0x2E, 0x14)
 
     fun createEntity(

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/KoulutussuunnitelmaHelper.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/helpers/KoulutussuunnitelmaHelper.kt
@@ -3,7 +3,6 @@ package fi.elsapalvelu.elsa.web.rest.helpers
 import fi.elsapalvelu.elsa.domain.kayttaja.ErikoistuvaLaakari
 import fi.elsapalvelu.elsa.domain.koulutus.Koulutussuunnitelma
 import fi.elsapalvelu.elsa.domain.kayttaja.User
-import fi.elsapalvelu.elsa.web.rest.createByteArray
 import fi.elsapalvelu.elsa.web.rest.findAll
 import jakarta.persistence.EntityManager
 
@@ -45,8 +44,8 @@ object KoulutussuunnitelmaHelper {
     const val DEFAULT_ELAMANKENTTA_YKSITYINEN = false
     const val UPDATED_ELAMANKENTTA_YKSITYINEN = true
 
-    val DEFAULT_FILE: ByteArray = createByteArray(1, "0")
-    val UPDATED_FILE: ByteArray = createByteArray(1, "1")
+    val DEFAULT_FILE: ByteArray = AsiakirjaHelper.ASIAKIRJA_PDF_DATA
+    val UPDATED_FILE: ByteArray = AsiakirjaHelper.ASIAKIRJA_PDF_DATA
 
     fun createEntity(em: EntityManager, user: User? = null): Koulutussuunnitelma {
 

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaSuoritusarviointiResourceIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/kouluttaja/KouluttajaSuoritusarviointiResourceIT.kt
@@ -132,6 +132,45 @@ class KouluttajaSuoritusarviointiResourceIT {
         assertThat(asiakirjaData?.data).isEqualTo(AsiakirjaHelper.ASIAKIRJA_PDF_DATA)
     }
 
+    @Test
+    @Transactional
+    fun updateSuoritusarviointiRejectsInvalidPdfContent() {
+        initTest()
+        suoritusarviointiRepository.saveAndFlush(suoritusarviointi)
+
+        val id = suoritusarviointi.id
+        assertNotNull(id)
+        val updatedSuoritusarviointi = suoritusarviointiRepository.findById(id).get()
+        em.detach(updatedSuoritusarviointi)
+        updatedSuoritusarviointi.arviointiAika = UPDATED_TAPAHTUMAN_AJANKOHTA
+        updatedSuoritusarviointi.arviointiPerustuu = ArvioinninPerustuminen.LASNA
+        updatedSuoritusarviointi.sanallinenArviointi = UPDATED_LISATIEDOT
+        updatedSuoritusarviointi.arvioitavatKokonaisuudet.forEach {
+            it.arviointiasteikonTaso = 5
+        }
+        updatedSuoritusarviointi.vaativuustaso = 5
+        val suoritusarviointiJson =
+            objectMapper.writeValueAsString(suoritusarviointiMapper.toDto(updatedSuoritusarviointi))
+
+        restSuoritusarviointiMockMvc.perform(
+            multipart("/api/kouluttaja/suoritusarvioinnit")
+                .file(
+                    MockMultipartFile(
+                        "arviointiFiles",
+                        "word-document.pdf",
+                        MediaType.APPLICATION_PDF_VALUE,
+                        "PK\u0003\u0004DOCX content".toByteArray()
+                    )
+                )
+                .param("suoritusarviointiJson", suoritusarviointiJson)
+                .with { it.method = "PUT"; it }
+                .with(csrf())
+        ).andExpect(status().isBadRequest)
+
+        em.clear()
+        assertThat(suoritusarviointiRepository.findById(id).get().arviointiAsiakirjat).isEmpty()
+    }
+
     fun initMockFile() {
         tempFile = File.createTempFile("file", "pdf")
         tempFile.writeBytes(AsiakirjaHelper.ASIAKIRJA_PDF_DATA)

--- a/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoLiiteIT.kt
+++ b/src/test/kotlin/fi/elsapalvelu/elsa/web/rest/vastuuhenkilo/VastuuhenkiloValmistumispyyntoLiiteIT.kt
@@ -20,6 +20,7 @@ import fi.elsapalvelu.elsa.service.dto.valmistuminen.ValmistumispyyntoHyvaksynta
 import fi.elsapalvelu.elsa.web.rest.common.KayttajaResourceWithMockUserIT
 import fi.elsapalvelu.elsa.web.rest.convertObjectToJsonBytes
 import fi.elsapalvelu.elsa.web.rest.findAll
+import fi.elsapalvelu.elsa.web.rest.errors.InvalidPdfAttachmentException
 import fi.elsapalvelu.elsa.web.rest.helpers.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,9 +37,13 @@ import org.springframework.security.test.context.TestSecurityContextHolder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
+import java.io.ByteArrayOutputStream
 import java.time.LocalDateTime
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import jakarta.persistence.EntityManager
 
 /**
@@ -48,8 +53,8 @@ import jakarta.persistence.EntityManager
  * These tests exercise the full HTTP → service → PDF generation stack so that
  * failures reproduce the real transaction rollback seen in production.
  *
- * Regression scenarios include non-PDF and empty attachments. Those inputs must
- * be skipped while valid PDFs are still merged into the generated document.
+ * Legacy attachments whose stored PDF metadata does not match their content must
+ * block approval with an actionable validation response. Valid PDFs are merged normally.
  *
  */
 @AutoConfigureMockMvc
@@ -76,6 +81,20 @@ class VastuuhenkiloValmistumispyyntoLiiteIT {
     }
 
     private val emptyPdf: ByteArray = ByteArray(0)
+
+    private val docxContent: ByteArray by lazy {
+        ByteArrayOutputStream().use { output ->
+            ZipOutputStream(output).use { zip ->
+                zip.putNextEntry(ZipEntry("[Content_Types].xml"))
+                zip.write("<Types/>".toByteArray())
+                zip.closeEntry()
+                zip.putNextEntry(ZipEntry("word/document.xml"))
+                zip.write("<document/>".toByteArray())
+                zip.closeEntry()
+            }
+            output.toByteArray()
+        }
+    }
 
     /**
      * A real JPEG (1×1 px) representing an attachment that must not be merged as PDF.
@@ -211,6 +230,25 @@ class VastuuhenkiloValmistumispyyntoLiiteIT {
         em.flush()
     }
 
+    private fun persistTyoskentelyjaksoWithAsiakirja(data: ByteArray) {
+        val tyoskentelyjakso = TyoskentelyjaksoHelper.createEntity(em)
+        tyoskentelyjakso.opintooikeus = opintooikeus
+        em.persist(tyoskentelyjakso)
+        em.flush()
+
+        em.persist(
+            Asiakirja(
+                opintooikeus = opintooikeus,
+                tyoskentelyjakso = tyoskentelyjakso,
+                nimi = "tyotodistus.pdf",
+                tyyppi = MediaType.APPLICATION_PDF_VALUE,
+                lisattypvm = LocalDateTime.now(),
+                asiakirjaData = AsiakirjaData(data = data)
+            )
+        )
+        em.flush()
+    }
+
     private fun persistValmistumispyyntoOdottaaHyvaksyntaa(): Valmistumispyynto {
         val freshOpintooikeus = em.find(Opintooikeus::class.java, opintooikeus.id!!)
         val freshAnotherVastuuhenkilo = em.find(Kayttaja::class.java, anotherVastuuhenkilo.id!!)
@@ -308,14 +346,11 @@ class VastuuhenkiloValmistumispyyntoLiiteIT {
     }
 
     /**
-     * ELSA-1127 – Zero-byte (empty) PDF attachment fixed.
-     *
-     * Empty blobs in [asiakirja_data] (LENGTH(data) = 0) are now skipped with a
-     * warning in [lisaaArvioinnit] instead of being passed to PdfReader.
+     * A legacy zero-byte assessment PDF must block approval instead of being omitted.
      */
     @Test
     @Transactional
-    fun approvalSucceedsBySkippingEmptyArviointiPdf() {
+    fun approvalIsBlockedWhenArviointiPdfIsEmpty() {
 
         persistKoulutussuunnitelma()
         persistSuoritusarviointiWithAsiakirja(MediaType.APPLICATION_PDF_VALUE, emptyPdf)
@@ -325,15 +360,71 @@ class VastuuhenkiloValmistumispyyntoLiiteIT {
         val valmistumispyynto = persistValmistumispyyntoOdottaaHyvaksyntaa()
 
         performApproval(valmistumispyynto.id)
-            .andExpect(status().isOk)
+            .andExpect(status().isBadRequest)
+            .andExpect(
+                jsonPath("$.message").value(
+                    "error.${InvalidPdfAttachmentException.ERROR_KEY}"
+                )
+            )
+            .andExpect(jsonPath("$.attachmentName").value("liite.pdf"))
+            .andExpect(jsonPath("$.attachmentSource").value("arviointi"))
+            .andExpect(jsonPath("$.attachmentDate").value("1970-01-01"))
     }
 
     /**
-     * ELSA-1127 – Zero-byte PDF in itsearviointi collection fixed.
+     * Legacy data can contain a DOCX whose stored name and MIME type claim it is a PDF.
+     * Approval must identify the affected assessment and require the file to be corrected.
      */
     @Test
     @Transactional
-    fun approvalSucceedsBySkippingEmptyItsearviointiPdf() {
+    fun approvalIsBlockedWhenDocxContentIsLabelledAsPdf() {
+
+        persistKoulutussuunnitelma()
+        persistSuoritusarviointiWithAsiakirja(MediaType.APPLICATION_PDF_VALUE, docxContent)
+
+        em.clear()
+
+        val valmistumispyynto = persistValmistumispyyntoOdottaaHyvaksyntaa()
+
+        performApproval(valmistumispyynto.id)
+            .andExpect(status().isBadRequest)
+            .andExpect(
+                jsonPath("$.message").value(
+                    "error.${InvalidPdfAttachmentException.ERROR_KEY}"
+                )
+            )
+            .andExpect(jsonPath("$.attachmentName").value("liite.pdf"))
+            .andExpect(jsonPath("$.attachmentSource").value("arviointi"))
+            .andExpect(jsonPath("$.attachmentDate").value("1970-01-01"))
+    }
+
+    /**
+     * A legacy invalid PDF attached to a work period must also block approval.
+     */
+    @Test
+    @Transactional
+    fun approvalIsBlockedWhenTyoskentelyjaksoPdfIsInvalid() {
+
+        persistKoulutussuunnitelma()
+        persistTyoskentelyjaksoWithAsiakirja(docxContent)
+
+        em.clear()
+
+        val valmistumispyynto = persistValmistumispyyntoOdottaaHyvaksyntaa()
+
+        performApproval(valmistumispyynto.id)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.attachmentName").value("tyotodistus.pdf"))
+            .andExpect(jsonPath("$.attachmentSource").value("tyoskentelyjakso"))
+            .andExpect(jsonPath("$.attachmentDate").value("1970-01-01"))
+    }
+
+    /**
+     * A legacy zero-byte self-assessment PDF must block approval instead of being omitted.
+     */
+    @Test
+    @Transactional
+    fun approvalIsBlockedWhenItsearviointiPdfIsEmpty() {
 
         persistKoulutussuunnitelma()
         persistSuoritusarviointiWithAsiakirja(MediaType.APPLICATION_PDF_VALUE, emptyPdf, itsearviointi = true)
@@ -343,7 +434,10 @@ class VastuuhenkiloValmistumispyyntoLiiteIT {
         val valmistumispyynto = persistValmistumispyyntoOdottaaHyvaksyntaa()
 
         performApproval(valmistumispyynto.id)
-            .andExpect(status().isOk)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.attachmentName").value("liite.pdf"))
+            .andExpect(jsonPath("$.attachmentSource").value("itsearviointi"))
+            .andExpect(jsonPath("$.attachmentDate").value("1970-01-01"))
     }
 
     /**
@@ -387,16 +481,11 @@ class VastuuhenkiloValmistumispyyntoLiiteIT {
     }
 
     /**
-     * ELSA-1127 – Empty motivaatiokirjeAsiakirja in Koulutussuunnitelma.
-     *
-     * [lisaaKoulutussuunnitelma] calls [yhdistaPdf] for the motivaatiokirje attachment.
-     * A zero-byte blob causes "PDF header not found" and rolls back the approval.
-     * The same defensive empty-data guard applied to [lisaaArvioinnit] is now also
-     * applied here – empty data is skipped with a warning.
+     * A legacy empty motivation-letter PDF must block approval instead of being omitted.
      */
     @Test
     @Transactional
-    fun approvalSucceedsWhenMotivaatiokirjeAsiakirjaIsEmpty() {
+    fun approvalIsBlockedWhenMotivaatiokirjeAsiakirjaIsEmpty() {
 
         persistKoulutussuunnitelmaWithMotivaatiokirje(emptyPdf)
 
@@ -404,9 +493,11 @@ class VastuuhenkiloValmistumispyyntoLiiteIT {
 
         val valmistumispyynto = persistValmistumispyyntoOdottaaHyvaksyntaa()
 
-        // FIXED: empty motivaatiokirje blob is skipped, approval succeeds
         performApproval(valmistumispyynto.id)
-            .andExpect(status().isOk)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.attachmentName").value("motivaatiokirje.pdf"))
+            .andExpect(jsonPath("$.attachmentSource").value("motivaatiokirje"))
+            .andExpect(jsonPath("$.attachmentDate").doesNotExist())
     }
 
     /**


### PR DESCRIPTION
This pull request introduces comprehensive validation for PDF attachments to ensure only valid, readable PDF files are accepted throughout the application. The changes affect both backend and frontend, improving error handling and user feedback when invalid PDFs are uploaded or encountered in workflows. The update includes a new PDF validation service, integration into file upload and PDF merging logic, and enhanced error messaging for users and test coverage for these scenarios.

**Backend: PDF Validation and Error Handling**

* Added a new service `PdfContentValidator` to verify that uploaded files are valid, readable, non-encrypted PDFs by attempting to read and copy their pages using iText.
* Integrated PDF content validation into `FileValidationServiceImpl` for all PDF uploads, ensuring files are checked before acceptance. If validation fails, the upload is rejected and a warning is logged. [[1]](diffhunk://#diff-d873e07f199f37834f4df4ba55948175786e6928636478a2d915531855d00f0bR5) [[2]](diffhunk://#diff-d873e07f199f37834f4df4ba55948175786e6928636478a2d915531855d00f0bL16-R18) [[3]](diffhunk://#diff-d873e07f199f37834f4df4ba55948175786e6928636478a2d915531855d00f0bR55-R57) [[4]](diffhunk://#diff-d873e07f199f37834f4df4ba55948175786e6928636478a2d915531855d00f0bL63-R90)
* Enhanced `PdfServiceImpl` to validate PDFs before merging, throwing a new `InvalidPdfAttachmentException` if an invalid PDF is encountered, and providing detailed error context. [[1]](diffhunk://#diff-82e301117a97af31e56b2d94072b98172091484d178be50a3707d26b029d8366R17-R24) [[2]](diffhunk://#diff-82e301117a97af31e56b2d94072b98172091484d178be50a3707d26b029d8366L34-R38) [[3]](diffhunk://#diff-82e301117a97af31e56b2d94072b98172091484d178be50a3707d26b029d8366R91-R93) [[4]](diffhunk://#diff-82e301117a97af31e56b2d94072b98172091484d178be50a3707d26b029d8366L95-R103) [[5]](diffhunk://#diff-82e301117a97af31e56b2d94072b98172091484d178be50a3707d26b029d8366R154-R164)

**Frontend: Error Handling and User Feedback**

* Extended the `ElsaError` type to include attachment metadata for invalid PDF errors, and implemented a new error formatting method in `valmistumispyynto.ts` to display detailed, context-aware error messages to users. [[1]](diffhunk://#diff-1b4a95b65fea8956418f11410de7b03f8f1474045a4e88eadf7cc7c1ecb6123cR1132-R1135) [[2]](diffhunk://#diff-c4303b4ae3e91ab0b45d7febcd23c88ca93d39ea19602dff9ac5ad1267a39c0eL3-R8) [[3]](diffhunk://#diff-c4303b4ae3e91ab0b45d7febcd23c88ca93d39ea19602dff9ac5ad1267a39c0eR105-R123)
* Updated toast notifications to display these new error messages and increased the auto-hide delay for better visibility. [[1]](diffhunk://#diff-6a033eb683d9eec738e2b3dbf35c215ef13d0fa2d15261e4d5f256bce225efdbL716-R720) [[2]](diffhunk://#diff-6f618d4d11ce6818e1db798dad0cda11b3ee0a262a5d70278bbb2f97e64cbc62L572-R576) [[3]](diffhunk://#diff-a473332b10d63d5755bbdff49f24b6c7b71cf85ecf6ff4c805c481239713a1bdR35)
* Added a new localized error message for invalid PDF attachments in `fi.json`.

**Testing and E2E Coverage**

* Added and refactored Cypress E2E tests to cover invalid PDF upload scenarios, including legacy attachments blocking approval and proper error display in the UI. [[1]](diffhunk://#diff-ebb734fc98b1697655f5f819d2f46974c2359222e908e06cdcca5a080e7e32d4L16-L55) [[2]](diffhunk://#diff-ebb734fc98b1697655f5f819d2f46974c2359222e908e06cdcca5a080e7e32d4L64-R89) [[3]](diffhunk://#diff-ebb734fc98b1697655f5f819d2f46974c2359222e908e06cdcca5a080e7e32d4L93-R108) [[4]](diffhunk://#diff-bdd8cdbb7cb2cb27a7168ca658a3bd280ec4d9929975f087437233a72fd557afR199-R242)

**Other**

* Updated Cypress to version 15.21.0.

These changes ensure robust handling of PDF files, prevent user confusion from invalid uploads, and improve overall reliability and user experience regarding document attachments.